### PR TITLE
Rolled package png back to 0.1-7 to fit with rsconnect version

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -824,10 +824,10 @@
     },
     "png": {
       "Package": "png",
-      "Version": "0.1-8",
+      "Version": "0.1-7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "bd54ba8a0a5faded999a7aab6e46b374",
+      "Hash": "03b7076c234cb3331288919983326c55",
       "Requirements": []
     },
     "praise": {


### PR DESCRIPTION
Last deploy failed due to png 0.1-8 not being available on rsconnect yet. Rolled back to 0.1-7 and deployed fine on dev.