### PR TITLE
Meta label missing bug

### DIFF
--- a/R/mainTests.r
+++ b/R/mainTests.r
@@ -1959,6 +1959,7 @@ col_name_spaces <- function(meta) {
 label <- function(meta) {
   completed_labels <- meta %>%
     filter(!is.na(label)) %>%
+    filter(label != "") %>%
     nrow()
 
   blank_labels <- nrow(meta) - completed_labels

--- a/R/manual_scripts/debugging.R
+++ b/R/manual_scripts/debugging.R
@@ -1,7 +1,18 @@
 # Debugging script
 # Use this script to manually read in and screen files for those occasions when the app breaks without a useful error
+# Helpful for running code in console
+# Uncomment when you need to use this, and always make sure to comment it again before committing
 
+# # Dependencies ==============================================================
 # source("global.R")
+# source("R/readFile.R")
+# source("R/screenFiles.R")
+# source("R/knownVariables.R")
+# source("R/fileValidation.R")
+# source("R/preCheck1.R")
+# source("R/preCheck2.R")
+# source("R/mainTests.R")
+#
 #
 # debugReadFile <- function(file) {
 #   output <- readFile(file)
@@ -9,14 +20,16 @@
 #   return(output)
 # }
 #
-# # Put the file paths of the files in here
+# # Choose files ==============================================================
 # datafile <- debugReadFile(file.choose())
 # metafile <- debugReadFile(file.choose())
 #
+# # Screen files ==============================================================
 # results <- screenFiles(datafile$filename, metafile$filename, datafile$fileSeparator, metafile$fileSeparator, datafile$fileCharacter, metafile$fileCharacter, datafile$mainFile, metafile$mainFile)
 #
 # data.table(results$results) %>% View()
 #
+# # Extra helpers =============================================================
 # data <- datafile$mainFile
 # meta <- metafile$mainFile
 #

--- a/tests/testthat/test-UI-03_additional_qa.R
+++ b/tests/testthat/test-UI-03_additional_qa.R
@@ -79,5 +79,7 @@ test_that("Additional QA tabs", {
   app$set_inputs(geog_indicator_parameter = "num_schools")
   app$set_inputs(submit_geographies = "click")
 
+  app$wait_for_idle(5) # this test seems weirdly flaky for unknown reasons
+
   app$expect_values(output = "geog_agg2")
 })

--- a/tests/testthat/test-data/label_blank_notNA.csv
+++ b/tests/testthat/test-data/label_blank_notNA.csv
@@ -1,0 +1,7 @@
+time_period,time_identifier,geographic_level,country_code,country_name,staff_count_type,some_number
+202122,Academic year,National,E92000001,England,Admin,6
+202122,Academic year,National,E92000001,England,Support,4
+202122,Academic year,National,E92000001,England,Teacher,2
+202122,Academic year,National,E92000001,England,Manager,6
+202122,Academic year,National,E92000001,England,Leader,8
+202122,Academic year,National,E92000001,England,Total,89098

--- a/tests/testthat/test-data/label_blank_notNA.meta.csv
+++ b/tests/testthat/test-data/label_blank_notNA.meta.csv
@@ -1,0 +1,3 @@
+﻿col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+"staff_count_type","Filter","","","","","",""
+"some_number","Indicator","Test indicator","","","0","",""

--- a/tests/testthat/test-function-edge_cases.R
+++ b/tests/testthat/test-function-edge_cases.R
@@ -198,3 +198,9 @@ test_that("prov_level_diff_names", {
 
   expect_equal(screeningOutput$results %>% filter(result == "FAIL") %>% nrow(), 0)
 })
+
+test_that("blank_meta_label_notNA_still_fails", {
+  screeningOutput <- testOther("../../tests/testthat/test-data/label_blank_notNA.csv")
+
+  expect_equal(screeningOutput$results %>% filter(test == "label") %>% pull(result) %>% unlist(use.names = FALSE), "FAIL")
+})


### PR DESCRIPTION
# Brief overview of changes

Addressed a bug where a metadata CSV could have a missing label for a filter / indicator but still pass the screening.

## Why are these changes being made?

Missing metadata labels are important to catch as they will prevent files from being uploaded to EES (and because all filters / indicators should have human readable versions for use in the service).

## Detailed description of changes

Added example test file and test case under 'edge cases', and then fixed the offending function by accounting for blanks as well as NAs.

## Additional information for reviewers

1. No idea how this hasn't come up before now, though a good one to have found and fixed.

2. Looking at the example file we had reported to us (left), you can see if opening in notepad that each cell is wrapped in quotes, which differs from the `label.csv` example we had in the main tests, an equivalent of this is on the right of the image.

![image](https://github.com/dfe-analytical-services/dfe-published-data-qa/assets/52536248/ba4e5285-a451-4bbf-b0c9-642a4367b837)

3. I also updated the debugging script as I realised after my recent PR #109, we needed to source more dependencies for the debugging to work (as we make use of Shiny autoloading scripts from the R folder for normal app running, so the global script no longer sources all dependencies alone).

4. The final UI test for the QA tabs was also failing intermittently on me, adding an extra wait seems to have made it pass reliably, so hoping this will also fix the existing failure in the GitHub actions on the master branch.