### PR TITLE
reordering acceptable_indicatorunits

### DIFF
--- a/R/knownVariables.r
+++ b/R/knownVariables.r
@@ -80,4 +80,4 @@ col_to_level_lookup <- rbind(
 ) %>%
   filter(!is.na(cols))
 
-acceptable_indicatorunits <- c( "%", "pp", "£", "£m")
+acceptable_indicatorunits <- c("%", "pp", "£", "£m")

--- a/R/knownVariables.r
+++ b/R/knownVariables.r
@@ -80,4 +80,4 @@ col_to_level_lookup <- rbind(
 ) %>%
   filter(!is.na(cols))
 
-acceptable_indicatorunits <- c("£", "£m", "%", "pp")
+acceptable_indicatorunits <- c( "%", "pp", "£", "£m")


### PR DESCRIPTION
Getting a unusual error when an app instance starts up on shinyapps.io. This doesn't happen on rsconnect, or when running locally. The script with the code that is flagged as an error hasn't been touched for some time, my only guess is that it's related to the pound symbol. Changing around the order of that line to test this theory.

![image](https://user-images.githubusercontent.com/52536248/133337715-d0ce8e49-8861-4c51-9f9c-cfa0a6aa3027.png)
