### PR TITLE
Fix error: Can't subset columns that don't exist

### DIFF
--- a/R/mainTests.r
+++ b/R/mainTests.r
@@ -1520,9 +1520,10 @@ country_combinations <- function(data) {
 # check that there is a 1:1 relationship between geography codes and names
 
 lower_level_geog_names <- geography_matrix[9:12, 2:3] %>% as.character() # skipping school/prov as they have legit duplicates
+lower_level_geog_levels <- geography_matrix[9:12, 1] %>% as.character()
 
 other_geography_duplicates <- function(data) {
-  if (!any(lower_level_geog_names %in% names(data))) {
+  if (!any(lower_level_geog_levels %in% unique(data$geographic_level))) {
     output <- list(
       "message" = "Lower-level geography data is not present in this data file.",
       "result" = "IGNORE"
@@ -1593,9 +1594,10 @@ other_geography_duplicates <- function(data) {
 # check that there is a 1:1 relationship between geography names and codes
 
 lower_level_geog_names <- geography_matrix[9:12, 2:3] %>% as.character() # skipping school/prov as they have legit duplicates
+lower_level_geog_levels <- geography_matrix[9:12, 1] %>% as.character()
 
 other_geography_code_duplicates <- function(data) {
-  if (!any(lower_level_geog_names %in% names(data))) {
+  if (!any(lower_level_geog_levels %in% unique(data$geographic_level))) {
     output <- list(
       "message" = "Lower-level geography data is not present in this data file.",
       "result" = "IGNORE"

--- a/tests/testthat/sch_prov/school_with_trust.csv
+++ b/tests/testthat/sch_prov/school_with_trust.csv
@@ -1,0 +1,7 @@
+time_identifier,time_period,geographic_level,country_code,country_name,region_code,region_name,old_la_code,new_la_code,la_name,estab,school_laestab,school_urn,school_name,trust_name,academy_type,academy_open_date,school_type,headcount,perm_excl,perm_excl_rate,suspension,susp_rate,one_plus_susp,one_plus_susp_rate
+Spring term,202122,School,E92000001,England,E13000001,Inner London,201,E09000001,City of London,3614,2013614,100000,The Aldgate School,z,z,z,State-funded primary,277,0,0,0,0,0,0
+Autumn term,202122,School,E92000001,England,E13000001,Inner London,201,E09000001,City of London,3614,2013614,100000,The Aldgate School,z,z,z,State-funded primary,269,0,0,0,0,0,0
+Autumn term,202122,School,E92000001,England,E13000001,Inner London,202,E09000007,Camden,2000,2022000,136807,St Luke's Church of England School,ST LUKE'S CHURCH OF ENGLAND SCHOOL,z,z,State-funded primary,101,0,0,0,0,0,0
+Spring term,202122,School,E92000001,England,E13000001,Inner London,202,E09000007,Camden,2000,2022000,136807,St Luke's Church of England School,ST LUKE'S CHURCH OF ENGLAND SCHOOL,z,z,State-funded primary,102,0,0,0,0,0,0
+Autumn term,202122,School,E92000001,England,E13000001,Inner London,202,E09000007,Camden,2001,2022001,139837,Abacus Belsize Primary School,ANTHEM SCHOOLS TRUST,z,z,State-funded secondary,156,0,0,0,0,0,0
+Spring term,202122,School,E92000001,England,E13000001,Inner London,202,E09000007,Camden,2001,2022001,139837,Abacus Belsize Primary School,ANTHEM SCHOOLS TRUST,z,z,State-funded secondary,163,0,0,0,0,0,0

--- a/tests/testthat/sch_prov/school_with_trust.meta.csv
+++ b/tests/testthat/sch_prov/school_with_trust.meta.csv
@@ -1,0 +1,9 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+school_type,Filter,School Type,,,,"State-funded primary, secondary and special",
+headcount,Indicator,Headcount,,,0,,
+perm_excl,Indicator,Permanent exclusions,,,0,,
+perm_excl_rate,Indicator,Permanent exclusions (rate),,,2,,
+suspension,Indicator,Suspensions,,,0,,
+susp_rate,Indicator,Suspension (rate),,,2,,
+one_plus_susp,Indicator,Pupil enrolments with one or more suspension,,,0,,
+one_plus_susp_rate,Indicator,Pupil enrolments with one or moresuspension (rate),,,2,,

--- a/tests/testthat/test-mainTests.R
+++ b/tests/testthat/test-mainTests.R
@@ -202,7 +202,7 @@ test_that("other_geography_duplicates", {
 
 # other_geography_code_duplicates -------------------------------------------------------------------------------------------------------
 
-test_that("other_geography_duplicates", {
+test_that("other_geography_code_duplicates", {
   expect_equal(testIndividualTest(pathStart, "other_geography_code_duplicates"), "FAIL")
 })
 

--- a/tests/testthat/test-screenFiles.R
+++ b/tests/testthat/test-screenFiles.R
@@ -175,6 +175,13 @@ test_that("sch_filter_group", {
   expect_equal(screeningOutput$results %>% filter(result == "FAIL") %>% nrow(), 0)
 })
 
+test_that("sch_with_trust_cols", {
+  screeningOutput <- testOther("../../tests/testthat/sch_prov/school_with_trust.csv")
+
+  expect_equal(screeningOutput$results %>% filter(test == "other_geography_duplicates") %>% pull(result) %>% unlist(use.names = FALSE), "IGNORE")
+  expect_equal(screeningOutput$results %>% filter(test == "other_geography_code_duplicates") %>% pull(result) %>% unlist(use.names = FALSE), "IGNORE")
+})
+
 test_that("not_sch_but_one_filter", {
   screeningOutput <- testOther("../../tests/testthat/sch_prov/not_sch_but_one_filter.csv")
 


### PR DESCRIPTION
## Pull request overview

We had a team report that one of their files was breaking the screener, it was causing an error in the code for the QA checks that would make the app crash without any helpful feedback. 

After investigating further, this was a file that should have been passing, but one of the tests was misunstanding the contents and getting tripped up over it. I've updated those tests to handle this scenario and allow the file to pass through going forwards.

## Pull request checklist

Please check if your PR fulfils the following:
- [ Yes ] Tests for the changes have been added (for bug fixes / features)
- [ N/A ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ Yes ] Tests have been run locally and are passing (`run_tests_locally()`)
- [ Yes ] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)

## What is the current behaviour?

The test case given is a legitimate file for the screener, but when using in the app it was disconnecting with no indication of why. Logs gave an unhelpful error message, even running the debugging script in the console was just giving that same error. Eventually, running each check function individually pinned it down to two tests that had the issue (error message same as in logs and console, though this point we at least know the functions):

![image](https://user-images.githubusercontent.com/52536248/229954402-8a777f97-22b6-4206-b6d5-767c7a9d1c75.png)

![image](https://user-images.githubusercontent.com/52536248/229954414-ff97c007-4e1e-4bd7-8bd1-301440e97328.png)

Running the code for those functions in the console and checking the outputs found that the tests were tripping up as they were finding trust_name in the data file and assuming there was MAT level data in them. There wasn't, so when it tried to create a table of MAT names / IDs for duplicates it couldn't find the columns needed for the processing and fell over. This was the specific code that was struggling in each of the two checks that had the error:

```
    codes <- geog_data %>%
      select(ID, geographic_level, !contains("name")) %>%
      mutate_if(is.numeric, as.character) %>%
      melt(id.vars = c("ID", "geographic_level"), na.rm = TRUE) %>%
      select(ID, geographic_level, code = value)

```

It was running fine until the final line, where there was no 'value' column present to create a 'code' column from. The error was exactly right, it just wasn't overly helpful in pinning down where it was!

## What is the new behaviour?

I've adapted the pre-check on these checks to check for the levels present in the geographic_level column rather than rely on the columns present, as this is a legitimate case of a team adding useful extra information about schools and should be allowed to pass.

Added some test data for this case of school level data with trust columns, and a unit test to check this scenario behaves as expected.

## Anything else

Fixed what I think was a typo in the tests where we were checking other_geography_duplicates() twice, instead of testing both it and other_geography_code_duplicates().