### PR TITLE
Updating EDA termination dates

### DIFF
--- a/data/english_devolved_areas.csv
+++ b/data/english_devolved_areas.csv
@@ -6,10 +6,11 @@ E47000003,West Yorkshire Combined Authority,31/12/2016,
 E47000004,"Halton, Knowsley, Liverpool, St Helens, Sefton and Wirral Combined Authority",31/12/2016,
 E47000005,"Durham, Gateshead, Newcastle Upon Tyne, North Tyneside, Northumberland, South Tyneside and Sunderland Combined Authority",31/12/2016,
 E47000001,Greater Manchester,,31/12/2016
-E47000002,Sheffield City Region,,31/12/2016
+E47000002,Sheffield City Region,31/12/2021,31/12/2016
+E47000002,South Yorkshire,,31/12/2021
 E47000003,West Yorkshire,,31/12/2016
 E47000004,Liverpool City Region,,31/12/2016
-E47000005,North East,,31/12/2016
+E47000005,North East,31/12/2018,31/12/2016
 E47000006,Tees Valley,,31/12/2016
 E47000007,West Midlands,,31/12/2016
 E47000008,Cambridgeshire and Peterborough,,03/03/2017


### PR DESCRIPTION
Added new line for E47000002 bringing in line with [ONS Geography Portal 2021 records](https://geoportal.statistics.gov.uk/documents/ons::combined-authorities-december-2021-names-and-codes-in-england-v2-1/about
): 
> File updated following late notification of name change for E47000002 - Sheffield City Region to South Yorkshire

Added termination date to E47000005 in line with [ONS Geography Portal 2018 records](https://geoportal.statistics.gov.uk/datasets/ons::combined-authorities-dec-2018-names-and-codes-in-england-v2/about):

> File updated to include changes to North East combined authority and the creation of North of Tyne combined authority

