### PR TITLE
Removing duplicate Selly Oak entry from pcons.csv

### DIFF
--- a/data/pcons.csv
+++ b/data/pcons.csv
@@ -467,7 +467,6 @@ E14000809,"Manchester, Withington",,
 E14000985,Sutton Coldfield,,
 E14000777,Leeds Central,,
 E14000781,Leeds West,,
-E14000567,"Birmingham,  Selly Oak",,2018-12-01
 E14000685,Eastleigh,,
 E14000886,Pudsey,,
 E14000779,Leeds North East,,


### PR DESCRIPTION
Removed "Birmingham,  Selly Oak" entry. This is a duplication of another line, but with a second space between , and Selly.