### PR TITLE
Fixing filter groups error

### DIFF
--- a/R/mainTests.r
+++ b/R/mainTests.r
@@ -59,7 +59,7 @@ duplicate_rows <- function(data, meta) {
     pull(col_name)
 
   filter_groups <- meta %>%
-    filter(!is.na(filter_grouping_column)& filter_grouping_column!="") %>%
+    filter(!is.na(filter_grouping_column) & filter_grouping_column != "") %>%
     pull(filter_grouping_column)
 
   present_obUnits_filters <- intersect(c(acceptable_observational_units, filters, filter_groups), names(data))
@@ -151,7 +151,7 @@ total <- function(data, meta) {
     pull(col_name)
 
   filter_groups <- meta %>%
-    filter(!is.na(filter_grouping_column)& filter_grouping_column!="") %>%
+    filter(!is.na(filter_grouping_column) & filter_grouping_column != "") %>%
     pull(filter_grouping_column)
 
   filters_and_groups <- c(filters, filter_groups)
@@ -1319,7 +1319,7 @@ filter_hint <- function(meta) {
 
 filter_group <- function(meta) {
   filter_groups <- meta %>%
-    filter(col_type == "Indicator", !is.na(filter_grouping_column)& filter_grouping_column!="") %>%
+    filter(col_type == "Indicator", !is.na(filter_grouping_column) & filter_grouping_column != "") %>%
     pull(filter_grouping_column)
 
   if (length(filter_groups) > 0) {
@@ -1341,7 +1341,7 @@ filter_group <- function(meta) {
 # filter groups should be in the vector for column names for the data file
 
 filter_group_match <- function(data, meta) {
-  meta_filter_groups <- meta %>% filter(!is.na(filter_grouping_column)& filter_grouping_column!="")
+  meta_filter_groups <- meta %>% filter(!is.na(filter_grouping_column) & filter_grouping_column != "")
 
   if (nrow(meta_filter_groups) == 0) {
     output <- list(
@@ -1380,7 +1380,7 @@ filter_group_match <- function(data, meta) {
 
 filter_group_level <- function(data, meta) {
   meta_filters_and_groups <- meta %>%
-    filter(col_type == "Filter", !is.na(filter_grouping_column)& filter_grouping_column!="") %>%
+    filter(col_type == "Filter", !is.na(filter_grouping_column) & filter_grouping_column != "") %>%
     select(col_name, filter_grouping_column)
 
   if (nrow(meta_filters_and_groups) == 0) {
@@ -1435,7 +1435,7 @@ filter_group_level <- function(data, meta) {
 # Checking that filter groups are not filters
 
 filter_group_not_filter <- function(meta) {
-  if (meta %>% filter(!is.na(filter_grouping_column)& filter_grouping_column!="") %>% nrow() == 0) {
+  if (meta %>% filter(!is.na(filter_grouping_column) & filter_grouping_column != "") %>% nrow() == 0) {
     output <- list(
       "message" = "There are no filter groups present.",
       "result" = "IGNORE"
@@ -1450,7 +1450,7 @@ filter_group_not_filter <- function(meta) {
     }
 
     pre_result <- stack(sapply(meta %>%
-      filter(!is.na(filter_grouping_column)& filter_grouping_column!="") %>%
+      filter(!is.na(filter_grouping_column) & filter_grouping_column != "") %>%
       pull(filter_grouping_column), filter_group_not_filter_check))
 
     filter_groups_in_col_names <- filter(pre_result, values == "FAIL") %>% pull(ind)
@@ -1475,13 +1475,13 @@ filter_group_not_filter <- function(meta) {
 # Checking that filter groups are not duplicated
 
 filter_group_duplicate <- function(meta) {
-  if (meta %>% filter(!is.na(filter_grouping_column)& filter_grouping_column!="") %>% nrow() == 0) {
+  if (meta %>% filter(!is.na(filter_grouping_column) & filter_grouping_column != "") %>% nrow() == 0) {
     output <- list(
       "message" = "There are no filter groups present.",
       "result" = "IGNORE"
     )
   } else {
-    if (suppressMessages(meta %>% filter(!is.na(filter_grouping_column)& filter_grouping_column!="") %>% get_dupes(filter_grouping_column) %>% nrow()) != 0) {
+    if (suppressMessages(meta %>% filter(!is.na(filter_grouping_column) & filter_grouping_column != "") %>% get_dupes(filter_grouping_column) %>% nrow()) != 0) {
       output <- list(
         "message" = "There are duplicated filter_group values.",
         "result" = "FAIL"

--- a/R/mainTests.r
+++ b/R/mainTests.r
@@ -59,7 +59,7 @@ duplicate_rows <- function(data, meta) {
     pull(col_name)
 
   filter_groups <- meta %>%
-    filter(!is.na(filter_grouping_column)) %>%
+    filter(!is.na(filter_grouping_column)& filter_grouping_column!="") %>%
     pull(filter_grouping_column)
 
   present_obUnits_filters <- intersect(c(acceptable_observational_units, filters, filter_groups), names(data))
@@ -151,7 +151,7 @@ total <- function(data, meta) {
     pull(col_name)
 
   filter_groups <- meta %>%
-    filter(!is.na(filter_grouping_column)) %>%
+    filter(!is.na(filter_grouping_column)& filter_grouping_column!="") %>%
     pull(filter_grouping_column)
 
   filters_and_groups <- c(filters, filter_groups)
@@ -1319,7 +1319,7 @@ filter_hint <- function(meta) {
 
 filter_group <- function(meta) {
   filter_groups <- meta %>%
-    filter(col_type == "Indicator", !is.na(filter_grouping_column)) %>%
+    filter(col_type == "Indicator", !is.na(filter_grouping_column)& filter_grouping_column!="") %>%
     pull(filter_grouping_column)
 
   if (length(filter_groups) > 0) {
@@ -1341,7 +1341,7 @@ filter_group <- function(meta) {
 # filter groups should be in the vector for column names for the data file
 
 filter_group_match <- function(data, meta) {
-  meta_filter_groups <- meta %>% filter(!is.na(filter_grouping_column))
+  meta_filter_groups <- meta %>% filter(!is.na(filter_grouping_column)& filter_grouping_column!="")
 
   if (nrow(meta_filter_groups) == 0) {
     output <- list(
@@ -1380,7 +1380,7 @@ filter_group_match <- function(data, meta) {
 
 filter_group_level <- function(data, meta) {
   meta_filters_and_groups <- meta %>%
-    filter(col_type == "Filter", !is.na(filter_grouping_column)) %>%
+    filter(col_type == "Filter", !is.na(filter_grouping_column)& filter_grouping_column!="") %>%
     select(col_name, filter_grouping_column)
 
   if (nrow(meta_filters_and_groups) == 0) {
@@ -1435,7 +1435,7 @@ filter_group_level <- function(data, meta) {
 # Checking that filter groups are not filters
 
 filter_group_not_filter <- function(meta) {
-  if (meta %>% filter(!is.na(filter_grouping_column)) %>% nrow() == 0) {
+  if (meta %>% filter(!is.na(filter_grouping_column)& filter_grouping_column!="") %>% nrow() == 0) {
     output <- list(
       "message" = "There are no filter groups present.",
       "result" = "IGNORE"
@@ -1450,7 +1450,7 @@ filter_group_not_filter <- function(meta) {
     }
 
     pre_result <- stack(sapply(meta %>%
-      filter(!is.na(filter_grouping_column)) %>%
+      filter(!is.na(filter_grouping_column)& filter_grouping_column!="") %>%
       pull(filter_grouping_column), filter_group_not_filter_check))
 
     filter_groups_in_col_names <- filter(pre_result, values == "FAIL") %>% pull(ind)
@@ -1475,13 +1475,13 @@ filter_group_not_filter <- function(meta) {
 # Checking that filter groups are not duplicated
 
 filter_group_duplicate <- function(meta) {
-  if (meta %>% filter(!is.na(filter_grouping_column)) %>% nrow() == 0) {
+  if (meta %>% filter(!is.na(filter_grouping_column)& filter_grouping_column!="") %>% nrow() == 0) {
     output <- list(
       "message" = "There are no filter groups present.",
       "result" = "IGNORE"
     )
   } else {
-    if (suppressMessages(meta %>% filter(!is.na(filter_grouping_column)) %>% get_dupes(filter_grouping_column) %>% nrow()) != 0) {
+    if (suppressMessages(meta %>% filter(!is.na(filter_grouping_column)& filter_grouping_column!="") %>% get_dupes(filter_grouping_column) %>% nrow()) != 0) {
       output <- list(
         "message" = "There are duplicated filter_group values.",
         "result" = "FAIL"

--- a/tests/testthat/otherData/blankFilterGroups.csv
+++ b/tests/testthat/otherData/blankFilterGroups.csv
@@ -1,0 +1,13 @@
+time_identifier,time_period,geographic_level,country_code,country_name,year_breakdown,categorytype,order_type,count,region_code,region_name
+Calendar year,2008,National,E92000001,England,Q1,Application,Non-Molestation,4452,,
+Calendar year,2009,National,E92000001,England,Q1,Application,Non-Molestation,2038,,
+Calendar year,2010,National,E92000001,England,Q4,Application,Occupation,1066,,
+Calendar year,2011,National,E92000001,England,Q1,Application,Occupation,5648,,
+Calendar year,2012,National,E92000001,England,Q2,Application,Non-Molestation,6046,,
+Calendar year,2013,National,E92000001,England,Q3,Application,Non-Molestation,7237,,
+Calendar year,2014,National,E92000001,England,Q4,Application,Occupation,7577,,
+Calendar year,2015,National,E92000001,England,Q1,Order made,Occupation,5437,,
+Calendar year,2016,National,E92000001,England,Q1,Order made,Occupation,1247,,
+Calendar year,2017,National,E92000001,England,Q4,Order made,Non-Molestation,3889,,
+Calendar year,2018,National,E92000001,England,Q4,Order made,Occupation,22,,
+Calendar year,2019,Regional,E92000001,England,Total,Total,Total,25373,E12000001,North East

--- a/tests/testthat/otherData/blankFilterGroups.meta.csv
+++ b/tests/testthat/otherData/blankFilterGroups.meta.csv
@@ -1,0 +1,4 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+count,Indicator,Total Count,Counts,,0,,
+order_type,Filter,Order type,,,,,categorytype
+year_breakdown,Filter,Year breakdown,,,,,

--- a/tests/testthat/test-screenFiles.R
+++ b/tests/testthat/test-screenFiles.R
@@ -71,3 +71,10 @@ test_that("ladWithinLA", {
 
   expect_equal(screeningOutput$results %>% filter(result != "PASS") %>% nrow(), 0)
 })
+
+test_that("blankFilterGroupsMeta", {
+  screeningOutput <- testOther("../../tests/testthat/otherData/blankFilterGroups.csv")
+  
+  expect_equal(screeningOutput$results %>% filter(result == "FAIL") %>% nrow(), 0)
+})
+

--- a/tests/testthat/test-screenFiles.R
+++ b/tests/testthat/test-screenFiles.R
@@ -74,7 +74,6 @@ test_that("ladWithinLA", {
 
 test_that("blankFilterGroupsMeta", {
   screeningOutput <- testOther("../../tests/testthat/otherData/blankFilterGroups.csv")
-  
+
   expect_equal(screeningOutput$results %>% filter(result == "FAIL") %>% nrow(), 0)
 })
-


### PR DESCRIPTION
Merging in the fix from the MoJ fixing branch around filter groups causing errors if they are read as empty character strings rather than NA.