### PR TITLE
Update 2024 lookups

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- 
+Hey, thanks for raising a PR! We're excited to see what you've done!
+To help us review the changes, please complete each section in this template by replacing '...' with details to help the reviewers of this pull request. 
+-->
+
+# Brief overview of changes
+
+...
+
+## Why are these changes being made?
+
+...
+
+## Detailed description of changes
+
+...
+
+## Additional information for reviewers
+
+...
+
+## Issue ticket number/s and link
+
+...

--- a/R/manual_scripts/update-geography-lookups.R
+++ b/R/manual_scripts/update-geography-lookups.R
@@ -3,7 +3,7 @@
 
 source("R/standard-data-prep/utils.R")
 
-# PCON LA =====================================================================
+# Ward PCON LAD LA ============================================================
 # Download latest from: https://geoportal.statistics.gov.uk/search?q=LUP_WPC&sort=Date%20Created%7Ccreated%7Cdesc
 # ...and save into /data/downloaded_source_data
 # Then add the file path into the function below to update the lookup to
@@ -12,11 +12,11 @@ source("R/standard-data-prep/utils.R")
 # Last title of file used on Open Geography Portal (in case it's helpful):
 # Ward to Westminster Parliamentary Constituency to Local Authority District to UTLA
 
-# Files used so far: 2017, 2019, 2020, 2021, 2022, 2023
+# Files used so far: 2017, 2019, 2020, 2021, 2022, 2023, 2024
 
 write_updated_lookup(
   new_lookup = tidy_downloaded_lookup(
-    open_geography_file = "data/downloaded_source_data/2023.csv",
+    open_geography_file = "data/downloaded_source_data/Ward_to_Westminster_Parliamentary_Constituency_to_LAD_to_UTLA_(July_2024)_Lookup_in_UK.csv",
     shorthand_lookup = open_geog_shorthand_lookup
   ),
   lookup_filepath = "data/ward_lad_la_pcon_hierarchy.csv"

--- a/R/manual_scripts/update-geography-lookups.R
+++ b/R/manual_scripts/update-geography-lookups.R
@@ -1,7 +1,7 @@
 # Code for updating geography lookups =================================
 # source functions and dependencies
 
-source("R/standard-data-prep/utils.R")
+source("R/manual_scripts/utils.R")
 
 # Ward PCON LAD LA ============================================================
 # Download latest from: https://geoportal.statistics.gov.uk/search?q=LUP_WPC&sort=Date%20Created%7Ccreated%7Cdesc

--- a/R/manual_scripts/utils.R
+++ b/R/manual_scripts/utils.R
@@ -46,7 +46,8 @@ tidy_downloaded_lookup <- function(
     shorthand_lookup) {
   # Read in the downloaded open geography file --------------------------------
   message("Reading in new data from: ", open_geography_file)
-  new_data <- read_csv(open_geography_file, show_col_types = FALSE)
+  new_data <- read_csv(open_geography_file, show_col_types = FALSE) %>%
+    select(-ends_with("NMW")) # remove Welsh name cols
 
   # Extract the year from columns ---------------------------------------------
   new_year <- names(new_data) %>%

--- a/README.md
+++ b/README.md
@@ -113,25 +113,13 @@ There is a GitHub action workflow that automatically runs this against PRs to en
 
 The standard geographies used in this tool are sourced from (or developed with) the Office for National Statistics (ONS). As such, they are maintained in line with the ONS's [open geography portal](https://geoportal.statistics.gov.uk/). 
 
-#### Updating pcon_la or lad_lsip lookups
+#### Updating ward_pcon_lad_la or lad_lsip lookups
 
-There's an R script in the R/standard-data-prep folder containing functions to update both the pcon_la and lad_lsip lookups. To use this, download the latest version of the file from the searches linked in the comments of that script, and then save a copy of that data in a new folder called /data/downloaded_source_data/. The functions will then append any new data from that CSV into the lookup files.
+There's an R script in the `R/manual_scripts/` folder containing functions to update both the geography lookups. To use this, download the latest version of the file from the searches linked in the comments of that script, and then save a copy of that data in a new folder called `/data/downloaded_source_data/`. The functions will then append any new data from that CSV into the lookup files.
 
 #### Local skills improvement plan area (LSIP)
 
 These were developed in direct communications with the ONS ([ONS Geography e-mail](mailto:ONS.Geography@ons.gov.uk)) and they provided the basis for the code and name file used in this tool. At the time of writing, this has not been added to the open geography portal, although boundary files have been ([LSIP boundary map files](https://geoportal.statistics.gov.uk/search?collection=Dataset&sort=name&tags=all(BDY_LSIP%2CAUG_2023))).
-
-#### Wards
-
-The Ward to LAD lookup has been downloaded from the [Open Geography Portal administrative lookups](https://geoportal.statistics.gov.uk/search?q=LUP_WD_LAD&sort=Title%7Ctitle%7Cdesc). 
-
-For example, in March 2024 we downloaded and used the 'Ward to Local Authority District (May 2023) Lookup in the United Kingdom' data set.
-
-#### PCon 2024 lookup
-
-We have recently added a lookup including provisional 2024 Parliamentary Constituency boundaries. This is available in the `data/pcon_2024_v2.csv` file, and further information on that file can be found on the [Open Geography Portal](https://geoportal.statistics.gov.uk/datasets/ons::postcode-to-new-westminster-parliamentary-constituencies-may-2024-lookup-in-the-uk/about).
-
-Long term we aim to remove this and instead update the Ward > PCon > LAD > LA lookup once that is released by ONS.
 
 ---
 

--- a/data/ward_lad_la_pcon_hierarchy.csv
+++ b/data/ward_lad_la_pcon_hierarchy.csv
@@ -1,4 +1,8802 @@
 first_available_year_included,most_recent_year_included,ward_name,pcon_name,lad_name,la_name,ward_code,pcon_code,lad_code,new_la_code
+2017,2024,Penicuik,Midlothian,Midlothian,Midlothian,S13003018,S14000045,S12000019,S12000019
+2017,2024,Bonnyrigg,Midlothian,Midlothian,Midlothian,S13003019,S14000045,S12000019,S12000019
+2017,2024,Dalkeith,Midlothian,Midlothian,Midlothian,S13003020,S14000045,S12000019,S12000019
+2017,2024,Midlothian West,Midlothian,Midlothian,Midlothian,S13003021,S14000045,S12000019,S12000019
+2017,2024,Midlothian East,Midlothian,Midlothian,Midlothian,S13003022,S14000045,S12000019,S12000019
+2017,2024,Midlothian South,Midlothian,Midlothian,Midlothian,S13003023,S14000045,S12000019,S12000019
+2017,2024,Irvine West,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003032,S14000048,S12000021,S12000021
+2017,2024,Kilwinning,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003034,S14000048,S12000021,S12000021
+2022,2024,Ardrossan,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003145,S14000048,S12000021,S12000021
+2022,2024,Arran,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003146,S14000048,S12000021,S12000021
+2022,2024,Garnock Valley,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003147,S14000048,S12000021,S12000021
+2022,2024,North Coast,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003148,S14000048,S12000021,S12000021
+2022,2024,Saltcoats and Stevenston,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003149,S14000048,S12000021,S12000021
+2017,2024,Stromness and South Isles,Orkney and Shetland,Orkney Islands,Orkney Islands,S13002734,S14000051,S12000023,S12000023
+2017,2024,West Mainland,Orkney and Shetland,Orkney Islands,Orkney Islands,S13002735,S14000051,S12000023,S12000023
+2017,2024,North Isles,Orkney and Shetland,Orkney Islands,Orkney Islands,S13002737,S14000051,S12000023,S12000023
+2022,2024,"East Mainland, South Ronaldsay and Burray",Orkney and Shetland,Orkney Islands,Orkney Islands,S13003150,S14000051,S12000023,S12000023
+2022,2024,Kirkwall East,Orkney and Shetland,Orkney Islands,Orkney Islands,S13003151,S14000051,S12000023,S12000023
+2017,2024,"Barrhead, Liboside and Uplawmoor",East Renfrewshire,East Renfrewshire,East Renfrewshire,S13002914,S14000021,S12000011,S12000011
+2017,2024,Newton Mearns North and Neilston,East Renfrewshire,East Renfrewshire,East Renfrewshire,S13002915,S14000021,S12000011,S12000011
+2017,2024,Giffnock and Thornliebank,East Renfrewshire,East Renfrewshire,East Renfrewshire,S13002916,S14000021,S12000011,S12000011
+2017,2024,"Clarkston, Netherlee and Williamwood",East Renfrewshire,East Renfrewshire,East Renfrewshire,S13002917,S14000021,S12000011,S12000011
+2017,2024,Newton Mearns South and Eaglesham,East Renfrewshire,East Renfrewshire,East Renfrewshire,S13002918,S14000021,S12000011,S12000011
+2017,2024,An Taobh Siar agus Nis,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13002608,S14000027,S12000013,S12000013
+2022,2024,Barraigh agus Bhatarsaigh,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003135,S14000027,S12000013,S12000013
+2022,2024,Loch a Tuath,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003136,S14000027,S12000013,S12000013
+2022,2024,Na Hearadh,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003137,S14000027,S12000013,S12000013
+2022,2024,Sgìr Ùige agus Càrlabhagh,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003138,S14000027,S12000013,S12000013
+2022,2024,Sgìre an Rubha,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003139,S14000027,S12000013,S12000013
+2022,2024,Sgìre nan Loch,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003140,S14000027,S12000013,S12000013
+2022,2024,Steòrnabhagh a Deas,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003141,S14000027,S12000013,S12000013
+2022,2024,Steòrnabhagh a Tuath,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003142,S14000027,S12000013,S12000013
+2022,2024,"Uibhist a Deas, Èirisgeigh agus Beinn na Faoghla",Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003143,S14000027,S12000013,S12000013
+2022,2024,Uibhist a Tuath,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003144,S14000027,S12000013,S12000013
+2022,2024,Kirkwall West and Orphir,Orkney and Shetland,Orkney Islands,Orkney Islands,S13003152,S14000051,S12000023,S12000023
+2017,2024,North Isles,Orkney and Shetland,Shetland Islands,Shetland Islands,S13002772,S14000051,S12000027,S12000027
+2017,2024,Shetland North,Orkney and Shetland,Shetland Islands,Shetland Islands,S13002773,S14000051,S12000027,S12000027
+2022,2024,Lerwick North and Bressay,Orkney and Shetland,Shetland Islands,Shetland Islands,S13002777,S14000051,S12000027,S12000027
+2022,2024,Lerwick South,Orkney and Shetland,Shetland Islands,Shetland Islands,S13003153,S14000051,S12000027,S12000027
+2022,2024,Shetland Central,Orkney and Shetland,Shetland Islands,Shetland Islands,S13003154,S14000051,S12000027,S12000027
+2022,2024,Shetland South,Orkney and Shetland,Shetland Islands,Shetland Islands,S13003155,S14000051,S12000027,S12000027
+2022,2024,Shetland West,Orkney and Shetland,Shetland Islands,Shetland Islands,S13003156,S14000051,S12000027,S12000027
+2024,2024,Burn Valley,Hartlepool,Hartlepool,Hartlepool,E05013038,E14001272,E06000001,E06000001
+2024,2024,Longhill & Bilton Grange,Kingston upon Hull East,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011535,E14001313,E06000010,E06000010
+2024,2024,De Bruce,Hartlepool,Hartlepool,Hartlepool,E05013039,E14001272,E06000001,E06000001
+2024,2024,Fens & Greatham,Hartlepool,Hartlepool,Hartlepool,E05013040,E14001272,E06000001,E06000001
+2024,2024,Foggy Furze,Hartlepool,Hartlepool,Hartlepool,E05013041,E14001272,E06000001,E06000001
+2024,2024,Hart,Hartlepool,Hartlepool,Hartlepool,E05013042,E14001272,E06000001,E06000001
+2024,2024,_,Hartlepool,Hartlepool,Hartlepool,E05013043,E14001272,E06000001,E06000001
+2024,2024,Manor House,Hartlepool,Hartlepool,Hartlepool,E05013044,E14001272,E06000001,E06000001
+2024,2024,Rossmere,Hartlepool,Hartlepool,Hartlepool,E05013045,E14001272,E06000001,E06000001
+2024,2024,Rural West,Hartlepool,Hartlepool,Hartlepool,E05013046,E14001272,E06000001,E06000001
+2024,2024,Seaton,Hartlepool,Hartlepool,Hartlepool,E05013047,E14001272,E06000001,E06000001
+2024,2024,Throston,Hartlepool,Hartlepool,Hartlepool,E05013048,E14001272,E06000001,E06000001
+2024,2024,Victoria,Hartlepool,Hartlepool,Hartlepool,E05013049,E14001272,E06000001,E06000001
+2024,2024,Acklam,Middlesbrough and Thornaby East,Middlesbrough,Middlesbrough,E05009853,E14001367,E06000002,E06000002
+2024,2024,Ayresome,Middlesbrough and Thornaby East,Middlesbrough,Middlesbrough,E05009854,E14001367,E06000002,E06000002
+2024,2024,Berwick Hills & Pallister,Middlesbrough and Thornaby East,Middlesbrough,Middlesbrough,E05009855,E14001367,E06000002,E06000002
+2024,2024,Brambles & Thorntree,Middlesbrough and Thornaby East,Middlesbrough,Middlesbrough,E05009856,E14001367,E06000002,E06000002
+2024,2024,Central,Middlesbrough and Thornaby East,Middlesbrough,Middlesbrough,E05009857,E14001367,E06000002,E06000002
+2024,2024,Coulby Newham,Middlesbrough South and East Cleveland,Middlesbrough,Middlesbrough,E05009858,E14001368,E06000002,E06000002
+2024,2024,Hemlington,Middlesbrough South and East Cleveland,Middlesbrough,Middlesbrough,E05009859,E14001368,E06000002,E06000002
+2024,2024,Kader,Middlesbrough and Thornaby East,Middlesbrough,Middlesbrough,E05009860,E14001367,E06000002,E06000002
+2024,2024,Ladgate,Middlesbrough South and East Cleveland,Middlesbrough,Middlesbrough,E05009861,E14001368,E06000002,E06000002
+2024,2024,Linthorpe,Middlesbrough and Thornaby East,Middlesbrough,Middlesbrough,E05009862,E14001367,E06000002,E06000002
+2024,2024,Longlands & Beechwood,Middlesbrough and Thornaby East,Middlesbrough,Middlesbrough,E05009863,E14001367,E06000002,E06000002
+2024,2024,Marton West,Middlesbrough South and East Cleveland,Middlesbrough,Middlesbrough,E05009865,E14001368,E06000002,E06000002
+2024,2024,Newport,Middlesbrough and Thornaby East,Middlesbrough,Middlesbrough,E05009866,E14001367,E06000002,E06000002
+2024,2024,North Ormesby,Middlesbrough and Thornaby East,Middlesbrough,Middlesbrough,E05009867,E14001367,E06000002,E06000002
+2024,2024,Park,Middlesbrough and Thornaby East,Middlesbrough,Middlesbrough,E05009869,E14001367,E06000002,E06000002
+2024,2024,Park End & Beckfield,Middlesbrough South and East Cleveland,Middlesbrough,Middlesbrough,E05009870,E14001368,E06000002,E06000002
+2024,2024,Stainton & Thornton,Middlesbrough South and East Cleveland,Middlesbrough,Middlesbrough,E05009871,E14001368,E06000002,E06000002
+2024,2024,Trimdon,Middlesbrough and Thornaby East,Middlesbrough,Middlesbrough,E05009872,E14001367,E06000002,E06000002
+2024,2024,Marton East,Middlesbrough South and East Cleveland,Middlesbrough,Middlesbrough,E05015468,E14001368,E06000002,E06000002
+2024,2024,Nunthorpe,Middlesbrough South and East Cleveland,Middlesbrough,Middlesbrough,E05015469,E14001368,E06000002,E06000002
+2024,2024,Belmont,Middlesbrough South and East Cleveland,Redcar and Cleveland,Redcar and Cleveland,E05012437,E14001368,E06000003,E06000003
+2024,2024,Brotton,Middlesbrough South and East Cleveland,Redcar and Cleveland,Redcar and Cleveland,E05012438,E14001368,E06000003,E06000003
+2024,2024,North Road,Darlington,Darlington,Darlington,E05010423,E14001190,E06000005,E06000005
+2024,2024,Coatham,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012439,E14001440,E06000003,E06000003
+2024,2024,Dormanstown,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012440,E14001440,E06000003,E06000003
+2024,2024,Eston,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012441,E14001440,E06000003,E06000003
+2024,2024,Grangetown,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012442,E14001440,E06000003,E06000003
+2024,2024,Guisborough,Middlesbrough South and East Cleveland,Redcar and Cleveland,Redcar and Cleveland,E05012443,E14001368,E06000003,E06000003
+2024,2024,Hutton,Middlesbrough South and East Cleveland,Redcar and Cleveland,Redcar and Cleveland,E05012444,E14001368,E06000003,E06000003
+2024,2024,Kirkleatham,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012445,E14001440,E06000003,E06000003
+2024,2024,Lockwood,Middlesbrough South and East Cleveland,Redcar and Cleveland,Redcar and Cleveland,E05012446,E14001368,E06000003,E06000003
+2024,2024,Loftus,Middlesbrough South and East Cleveland,Redcar and Cleveland,Redcar and Cleveland,E05012447,E14001368,E06000003,E06000003
+2024,2024,Longbeck,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012448,E14001440,E06000003,E06000003
+2024,2024,Newcomen,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012449,E14001440,E06000003,E06000003
+2024,2024,Normanby,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012450,E14001440,E06000003,E06000003
+2024,2024,Ormesby,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012451,E14001440,E06000003,E06000003
+2024,2024,St Germain's,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012452,E14001440,E06000003,E06000003
+2024,2024,Saltburn,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012453,E14001440,E06000003,E06000003
+2024,2024,Skelton East,Middlesbrough South and East Cleveland,Redcar and Cleveland,Redcar and Cleveland,E05012454,E14001368,E06000003,E06000003
+2024,2024,Marfleet,Kingston upon Hull East,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011536,E14001313,E06000010,E06000010
+2024,2024,Newington & Gipsyville,Kingston upon Hull West and Haltemprice,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011537,E14001315,E06000010,E06000010
+2024,2024,North Carr,Kingston upon Hull East,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011538,E14001313,E06000010,E06000010
+2024,2024,Orchard Park,Kingston upon Hull North and Cottingham,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011539,E14001314,E06000010,E06000010
+2024,2024,Pickering,Kingston upon Hull West and Haltemprice,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011540,E14001315,E06000010,E06000010
+2024,2024,St Andrew's & Docklands,Kingston upon Hull West and Haltemprice,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011541,E14001315,E06000010,E06000010
+2024,2024,Southcoates,Kingston upon Hull East,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011542,E14001313,E06000010,E06000010
+2024,2024,Sutton,Kingston upon Hull East,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011543,E14001313,E06000010,E06000010
+2024,2024,University,Kingston upon Hull North and Cottingham,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011544,E14001314,E06000010,E06000010
+2024,2024,West Carr,Kingston upon Hull North and Cottingham,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011545,E14001314,E06000010,E06000010
+2024,2024,Beverley Rural,Beverley and Holderness,East Riding of Yorkshire,East Riding of Yorkshire,E05001687,E14001087,E06000011,E06000011
+2024,2024,Bridlington Central and Old Town,Bridlington and the Wolds,East Riding of Yorkshire,East Riding of Yorkshire,E05001688,E14001127,E06000011,E06000011
+2024,2024,Bridlington North,Bridlington and the Wolds,East Riding of Yorkshire,East Riding of Yorkshire,E05001689,E14001127,E06000011,E06000011
+2024,2024,Bridlington South,Bridlington and the Wolds,East Riding of Yorkshire,East Riding of Yorkshire,E05001690,E14001127,E06000011,E06000011
+2024,2024,Cottingham North,Kingston upon Hull North and Cottingham,East Riding of Yorkshire,East Riding of Yorkshire,E05001691,E14001314,E06000011,E06000011
+2024,2024,Cottingham South,Kingston upon Hull North and Cottingham,East Riding of Yorkshire,East Riding of Yorkshire,E05001692,E14001314,E06000011,E06000011
+2024,2024,Dale,Goole and Pocklington,East Riding of Yorkshire,East Riding of Yorkshire,E05001693,E14001250,E06000011,E06000011
+2024,2024,Driffield and Rural,Bridlington and the Wolds,East Riding of Yorkshire,East Riding of Yorkshire,E05001694,E14001127,E06000011,E06000011
+2024,2024,East Wolds and Coastal,Bridlington and the Wolds,East Riding of Yorkshire,East Riding of Yorkshire,E05001695,E14001127,E06000011,E06000011
+2024,2024,Goole North,Goole and Pocklington,East Riding of Yorkshire,East Riding of Yorkshire,E05001696,E14001250,E06000011,E06000011
+2024,2024,Goole South,Goole and Pocklington,East Riding of Yorkshire,East Riding of Yorkshire,E05001697,E14001250,E06000011,E06000011
+2024,2024,Hessle,Kingston upon Hull West and Haltemprice,East Riding of Yorkshire,East Riding of Yorkshire,E05001698,E14001315,E06000011,E06000011
+2024,2024,Howden,Goole and Pocklington,East Riding of Yorkshire,East Riding of Yorkshire,E05001699,E14001250,E06000011,E06000011
+2024,2024,Howdenshire,Goole and Pocklington,East Riding of Yorkshire,East Riding of Yorkshire,E05001700,E14001250,E06000011,E06000011
+2024,2024,Mid Holderness,Beverley and Holderness,East Riding of Yorkshire,East Riding of Yorkshire,E05001701,E14001087,E06000011,E06000011
+2024,2024,Minster and Woodmansey,Beverley and Holderness,East Riding of Yorkshire,East Riding of Yorkshire,E05001702,E14001087,E06000011,E06000011
+2024,2024,North Holderness,Bridlington and the Wolds,East Riding of Yorkshire,East Riding of Yorkshire,E05001703,E14001127,E06000011,E06000011
+2024,2024,St Mary's,Beverley and Holderness,East Riding of Yorkshire,East Riding of Yorkshire,E05001705,E14001087,E06000011,E06000011
+2024,2024,"Snaith, Airmyn, Rawcliffe and Marshland",Goole and Pocklington,East Riding of Yorkshire,East Riding of Yorkshire,E05001706,E14001250,E06000011,E06000011
+2024,2024,South East Holderness,Beverley and Holderness,East Riding of Yorkshire,East Riding of Yorkshire,E05001707,E14001087,E06000011,E06000011
+2024,2024,South Hunsley,Goole and Pocklington,East Riding of Yorkshire,East Riding of Yorkshire,E05001708,E14001250,E06000011,E06000011
+2024,2024,South West Holderness,Beverley and Holderness,East Riding of Yorkshire,East Riding of Yorkshire,E05001709,E14001087,E06000011,E06000011
+2024,2024,Tranby,Kingston upon Hull West and Haltemprice,East Riding of Yorkshire,East Riding of Yorkshire,E05001710,E14001315,E06000011,E06000011
+2024,2024,Willerby and Kirk Ella,Kingston upon Hull West and Haltemprice,East Riding of Yorkshire,East Riding of Yorkshire,E05001711,E14001315,E06000011,E06000011
+2024,2024,Pocklington Provincial,Goole and Pocklington,East Riding of Yorkshire,East Riding of Yorkshire,E05015474,E14001250,E06000011,E06000011
+2024,2024,Wolds Weighton,Bridlington and the Wolds,East Riding of Yorkshire,East Riding of Yorkshire,E05015475,E14001127,E06000011,E06000011
+2024,2024,Wolds Weighton,Goole and Pocklington,East Riding of Yorkshire,East Riding of Yorkshire,E05015475,E14001250,E06000011,E06000011
+2024,2024,Croft Baker,Great Grimsby and Cleethorpes,North East Lincolnshire,North East Lincolnshire,E05001713,E14001255,E06000012,E06000012
+2024,2024,East Marsh,Great Grimsby and Cleethorpes,North East Lincolnshire,North East Lincolnshire,E05001714,E14001255,E06000012,E06000012
+2024,2024,Freshney,Great Grimsby and Cleethorpes,North East Lincolnshire,North East Lincolnshire,E05001715,E14001255,E06000012,E06000012
+2024,2024,Haverstoe,Great Grimsby and Cleethorpes,North East Lincolnshire,North East Lincolnshire,E05001716,E14001255,E06000012,E06000012
+2024,2024,Heneage,Great Grimsby and Cleethorpes,North East Lincolnshire,North East Lincolnshire,E05001717,E14001255,E06000012,E06000012
+2024,2024,Humberston and New Waltham,Brigg and Immingham,North East Lincolnshire,North East Lincolnshire,E05001718,E14001128,E06000012,E06000012
+2024,2024,Immingham,Brigg and Immingham,North East Lincolnshire,North East Lincolnshire,E05001719,E14001128,E06000012,E06000012
+2024,2024,Park,Great Grimsby and Cleethorpes,North East Lincolnshire,North East Lincolnshire,E05001720,E14001255,E06000012,E06000012
+2024,2024,Scartho,Brigg and Immingham,North East Lincolnshire,North East Lincolnshire,E05001721,E14001128,E06000012,E06000012
+2024,2024,Sidney Sussex,Great Grimsby and Cleethorpes,North East Lincolnshire,North East Lincolnshire,E05001722,E14001255,E06000012,E06000012
+2024,2024,South,Great Grimsby and Cleethorpes,North East Lincolnshire,North East Lincolnshire,E05001723,E14001255,E06000012,E06000012
+2024,2024,Waltham,Brigg and Immingham,North East Lincolnshire,North East Lincolnshire,E05001724,E14001128,E06000012,E06000012
+2024,2024,Northgate,Darlington,Darlington,Darlington,E05010424,E14001190,E06000005,E06000005
+2024,2024,Park East,Darlington,Darlington,Darlington,E05010425,E14001190,E06000005,E06000005
+2024,2024,Park West,Darlington,Darlington,Darlington,E05010426,E14001190,E06000005,E06000005
+2024,2024,Pierremont,Darlington,Darlington,Darlington,E05010427,E14001190,E06000005,E06000005
+2024,2024,Red Hall & Lingfield,Darlington,Darlington,Darlington,E05010428,E14001190,E06000005,E06000005
+2024,2024,Sadberge & Middleton St George,Stockton West,Darlington,Darlington,E05010429,E14001519,E06000005,E06000005
+2024,2024,Stephenson,Darlington,Darlington,Darlington,E05010430,E14001190,E06000005,E06000005
+2024,2024,Whinfield,Darlington,Darlington,Darlington,E05010431,E14001190,E06000005,E06000005
+2024,2024,Appleton,Widnes and Halewood,Halton,Halton,E05013169,E14001584,E06000006,E06000006
+2024,2024,Bankfield,Widnes and Halewood,Halton,Halton,E05013170,E14001584,E06000006,E06000006
+2024,2024,Beechwood & Heath,Runcorn and Helsby,Halton,Halton,E05013171,E14001455,E06000006,E06000006
+2024,2024,Birchfield,Widnes and Halewood,Halton,Halton,E05013172,E14001584,E06000006,E06000006
+2024,2024,Bridgewater,Runcorn and Helsby,Halton,Halton,E05013173,E14001455,E06000006,E06000006
+2024,2024,Central & West Bank,Widnes and Halewood,Halton,Halton,E05013174,E14001584,E06000006,E06000006
+2024,2024,"Daresbury, Moore & Sandymoor",Runcorn and Helsby,Halton,Halton,E05013175,E14001455,E06000006,E06000006
+2024,2024,"Ditton, Hale Village & Halebank",Widnes and Halewood,Halton,Halton,E05013176,E14001584,E06000006,E06000006
+2024,2024,Farnworth,Widnes and Halewood,Halton,Halton,E05013177,E14001584,E06000006,E06000006
+2024,2024,Grange,Runcorn and Helsby,Halton,Halton,E05013178,E14001455,E06000006,E06000006
+2024,2024,Halton Castle,Runcorn and Helsby,Halton,Halton,E05013179,E14001455,E06000006,E06000006
+2024,2024,Halton Lea,Runcorn and Helsby,Halton,Halton,E05013180,E14001455,E06000006,E06000006
+2024,2024,Halton View,Widnes and Halewood,Halton,Halton,E05013181,E14001584,E06000006,E06000006
+2024,2024,Highfield,Widnes and Halewood,Halton,Halton,E05013182,E14001584,E06000006,E06000006
+2024,2024,Hough Green,Widnes and Halewood,Halton,Halton,E05013183,E14001584,E06000006,E06000006
+2024,2024,Mersey & Weston,Runcorn and Helsby,Halton,Halton,E05013184,E14001455,E06000006,E06000006
+2024,2024,Norton North,Runcorn and Helsby,Halton,Halton,E05013185,E14001455,E06000006,E06000006
+2024,2024,Norton South & Preston Brook,Runcorn and Helsby,Halton,Halton,E05013186,E14001455,E06000006,E06000006
+2024,2024,Appleton,Warrington South,Warrington,Warrington,E05011024,E14001565,E06000007,E06000007
+2024,2024,Bewsey and Whitecross,Warrington South,Warrington,Warrington,E05011025,E14001565,E06000007,E06000007
+2024,2024,Birchwood,Warrington North,Warrington,Warrington,E05011026,E14001564,E06000007,E06000007
+2024,2024,Burtonwood and Winwick,Warrington North,Warrington,Warrington,E05011027,E14001564,E06000007,E06000007
+2024,2024,Chapelford and Old Hall,Warrington South,Warrington,Warrington,E05011028,E14001565,E06000007,E06000007
+2024,2024,"Culcheth, Glazebury and Croft",Warrington North,Warrington,Warrington,E05011029,E14001564,E06000007,E06000007
+2024,2024,Fairfield and Howley,Warrington North,Warrington,Warrington,E05011030,E14001564,E06000007,E06000007
+2024,2024,Grappenhall,Warrington South,Warrington,Warrington,E05011031,E14001565,E06000007,E06000007
+2024,2024,Great Sankey North and Whittle Hall,Warrington South,Warrington,Warrington,E05011032,E14001565,E06000007,E06000007
+2024,2024,Great Sankey South,Warrington South,Warrington,Warrington,E05011033,E14001565,E06000007,E06000007
+2024,2024,Latchford East,Warrington South,Warrington,Warrington,E05011034,E14001565,E06000007,E06000007
+2024,2024,Latchford West,Warrington South,Warrington,Warrington,E05011035,E14001565,E06000007,E06000007
+2024,2024,Lymm North and Thelwall,Tatton,Warrington,Warrington,E05011036,E14001539,E06000007,E06000007
+2024,2024,Lymm North and Thelwall,Warrington South,Warrington,Warrington,E05011036,E14001565,E06000007,E06000007
+2024,2024,Lymm South,Tatton,Warrington,Warrington,E05011037,E14001539,E06000007,E06000007
+2024,2024,Orford,Warrington North,Warrington,Warrington,E05011038,E14001564,E06000007,E06000007
+2024,2024,Penketh and Cuerdley,Warrington South,Warrington,Warrington,E05011039,E14001565,E06000007,E06000007
+2024,2024,Poplars and Hulme,Warrington North,Warrington,Warrington,E05011040,E14001564,E06000007,E06000007
+2024,2024,Poulton North,Warrington North,Warrington,Warrington,E05011041,E14001564,E06000007,E06000007
+2024,2024,Poulton South,Warrington North,Warrington,Warrington,E05011042,E14001564,E06000007,E06000007
+2024,2024,Rixton and Woolston,Warrington North,Warrington,Warrington,E05011043,E14001564,E06000007,E06000007
+2024,2024,Stockton Heath,Warrington South,Warrington,Warrington,E05011044,E14001565,E06000007,E06000007
+2024,2024,Westbrook,Warrington North,Warrington,Warrington,E05011045,E14001564,E06000007,E06000007
+2024,2024,Skelton West,Middlesbrough South and East Cleveland,Redcar and Cleveland,Redcar and Cleveland,E05012455,E14001368,E06000003,E06000003
+2024,2024,South Bank,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012456,E14001440,E06000003,E06000003
+2024,2024,Teesville,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012457,E14001440,E06000003,E06000003
+2024,2024,West Dyke,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012458,E14001440,E06000003,E06000003
+2024,2024,Wheatlands,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012459,E14001440,E06000003,E06000003
+2024,2024,Zetland,Redcar,Redcar and Cleveland,Redcar and Cleveland,E05012460,E14001440,E06000003,E06000003
+2024,2024,Billingham Central,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014858,E14001518,E06000004,E06000004
+2024,2024,Billingham East,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014859,E14001518,E06000004,E06000004
+2024,2024,Billingham North,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014860,E14001518,E06000004,E06000004
+2024,2024,Billingham South,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014861,E14001518,E06000004,E06000004
+2024,2024,Billingham West & Wolviston,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014862,E14001518,E06000004,E06000004
+2024,2024,Bishopsgarth & Elm Tree,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014863,E14001519,E06000004,E06000004
+2024,2024,Eaglescliffe East,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014864,E14001518,E06000004,E06000004
+2024,2024,Eaglescliffe East,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014864,E14001519,E06000004,E06000004
+2024,2024,Eaglescliffe West,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014865,E14001519,E06000004,E06000004
+2024,2024,Fairfield,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014866,E14001519,E06000004,E06000004
+2024,2024,Grangefield,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014867,E14001518,E06000004,E06000004
+2024,2024,Grangefield,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014867,E14001519,E06000004,E06000004
+2024,2024,Hardwick & Salters Lane,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014868,E14001518,E06000004,E06000004
+2024,2024,Hartburn,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014869,E14001518,E06000004,E06000004
+2024,2024,Hartburn,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014869,E14001519,E06000004,E06000004
+2024,2024,Ingleby Barwick North,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014870,E14001519,E06000004,E06000004
+2024,2024,Ingleby Barwick South,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014871,E14001519,E06000004,E06000004
+2024,2024,Mandale & Victoria,Middlesbrough and Thornaby East,Stockton-on-Tees,Stockton-on-Tees,E05014872,E14001367,E06000004,E06000004
+2024,2024,Newtown,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014873,E14001518,E06000004,E06000004
+2024,2024,Northern Parishes,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014874,E14001518,E06000004,E06000004
+2024,2024,Northern Parishes,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014874,E14001519,E06000004,E06000004
+2024,2024,Norton Central,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014875,E14001518,E06000004,E06000004
+2024,2024,Norton North,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014876,E14001518,E06000004,E06000004
+2024,2024,Norton South,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014877,E14001518,E06000004,E06000004
+2024,2024,Ropner,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014878,E14001518,E06000004,E06000004
+2024,2024,Roseworth,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014879,E14001518,E06000004,E06000004
+2024,2024,Southern Villages,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014880,E14001519,E06000004,E06000004
+2024,2024,Stainsby Hill,Middlesbrough and Thornaby East,Stockton-on-Tees,Stockton-on-Tees,E05014881,E14001367,E06000004,E06000004
+2024,2024,Stainsby Hill,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014881,E14001519,E06000004,E06000004
+2024,2024,Stockton Town Centre,Stockton North,Stockton-on-Tees,Stockton-on-Tees,E05014882,E14001518,E06000004,E06000004
+2024,2024,Village,Middlesbrough and Thornaby East,Stockton-on-Tees,Stockton-on-Tees,E05014883,E14001367,E06000004,E06000004
+2024,2024,Village,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014883,E14001519,E06000004,E06000004
+2024,2024,Yarm,Stockton West,Stockton-on-Tees,Stockton-on-Tees,E05014884,E14001519,E06000004,E06000004
+2024,2024,Bank Top & Lascelles,Darlington,Darlington,Darlington,E05010412,E14001190,E06000005,E06000005
+2024,2024,Brinkburn & Faverdale,Darlington,Darlington,Darlington,E05010413,E14001190,E06000005,E06000005
+2024,2024,Cockerton,Darlington,Darlington,Darlington,E05010414,E14001190,E06000005,E06000005
+2024,2024,College,Darlington,Darlington,Darlington,E05010415,E14001190,E06000005,E06000005
+2024,2024,Eastbourne,Darlington,Darlington,Darlington,E05010416,E14001190,E06000005,E06000005
+2024,2024,Harrowgate Hill,Darlington,Darlington,Darlington,E05010417,E14001190,E06000005,E06000005
+2024,2024,Haughton & Springfield,Darlington,Darlington,Darlington,E05010418,E14001190,E06000005,E06000005
+2024,2024,Heighington & Coniscliffe,Darlington,Darlington,Darlington,E05010419,E14001190,E06000005,E06000005
+2024,2024,Hummersknott,Darlington,Darlington,Darlington,E05010420,E14001190,E06000005,E06000005
+2024,2024,Hurworth,Stockton West,Darlington,Darlington,E05010421,E14001519,E06000005,E06000005
+2024,2024,Mowden,Darlington,Darlington,Darlington,E05010422,E14001190,E06000005,E06000005
+2024,2024,Audley & Queen's Park,Blackburn,Blackburn with Darwen,Blackburn with Darwen,E05011508,E14001102,E06000008,E06000008
+2024,2024,Alvaston South,Derby South,Derby,Derby,E05015510,E14001194,E06000015,E06000015
+2024,2024,Arboretum,Derby North,Derby,Derby,E05015511,E14001193,E06000015,E06000015
+2024,2024,Arboretum,Derby South,Derby,Derby,E05015511,E14001194,E06000015,E06000015
+2024,2024,Blagreaves,Derby South,Derby,Derby,E05015512,E14001194,E06000015,E06000015
+2024,2024,Chaddesden East,Derby North,Derby,Derby,E05015513,E14001193,E06000015,E06000015
+2024,2024,Chaddesden North,Derby North,Derby,Derby,E05015514,E14001193,E06000015,E06000015
+2024,2024,Chaddesden North,Mid Derbyshire,Derby,Derby,E05015514,E14001362,E06000015,E06000015
+2024,2024,Chaddesden West,Derby North,Derby,Derby,E05015515,E14001193,E06000015,E06000015
+2024,2024,Chellaston & Shelton Lock,Derby South,Derby,Derby,E05015516,E14001194,E06000015,E06000015
+2024,2024,Darley,Derby North,Derby,Derby,E05015517,E14001193,E06000015,E06000015
+2024,2024,Darley,Derby South,Derby,Derby,E05015517,E14001194,E06000015,E06000015
+2024,2024,Littleover,Derby North,Derby,Derby,E05015518,E14001193,E06000015,E06000015
+2024,2024,Mackworth & New Zealand,Derby North,Derby,Derby,E05015519,E14001193,E06000015,E06000015
+2024,2024,Mickleover,Derby North,Derby,Derby,E05015520,E14001193,E06000015,E06000015
+2024,2024,Normanton,Derby North,Derby,Derby,E05015521,E14001193,E06000015,E06000015
+2024,2024,Normanton,Derby South,Derby,Derby,E05015521,E14001194,E06000015,E06000015
+2024,2024,Oakwood,Derby North,Derby,Derby,E05015522,E14001193,E06000015,E06000015
+2024,2024,Oakwood,Mid Derbyshire,Derby,Derby,E05015522,E14001362,E06000015,E06000015
+2024,2024,Sinfin & Osmaston,Derby South,Derby,Derby,E05015523,E14001194,E06000015,E06000015
+2024,2024,Bastwell & Daisyfield,Blackburn,Blackburn with Darwen,Blackburn with Darwen,E05011509,E14001102,E06000008,E06000008
+2024,2024,Spondon,Mid Derbyshire,Derby,Derby,E05015524,E14001362,E06000015,E06000015
+2024,2024,Billinge & Beardwood,Blackburn,Blackburn with Darwen,Blackburn with Darwen,E05011510,E14001102,E06000008,E06000008
+2024,2024,Abbey,Leicester West,Leicester,Leicester,E05010458,E14001328,E06000016,E06000016
+2024,2024,Blackburn Central,Blackburn,Blackburn with Darwen,Blackburn with Darwen,E05011511,E14001102,E06000008,E06000008
+2024,2024,Aylestone,Leicester West,Leicester,Leicester,E05010459,E14001328,E06000016,E06000016
+2024,2024,Blackburn South & Lower Darwen,Rossendale and Darwen,Blackburn with Darwen,Blackburn with Darwen,E05011512,E14001450,E06000008,E06000008
+2024,2024,Beaumont Leys,Leicester West,Leicester,Leicester,E05010460,E14001328,E06000016,E06000016
+2024,2024,Blackburn South East,Blackburn,Blackburn with Darwen,Blackburn with Darwen,E05011513,E14001102,E06000008,E06000008
+2024,2024,Belgrave,Leicester East,Leicester,Leicester,E05010461,E14001326,E06000016,E06000016
+2024,2024,Braunstone Park & Rowley Fields,Leicester West,Leicester,Leicester,E05010462,E14001328,E06000016,E06000016
+2024,2024,Castle,Leicester South,Leicester,Leicester,E05010463,E14001327,E06000016,E06000016
+2024,2024,Evington,Leicester East,Leicester,Leicester,E05010464,E14001326,E06000016,E06000016
+2024,2024,Evington,Leicester South,Leicester,Leicester,E05010464,E14001327,E06000016,E06000016
+2024,2024,Eyres Monsell,Leicester South,Leicester,Leicester,E05010465,E14001327,E06000016,E06000016
+2024,2024,Fosse,Leicester West,Leicester,Leicester,E05010466,E14001328,E06000016,E06000016
+2024,2024,Humberstone & Hamilton,Leicester East,Leicester,Leicester,E05010467,E14001326,E06000016,E06000016
+2024,2024,Knighton,Leicester South,Leicester,Leicester,E05010468,E14001327,E06000016,E06000016
+2024,2024,North Evington,Leicester East,Leicester,Leicester,E05010469,E14001326,E06000016,E06000016
+2024,2024,Rushey Mead,Leicester East,Leicester,Leicester,E05010470,E14001326,E06000016,E06000016
+2024,2024,Saffron,Leicester South,Leicester,Leicester,E05010471,E14001327,E06000016,E06000016
+2024,2024,Spinney Hills,Leicester South,Leicester,Leicester,E05010472,E14001327,E06000016,E06000016
+2024,2024,Stoneygate,Leicester South,Leicester,Leicester,E05010473,E14001327,E06000016,E06000016
+2024,2024,Thurncourt,Leicester East,Leicester,Leicester,E05010474,E14001326,E06000016,E06000016
+2024,2024,Troon,Leicester East,Leicester,Leicester,E05010475,E14001326,E06000016,E06000016
+2024,2024,Westcotes,Leicester West,Leicester,Leicester,E05010476,E14001328,E06000016,E06000016
+2024,2024,Western,Leicester West,Leicester,Leicester,E05010477,E14001328,E06000016,E06000016
+2024,2024,Wycliffe,Leicester South,Leicester,Leicester,E05010478,E14001327,E06000016,E06000016
+2024,2024,Barleythorpe,Rutland and Stamford,Rutland,Rutland,E05012632,E14001458,E06000017,E06000017
+2024,2024,Braunston & Martinsthorpe,Rutland and Stamford,Rutland,Rutland,E05012633,E14001458,E06000017,E06000017
+2024,2024,Cottesmore,Rutland and Stamford,Rutland,Rutland,E05012634,E14001458,E06000017,E06000017
+2024,2024,Exton,Rutland and Stamford,Rutland,Rutland,E05012635,E14001458,E06000017,E06000017
+2024,2024,Greetham,Rutland and Stamford,Rutland,Rutland,E05012636,E14001458,E06000017,E06000017
+2024,2024,Ketton,Rutland and Stamford,Rutland,Rutland,E05012637,E14001458,E06000017,E06000017
+2024,2024,Langham,Rutland and Stamford,Rutland,Rutland,E05012638,E14001458,E06000017,E06000017
+2024,2024,Lyddington,Rutland and Stamford,Rutland,Rutland,E05012639,E14001458,E06000017,E06000017
+2024,2024,Normanton,Rutland and Stamford,Rutland,Rutland,E05012640,E14001458,E06000017,E06000017
+2024,2024,Oakham North East,Rutland and Stamford,Rutland,Rutland,E05012641,E14001458,E06000017,E06000017
+2024,2024,Oakham North West,Rutland and Stamford,Rutland,Rutland,E05012642,E14001458,E06000017,E06000017
+2024,2024,Oakham South,Rutland and Stamford,Rutland,Rutland,E05012643,E14001458,E06000017,E06000017
+2024,2024,Ryhall & Casterton,Rutland and Stamford,Rutland,Rutland,E05012644,E14001458,E06000017,E06000017
+2024,2024,Uppingham,Rutland and Stamford,Rutland,Rutland,E05012645,E14001458,E06000017,E06000017
+2024,2024,Whissendine,Rutland and Stamford,Rutland,Rutland,E05012646,E14001458,E06000017,E06000017
+2024,2024,Aspley,Nottingham North and Kimberley,Nottingham,Nottingham,E05012270,E14001411,E06000018,E06000018
+2024,2024,Basford,Nottingham North and Kimberley,Nottingham,Nottingham,E05012271,E14001411,E06000018,E06000018
+2024,2024,Berridge,Nottingham East,Nottingham,Nottingham,E05012272,E14001410,E06000018,E06000018
+2024,2024,Bestwood,Nottingham North and Kimberley,Nottingham,Nottingham,E05012273,E14001411,E06000018,E06000018
+2024,2024,Bilborough,Nottingham South,Nottingham,Nottingham,E05012274,E14001412,E06000018,E06000018
+2024,2024,Bulwell,Nottingham North and Kimberley,Nottingham,Nottingham,E05012275,E14001411,E06000018,E06000018
+2024,2024,Bulwell Forest,Nottingham North and Kimberley,Nottingham,Nottingham,E05012276,E14001411,E06000018,E06000018
+2024,2024,Castle,Nottingham East,Nottingham,Nottingham,E05012277,E14001410,E06000018,E06000018
+2024,2024,Clifton East,Nottingham South,Nottingham,Nottingham,E05012278,E14001412,E06000018,E06000018
+2024,2024,Clifton West,Nottingham South,Nottingham,Nottingham,E05012279,E14001412,E06000018,E06000018
+2024,2024,Dales,Nottingham East,Nottingham,Nottingham,E05012280,E14001410,E06000018,E06000018
+2024,2024,Hyson Green & Arboretum,Nottingham East,Nottingham,Nottingham,E05012281,E14001410,E06000018,E06000018
+2024,2024,Leen Valley,Nottingham North and Kimberley,Nottingham,Nottingham,E05012282,E14001411,E06000018,E06000018
+2024,2024,Lenton & Wollaton East,Nottingham South,Nottingham,Nottingham,E05012283,E14001412,E06000018,E06000018
+2024,2024,Mapperley,Nottingham East,Nottingham,Nottingham,E05012284,E14001410,E06000018,E06000018
+2024,2024,Meadows,Nottingham South,Nottingham,Nottingham,E05012285,E14001412,E06000018,E06000018
+2024,2024,Radford,Nottingham South,Nottingham,Nottingham,E05012286,E14001412,E06000018,E06000018
+2024,2024,St. Ann's,Nottingham East,Nottingham,Nottingham,E05012287,E14001410,E06000018,E06000018
+2024,2024,Sherwood,Nottingham East,Nottingham,Nottingham,E05012288,E14001410,E06000018,E06000018
+2024,2024,Wollaton West,Nottingham South,Nottingham,Nottingham,E05012289,E14001412,E06000018,E06000018
+2024,2024,Arrow,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009438,E14001395,E06000019,E06000019
+2024,2024,Aylestone Hill,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009439,E14001281,E06000019,E06000019
+2024,2024,Backbury,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009440,E14001395,E06000019,E06000019
+2024,2024,Belmont Rural,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009441,E14001281,E06000019,E06000019
+2024,2024,Birch,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009442,E14001281,E06000019,E06000019
+2024,2024,Bircher,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009443,E14001395,E06000019,E06000019
+2024,2024,Bishops Frome & Cradley,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009444,E14001395,E06000019,E06000019
+2024,2024,Bobblestock,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009445,E14001281,E06000019,E06000019
+2024,2024,Bromyard Bringsty,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009446,E14001395,E06000019,E06000019
+2024,2024,Bromyard West,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009447,E14001395,E06000019,E06000019
+2024,2024,Castle,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009448,E14001395,E06000019,E06000019
+2024,2024,Central,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009449,E14001281,E06000019,E06000019
+2024,2024,College,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009450,E14001281,E06000019,E06000019
+2024,2024,Dinedor Hill,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009452,E14001281,E06000019,E06000019
+2024,2024,Eign Hill,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009453,E14001281,E06000019,E06000019
+2024,2024,Golden Valley North,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009454,E14001281,E06000019,E06000019
+2024,2024,Golden Valley South,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009455,E14001281,E06000019,E06000019
+2024,2024,Greyfriars,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009456,E14001281,E06000019,E06000019
+2024,2024,Hagley,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009457,E14001395,E06000019,E06000019
+2024,2024,Hampton,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009458,E14001395,E06000019,E06000019
+2024,2024,Hinton & Hunderton,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009459,E14001281,E06000019,E06000019
+2024,2024,Holmer,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009460,E14001395,E06000019,E06000019
+2024,2024,Hope End,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009461,E14001395,E06000019,E06000019
+2024,2024,Darwen East,Rossendale and Darwen,Blackburn with Darwen,Blackburn with Darwen,E05011514,E14001450,E06000008,E06000008
+2024,2024,Darwen South,Rossendale and Darwen,Blackburn with Darwen,Blackburn with Darwen,E05011515,E14001450,E06000008,E06000008
+2024,2024,Darwen West,Rossendale and Darwen,Blackburn with Darwen,Blackburn with Darwen,E05011516,E14001450,E06000008,E06000008
+2024,2024,Ewood,Blackburn,Blackburn with Darwen,Blackburn with Darwen,E05011517,E14001102,E06000008,E06000008
+2024,2024,Little Harwood & Whitebirk,Blackburn,Blackburn with Darwen,Blackburn with Darwen,E05011518,E14001102,E06000008,E06000008
+2024,2024,Livesey with Pleasington,Blackburn,Blackburn with Darwen,Blackburn with Darwen,E05011519,E14001102,E06000008,E06000008
+2024,2024,Mill Hill & Moorgate,Blackburn,Blackburn with Darwen,Blackburn with Darwen,E05011520,E14001102,E06000008,E06000008
+2024,2024,Roe Lee,Blackburn,Blackburn with Darwen,Blackburn with Darwen,E05011521,E14001102,E06000008,E06000008
+2024,2024,Shear Brow & Corporation Park,Blackburn,Blackburn with Darwen,Blackburn with Darwen,E05011522,E14001102,E06000008,E06000008
+2024,2024,Wensley Fold,Blackburn,Blackburn with Darwen,Blackburn with Darwen,E05011523,E14001102,E06000008,E06000008
+2024,2024,West Pennine,Rossendale and Darwen,Blackburn with Darwen,Blackburn with Darwen,E05011524,E14001450,E06000008,E06000008
+2024,2024,Anchorsholme,Blackpool North and Fleetwood,Blackpool,Blackpool,E05015186,E14001104,E06000009,E06000009
+2024,2024,Bispham,Blackpool North and Fleetwood,Blackpool,Blackpool,E05015187,E14001104,E06000009,E06000009
+2024,2024,Bloomfield,Blackpool South,Blackpool,Blackpool,E05015188,E14001105,E06000009,E06000009
+2024,2024,Brunswick,Blackpool South,Blackpool,Blackpool,E05015189,E14001105,E06000009,E06000009
+2024,2024,Claremont,Blackpool South,Blackpool,Blackpool,E05015190,E14001105,E06000009,E06000009
+2024,2024,Clifton,Blackpool South,Blackpool,Blackpool,E05015191,E14001105,E06000009,E06000009
+2024,2024,Greenlands,Blackpool North and Fleetwood,Blackpool,Blackpool,E05015192,E14001104,E06000009,E06000009
+2024,2024,Greenlands,Blackpool South,Blackpool,Blackpool,E05015192,E14001105,E06000009,E06000009
+2024,2024,Hawes Side,Blackpool South,Blackpool,Blackpool,E05015193,E14001105,E06000009,E06000009
+2024,2024,Highfield,Blackpool South,Blackpool,Blackpool,E05015194,E14001105,E06000009,E06000009
+2024,2024,Ingthorpe,Blackpool North and Fleetwood,Blackpool,Blackpool,E05015195,E14001104,E06000009,E06000009
+2024,2024,Layton,Blackpool South,Blackpool,Blackpool,E05015196,E14001105,E06000009,E06000009
+2024,2024,Marton,Blackpool South,Blackpool,Blackpool,E05015197,E14001105,E06000009,E06000009
+2024,2024,Norbreck,Blackpool North and Fleetwood,Blackpool,Blackpool,E05015198,E14001104,E06000009,E06000009
+2024,2024,Park,Blackpool South,Blackpool,Blackpool,E05015199,E14001105,E06000009,E06000009
+2024,2024,Squires Gate,Blackpool South,Blackpool,Blackpool,E05015200,E14001105,E06000009,E06000009
+2024,2024,Stanley,Blackpool South,Blackpool,Blackpool,E05015201,E14001105,E06000009,E06000009
+2024,2024,Talbot,Blackpool South,Blackpool,Blackpool,E05015202,E14001105,E06000009,E06000009
+2024,2024,Tyldesley,Blackpool South,Blackpool,Blackpool,E05015203,E14001105,E06000009,E06000009
+2024,2024,Victoria,Blackpool South,Blackpool,Blackpool,E05015204,E14001105,E06000009,E06000009
+2024,2024,Warbreck,Blackpool North and Fleetwood,Blackpool,Blackpool,E05015205,E14001104,E06000009,E06000009
+2024,2024,Warbreck,Blackpool South,Blackpool,Blackpool,E05015205,E14001105,E06000009,E06000009
+2024,2024,Waterloo,Blackpool South,Blackpool,Blackpool,E05015206,E14001105,E06000009,E06000009
+2024,2024,Avenue,Kingston upon Hull North and Cottingham,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011525,E14001314,E06000010,E06000010
+2024,2024,Beverley & Newland,Kingston upon Hull North and Cottingham,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011526,E14001314,E06000010,E06000010
+2024,2024,Boothferry,Kingston upon Hull West and Haltemprice,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011527,E14001315,E06000010,E06000010
+2024,2024,Bricknell,Kingston upon Hull North and Cottingham,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011528,E14001314,E06000010,E06000010
+2024,2024,Central,Kingston upon Hull North and Cottingham,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011529,E14001314,E06000010,E06000010
+2024,2024,Derringham,Kingston upon Hull West and Haltemprice,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011530,E14001315,E06000010,E06000010
+2024,2024,Drypool,Kingston upon Hull East,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011531,E14001313,E06000010,E06000010
+2024,2024,Holderness,Kingston upon Hull East,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011532,E14001313,E06000010,E06000010
+2024,2024,Ings,Kingston upon Hull East,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011533,E14001313,E06000010,E06000010
+2024,2024,Kingswood,Kingston upon Hull North and Cottingham,"Kingston upon Hull, City of","Kingston upon Hull, City of",E05011534,E14001314,E06000010,E06000010
+2024,2024,West Marsh,Great Grimsby and Cleethorpes,North East Lincolnshire,North East Lincolnshire,E05001725,E14001255,E06000012,E06000012
+2024,2024,Wolds,Brigg and Immingham,North East Lincolnshire,North East Lincolnshire,E05001726,E14001128,E06000012,E06000012
+2024,2024,Yarborough,Great Grimsby and Cleethorpes,North East Lincolnshire,North East Lincolnshire,E05001727,E14001255,E06000012,E06000012
+2024,2024,Ashby Central,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015074,E14001462,E06000013,E06000013
+2024,2024,Ashby Lakeside,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015075,E14001462,E06000013,E06000013
+2024,2024,Axholme Central,Doncaster East and the Isle of Axholme,North Lincolnshire,North Lincolnshire,E05015076,E14001199,E06000013,E06000013
+2024,2024,Axholme North,Doncaster East and the Isle of Axholme,North Lincolnshire,North Lincolnshire,E05015077,E14001199,E06000013,E06000013
+2024,2024,Axholme South,Doncaster East and the Isle of Axholme,North Lincolnshire,North Lincolnshire,E05015078,E14001199,E06000013,E06000013
+2024,2024,Barton,Brigg and Immingham,North Lincolnshire,North Lincolnshire,E05015079,E14001128,E06000013,E06000013
+2024,2024,Bottesford,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015080,E14001462,E06000013,E06000013
+2024,2024,Brigg & Wolds,Brigg and Immingham,North Lincolnshire,North Lincolnshire,E05015081,E14001128,E06000013,E06000013
+2024,2024,Brigg & Wolds,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015081,E14001462,E06000013,E06000013
+2024,2024,Broughton & Scawby,Brigg and Immingham,North Lincolnshire,North Lincolnshire,E05015082,E14001128,E06000013,E06000013
+2024,2024,Broughton & Scawby,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015082,E14001462,E06000013,E06000013
+2024,2024,Brumby,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015083,E14001462,E06000013,E06000013
+2024,2024,Burringham & Gunness,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015084,E14001462,E06000013,E06000013
+2024,2024,Burton upon Stather & Winterton,Brigg and Immingham,North Lincolnshire,North Lincolnshire,E05015085,E14001128,E06000013,E06000013
+2024,2024,Burton upon Stather & Winterton,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015085,E14001462,E06000013,E06000013
+2024,2024,Crosby & Park,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015086,E14001462,E06000013,E06000013
+2024,2024,Ferry,Brigg and Immingham,North Lincolnshire,North Lincolnshire,E05015087,E14001128,E06000013,E06000013
+2024,2024,Frodingham,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015088,E14001462,E06000013,E06000013
+2024,2024,Kingsway with Lincoln Gardens,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015089,E14001462,E06000013,E06000013
+2024,2024,Messingham,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015090,E14001462,E06000013,E06000013
+2024,2024,Ridge,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015091,E14001462,E06000013,E06000013
+2024,2024,Town,Scunthorpe,North Lincolnshire,North Lincolnshire,E05015092,E14001462,E06000013,E06000013
+2024,2024,Acomb,York Central,York,York,E05010311,E14001604,E06000014,E06000014
+2024,2024,Bishopthorpe,York Outer,York,York,E05010312,E14001605,E06000014,E06000014
+2024,2024,Clifton,York Central,York,York,E05010313,E14001604,E06000014,E06000014
+2024,2024,Copmanthorpe,York Outer,York,York,E05010314,E14001605,E06000014,E06000014
+2024,2024,Dringhouses & Woodthorpe,York Outer,York,York,E05010315,E14001605,E06000014,E06000014
+2024,2024,Fishergate,York Central,York,York,E05010316,E14001604,E06000014,E06000014
+2024,2024,Fulford & Heslington,York Outer,York,York,E05010317,E14001605,E06000014,E06000014
+2024,2024,Guildhall,York Central,York,York,E05010318,E14001604,E06000014,E06000014
+2024,2024,Haxby & Wigginton,York Outer,York,York,E05010319,E14001605,E06000014,E06000014
+2024,2024,Heworth,York Central,York,York,E05010320,E14001604,E06000014,E06000014
+2024,2024,Heworth Without,York Outer,York,York,E05010321,E14001605,E06000014,E06000014
+2024,2024,Holgate,York Central,York,York,E05010322,E14001604,E06000014,E06000014
+2024,2024,Hull Road,York Central,York,York,E05010323,E14001604,E06000014,E06000014
+2024,2024,Huntington & New Earswick,York Outer,York,York,E05010324,E14001605,E06000014,E06000014
+2024,2024,Micklegate,York Central,York,York,E05010325,E14001604,E06000014,E06000014
+2024,2024,Osbaldwick & Derwent,York Outer,York,York,E05010326,E14001605,E06000014,E06000014
+2024,2024,Rawcliffe & Clifton Without,York Outer,York,York,E05010327,E14001605,E06000014,E06000014
+2024,2024,Rural West York,York Outer,York,York,E05010328,E14001605,E06000014,E06000014
+2024,2024,Strensall,York Outer,York,York,E05010329,E14001605,E06000014,E06000014
+2024,2024,Westfield,York Central,York,York,E05010330,E14001604,E06000014,E06000014
+2024,2024,Wheldrake,York Outer,York,York,E05010331,E14001605,E06000014,E06000014
+2024,2024,Abbey,Derby North,Derby,Derby,E05015507,E14001193,E06000015,E06000015
+2024,2024,Abbey,Derby South,Derby,Derby,E05015507,E14001194,E06000015,E06000015
+2024,2024,Allestree,Mid Derbyshire,Derby,Derby,E05015508,E14001362,E06000015,E06000015
+2024,2024,Alvaston North,Derby South,Derby,Derby,E05015509,E14001194,E06000015,E06000015
+2024,2024,Kerne Bridge,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009462,E14001281,E06000019,E06000019
+2024,2024,Kings Acre,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009463,E14001281,E06000019,E06000019
+2024,2024,Kington,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009464,E14001395,E06000019,E06000019
+2024,2024,Ledbury North,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009465,E14001395,E06000019,E06000019
+2024,2024,Ledbury South,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009466,E14001395,E06000019,E06000019
+2024,2024,Wick St Lawrence & St Georges,Weston-super-Mare,North Somerset,North Somerset,E05010307,E14001581,E06000024,E06000024
+2024,2024,Ledbury West,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009467,E14001395,E06000019,E06000019
+2024,2024,Leominster East,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009468,E14001395,E06000019,E06000019
+2024,2024,Winford,North Somerset,North Somerset,North Somerset,E05010308,E14001399,E06000024,E06000024
+2024,2024,Leominster North & Rural,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009469,E14001395,E06000019,E06000019
+2024,2024,Wrington,North Somerset,North Somerset,North Somerset,E05010309,E14001399,E06000024,E06000024
+2024,2024,Leominster South,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009470,E14001395,E06000019,E06000019
+2024,2024,Yatton,Wells and Mendip Hills,North Somerset,North Somerset,E05010310,E14001572,E06000024,E06000024
+2024,2024,Leominster West,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009471,E14001395,E06000019,E06000019
+2024,2024,Muxton,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015225,E14001543,E06000020,E06000020
+2024,2024,Hampton Vale,North West Cambridgeshire,Peterborough,Peterborough,E05010815,E14001401,E06000031,E06000031
+2024,2024,Bitton & Oldland Common,North East Somerset and Hanham,South Gloucestershire,South Gloucestershire,E05012104,E14001394,E06000025,E06000025
+2024,2024,Llangarron,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009472,E14001281,E06000019,E06000019
+2024,2024,Newport East,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015226,E14001543,E06000020,E06000020
+2024,2024,Hargate and Hempsted,North West Cambridgeshire,Peterborough,Peterborough,E05010816,E14001401,E06000031,E06000031
+2024,2024,Boyd Valley,Thornbury and Yate,South Gloucestershire,South Gloucestershire,E05012105,E14001545,E06000025,E06000025
+2024,2024,Mortimer,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009473,E14001395,E06000019,E06000019
+2024,2024,Newport North,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015227,E14001543,E06000020,E06000020
+2024,2024,North,Peterborough,Peterborough,Peterborough,E05010817,E14001425,E06000031,E06000031
+2024,2024,Bradley Stoke North,Filton and Bradley Stoke,South Gloucestershire,South Gloucestershire,E05012106,E14001237,E06000025,E06000025
+2024,2024,Newton Farm,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009474,E14001281,E06000019,E06000019
+2024,2024,Newport South,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015228,E14001543,E06000020,E06000020
+2024,2024,Orton Longueville,North West Cambridgeshire,Peterborough,Peterborough,E05010818,E14001401,E06000031,E06000031
+2024,2024,Bradley Stoke South,Filton and Bradley Stoke,South Gloucestershire,South Gloucestershire,E05012107,E14001237,E06000025,E06000025
+2024,2024,Old Gore,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009475,E14001395,E06000019,E06000019
+2024,2024,Penyard,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009476,E14001281,E06000019,E06000019
+2024,2024,Red Hill,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009478,E14001281,E06000019,E06000019
+2024,2024,Ross East,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009479,E14001281,E06000019,E06000019
+2024,2024,Ross North,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009480,E14001281,E06000019,E06000019
+2024,2024,Ross West,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009481,E14001281,E06000019,E06000019
+2024,2024,Saxon Gate,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009482,E14001281,E06000019,E06000019
+2024,2024,Three Crosses,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009485,E14001395,E06000019,E06000019
+2024,2024,Tupsley,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009486,E14001281,E06000019,E06000019
+2024,2024,Weobley,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009487,E14001395,E06000019,E06000019
+2024,2024,Whitecross,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009488,E14001281,E06000019,E06000019
+2024,2024,Widemarsh,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009489,E14001281,E06000019,E06000019
+2024,2024,Wormside,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05009490,E14001281,E06000019,E06000019
+2024,2024,Credenhill,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05012957,E14001395,E06000019,E06000019
+2024,2024,Queenswood,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05012958,E14001395,E06000019,E06000019
+2024,2024,Stoney Street,Hereford and South Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05012959,E14001281,E06000019,E06000019
+2024,2024,Sutton Walls,North Herefordshire,"Herefordshire, County of","Herefordshire, County of",E05012960,E14001395,E06000019,E06000019
+2024,2024,Admaston & Bratton,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015207,E14001543,E06000020,E06000020
+2024,2024,Apley Castle,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015208,E14001543,E06000020,E06000020
+2024,2024,Arleston & College,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015209,E14001543,E06000020,E06000020
+2024,2024,Brookside,Telford,Telford and Wrekin,Telford and Wrekin,E05015210,E14001541,E06000020,E06000020
+2024,2024,Church Aston & Lilleshall,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015211,E14001543,E06000020,E06000020
+2024,2024,Dawley & Aqueduct,Telford,Telford and Wrekin,Telford and Wrekin,E05015212,E14001541,E06000020,E06000020
+2024,2024,Donnington,Telford,Telford and Wrekin,Telford and Wrekin,E05015213,E14001541,E06000020,E06000020
+2024,2024,Donnington,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015213,E14001543,E06000020,E06000020
+2024,2024,Edgmond,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015214,E14001543,E06000020,E06000020
+2024,2024,Ercall,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015215,E14001543,E06000020,E06000020
+2024,2024,Ercall Magna,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015216,E14001543,E06000020,E06000020
+2024,2024,Hadley & Leegomery,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015217,E14001543,E06000020,E06000020
+2024,2024,Haygate & Park,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015218,E14001543,E06000020,E06000020
+2024,2024,Horsehay & Lightmoor,Telford,Telford and Wrekin,Telford and Wrekin,E05015219,E14001541,E06000020,E06000020
+2024,2024,Ironbridge Gorge,Telford,Telford and Wrekin,Telford and Wrekin,E05015220,E14001541,E06000020,E06000020
+2024,2024,Ketley,Telford,Telford and Wrekin,Telford and Wrekin,E05015221,E14001541,E06000020,E06000020
+2024,2024,Lawley,Telford,Telford and Wrekin,Telford and Wrekin,E05015222,E14001541,E06000020,E06000020
+2024,2024,Lawley,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015222,E14001543,E06000020,E06000020
+2024,2024,Madeley & Sutton Hill,Telford,Telford and Wrekin,Telford and Wrekin,E05015223,E14001541,E06000020,E06000020
+2024,2024,Malinslee & Dawley Bank,Telford,Telford and Wrekin,Telford and Wrekin,E05015224,E14001541,E06000020,E06000020
+2024,2024,Charfield,Thornbury and Yate,South Gloucestershire,South Gloucestershire,E05012108,E14001545,E06000025,E06000025
+2024,2024,Charlton & Cribbs,Filton and Bradley Stoke,South Gloucestershire,South Gloucestershire,E05012109,E14001237,E06000025,E06000025
+2024,2024,Chipping Sodbury & Cotswold Edge,Thornbury and Yate,South Gloucestershire,South Gloucestershire,E05012110,E14001545,E06000025,E06000025
+2024,2024,Dodington,Thornbury and Yate,South Gloucestershire,South Gloucestershire,E05012111,E14001545,E06000025,E06000025
+2024,2024,Emersons Green,Filton and Bradley Stoke,South Gloucestershire,South Gloucestershire,E05012112,E14001237,E06000025,E06000025
+2024,2024,Filton,Filton and Bradley Stoke,South Gloucestershire,South Gloucestershire,E05012113,E14001237,E06000025,E06000025
+2024,2024,Frampton Cotterell,Thornbury and Yate,South Gloucestershire,South Gloucestershire,E05012114,E14001545,E06000025,E06000025
+2024,2024,Frenchay & Downend,Filton and Bradley Stoke,South Gloucestershire,South Gloucestershire,E05012115,E14001237,E06000025,E06000025
+2024,2024,Hanham,North East Somerset and Hanham,South Gloucestershire,South Gloucestershire,E05012116,E14001394,E06000025,E06000025
+2024,2024,Kingswood,Bristol North East,South Gloucestershire,South Gloucestershire,E05012117,E14001133,E06000025,E06000025
+2024,2024,Longwell Green,North East Somerset and Hanham,South Gloucestershire,South Gloucestershire,E05012118,E14001394,E06000025,E06000025
+2024,2024,New Cheltenham,Bristol North East,South Gloucestershire,South Gloucestershire,E05012119,E14001133,E06000025,E06000025
+2024,2024,Parkwall & Warmley,North East Somerset and Hanham,South Gloucestershire,South Gloucestershire,E05012120,E14001394,E06000025,E06000025
+2024,2024,Patchway Coniston,Filton and Bradley Stoke,South Gloucestershire,South Gloucestershire,E05012121,E14001237,E06000025,E06000025
+2024,2024,Pilning & Severn Beach,Thornbury and Yate,South Gloucestershire,South Gloucestershire,E05012122,E14001545,E06000025,E06000025
+2024,2024,Severn Vale,Thornbury and Yate,South Gloucestershire,South Gloucestershire,E05012123,E14001545,E06000025,E06000025
+2024,2024,Staple Hill & Mangotsfield,Bristol North East,South Gloucestershire,South Gloucestershire,E05012124,E14001133,E06000025,E06000025
+2024,2024,Stoke Gifford,Filton and Bradley Stoke,South Gloucestershire,South Gloucestershire,E05012125,E14001237,E06000025,E06000025
+2024,2024,Stoke Park & Cheswick,Filton and Bradley Stoke,South Gloucestershire,South Gloucestershire,E05012126,E14001237,E06000025,E06000025
+2024,2024,Thornbury,Thornbury and Yate,South Gloucestershire,South Gloucestershire,E05012127,E14001545,E06000025,E06000025
+2024,2024,Winterbourne,Filton and Bradley Stoke,South Gloucestershire,South Gloucestershire,E05012128,E14001237,E06000025,E06000025
+2024,2024,Orton Waterville,North West Cambridgeshire,Peterborough,Peterborough,E05010819,E14001401,E06000031,E06000031
+2024,2024,Woodstock,Bristol North East,South Gloucestershire,South Gloucestershire,E05012129,E14001133,E06000025,E06000025
+2024,2024,Newport West,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015229,E14001543,E06000020,E06000020
+2024,2024,Park,Peterborough,Peterborough,Peterborough,E05010820,E14001425,E06000031,E06000031
+2024,2024,Oakengates & Ketley Bank,Telford,Telford and Wrekin,Telford and Wrekin,E05015230,E14001541,E06000020,E06000020
+2024,2024,Paston and Walton,Peterborough,Peterborough,Peterborough,E05010821,E14001425,E06000031,E06000031
+2024,2024,Overdale & The Rock,Telford,Telford and Wrekin,Telford and Wrekin,E05015231,E14001541,E06000020,E06000020
+2024,2024,Ravensthorpe,Peterborough,Peterborough,Peterborough,E05010822,E14001425,E06000031,E06000031
+2024,2024,Priorslee,Telford,Telford and Wrekin,Telford and Wrekin,E05015232,E14001541,E06000020,E06000020
+2024,2024,Stanground South,North West Cambridgeshire,Peterborough,Peterborough,E05010823,E14001401,E06000031,E06000031
+2024,2024,Shawbirch & Dothill,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015233,E14001543,E06000020,E06000020
+2024,2024,Werrington,Peterborough,Peterborough,Peterborough,E05010824,E14001425,E06000031,E06000031
+2024,2024,St Georges,Telford,Telford and Wrekin,Telford and Wrekin,E05015234,E14001541,E06000020,E06000020
+2024,2024,West,Peterborough,Peterborough,Peterborough,E05010825,E14001425,E06000031,E06000031
+2024,2024,The Nedge,Telford,Telford and Wrekin,Telford and Wrekin,E05015235,E14001541,E06000020,E06000020
+2024,2024,Wittering,North West Cambridgeshire,Peterborough,Peterborough,E05010826,E14001401,E06000031,E06000031
+2024,2024,Woodside,Telford,Telford and Wrekin,Telford and Wrekin,E05015236,E14001541,E06000020,E06000020
+2024,2024,Barnfield,Luton North,Luton,Luton,E05014735,E14001345,E06000032,E06000032
+2024,2024,Wrockwardine,The Wrekin,Telford and Wrekin,Telford and Wrekin,E05015237,E14001543,E06000020,E06000020
+2024,2024,Yate Central,Thornbury and Yate,South Gloucestershire,South Gloucestershire,E05012130,E14001545,E06000025,E06000025
+2024,2024,Barnfield,Luton South and South Bedfordshire,Luton,Luton,E05014735,E14001346,E06000032,E06000032
+2024,2024,Wrockwardine Wood & Trench,Telford,Telford and Wrekin,Telford and Wrekin,E05015238,E14001541,E06000020,E06000020
+2024,2024,Yate North,Thornbury and Yate,South Gloucestershire,South Gloucestershire,E05012131,E14001545,E06000025,E06000025
+2024,2024,Beech Hill,Luton North,Luton,Luton,E05014736,E14001345,E06000032,E06000032
+2024,2024,Abbey Hulton,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014555,E14001520,E06000021,E06000021
+2024,2024,Budshead,Plymouth Moor View,Plymouth,Plymouth,E05002078,E14001426,E06000026,E06000026
+2024,2024,Beech Hill,Luton South and South Bedfordshire,Luton,Luton,E05014736,E14001346,E06000032,E06000032
+2024,2024,"Baddeley, Milton & Norton",Stoke-on-Trent North,Stoke-on-Trent,Stoke-on-Trent,E05014556,E14001521,E06000021,E06000021
+2024,2024,Compton,Plymouth Sutton and Devonport,Plymouth,Plymouth,E05002079,E14001427,E06000026,E06000026
+2024,2024,Biscot,Luton South and South Bedfordshire,Luton,Luton,E05014737,E14001346,E06000032,E06000032
+2024,2024,Basford & Hartshill,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014557,E14001520,E06000021,E06000021
+2024,2024,Devonport,Plymouth Sutton and Devonport,Plymouth,Plymouth,E05002080,E14001427,E06000026,E06000026
+2024,2024,Bramingham,Luton North,Luton,Luton,E05014738,E14001345,E06000032,E06000032
+2024,2024,"Bentilee, Ubberley & Townsend",Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014558,E14001520,E06000021,E06000021
+2024,2024,Drake,Plymouth Sutton and Devonport,Plymouth,Plymouth,E05002081,E14001427,E06000026,E06000026
+2024,2024,Central,Luton South and South Bedfordshire,Luton,Luton,E05014739,E14001346,E06000032,E06000032
+2024,2024,Trent Vale & Oak Hill,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014587,E14001520,E06000021,E06000021
+2024,2024,Birches Head & Northwood,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014559,E14001520,E06000021,E06000021
+2024,2024,Blurton,Stoke-on-Trent South,Stoke-on-Trent,Stoke-on-Trent,E05014560,E14001522,E06000021,E06000021
+2024,2024,Boothen,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014561,E14001520,E06000021,E06000021
+2024,2024,Bradeley & Chell Heath,Stoke-on-Trent North,Stoke-on-Trent,Stoke-on-Trent,E05014562,E14001521,E06000021,E06000021
+2024,2024,Bucknall & Eaton Park,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014563,E14001520,E06000021,E06000021
+2024,2024,Burslem,Stoke-on-Trent North,Stoke-on-Trent,Stoke-on-Trent,E05014564,E14001521,E06000021,E06000021
+2024,2024,Burslem Park,Stoke-on-Trent North,Stoke-on-Trent,Stoke-on-Trent,E05014565,E14001521,E06000021,E06000021
+2024,2024,Dresden & Florence,Stoke-on-Trent South,Stoke-on-Trent,Stoke-on-Trent,E05014566,E14001522,E06000021,E06000021
+2024,2024,Etruria & Hanley,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014567,E14001520,E06000021,E06000021
+2024,2024,Etruria & Hanley,Stoke-on-Trent North,Stoke-on-Trent,Stoke-on-Trent,E05014567,E14001521,E06000021,E06000021
+2024,2024,Fenton East,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014568,E14001520,E06000021,E06000021
+2024,2024,Fenton West & Mount Pleasant,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014569,E14001520,E06000021,E06000021
+2024,2024,Ford Green & Smallthorne,Stoke-on-Trent North,Stoke-on-Trent,Stoke-on-Trent,E05014570,E14001521,E06000021,E06000021
+2024,2024,Goldenhill & Sandyford,Stoke-on-Trent North,Stoke-on-Trent,Stoke-on-Trent,E05014571,E14001521,E06000021,E06000021
+2024,2024,Great Chell & Packmoor,Stoke-on-Trent North,Stoke-on-Trent,Stoke-on-Trent,E05014572,E14001521,E06000021,E06000021
+2024,2024,"Hanford, Newstead & Trentham",Stoke-on-Trent South,Stoke-on-Trent,Stoke-on-Trent,E05014573,E14001522,E06000021,E06000021
+2024,2024,"Hanley Park, Joiner's Square & Shelton",Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014574,E14001520,E06000021,E06000021
+2024,2024,Hartshill Park & Stoke,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014575,E14001520,E06000021,E06000021
+2024,2024,Hollybush,Stoke-on-Trent South,Stoke-on-Trent,Stoke-on-Trent,E05014576,E14001522,E06000021,E06000021
+2024,2024,Lightwood North & Normacot,Stoke-on-Trent South,Stoke-on-Trent,Stoke-on-Trent,E05014577,E14001522,E06000021,E06000021
+2024,2024,Little Chell & Stanfield,Stoke-on-Trent North,Stoke-on-Trent,Stoke-on-Trent,E05014578,E14001521,E06000021,E06000021
+2024,2024,Longton & Meir Hay South,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014579,E14001520,E06000021,E06000021
+2024,2024,Longton & Meir Hay South,Stoke-on-Trent South,Stoke-on-Trent,Stoke-on-Trent,E05014579,E14001522,E06000021,E06000021
+2024,2024,"Meir Hay North, Parkhall & Weston Coyney",Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014580,E14001520,E06000021,E06000021
+2024,2024,"Meir Hay North, Parkhall & Weston Coyney",Stoke-on-Trent South,Stoke-on-Trent,Stoke-on-Trent,E05014580,E14001522,E06000021,E06000021
+2024,2024,Meir North,Stoke-on-Trent South,Stoke-on-Trent,Stoke-on-Trent,E05014581,E14001522,E06000021,E06000021
+2024,2024,Meir Park,Stoke-on-Trent South,Stoke-on-Trent,Stoke-on-Trent,E05014582,E14001522,E06000021,E06000021
+2024,2024,Meir South,Stoke-on-Trent South,Stoke-on-Trent,Stoke-on-Trent,E05014583,E14001522,E06000021,E06000021
+2024,2024,Moorcroft & Sneyd Green,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014584,E14001520,E06000021,E06000021
+2024,2024,Moorcroft & Sneyd Green,Stoke-on-Trent North,Stoke-on-Trent,Stoke-on-Trent,E05014584,E14001521,E06000021,E06000021
+2024,2024,Southway,Plymouth Moor View,Plymouth,Plymouth,E05002095,E14001426,E06000026,E06000026
+2024,2024,Penkhull & Springfields,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014585,E14001520,E06000021,E06000021
+2024,2024,Sandford Hill,Stoke-on-Trent Central,Stoke-on-Trent,Stoke-on-Trent,E05014586,E14001520,E06000021,E06000021
+2024,2024,Stoke,Plymouth Sutton and Devonport,Plymouth,Plymouth,E05002096,E14001427,E06000026,E06000026
+2024,2024,Sutton and Mount Gould,Plymouth Sutton and Devonport,Plymouth,Plymouth,E05002097,E14001427,E06000026,E06000026
+2024,2024,Barton with Watcombe,Torbay,Torbay,Torbay,E05012254,E14001551,E06000027,E06000027
+2024,2024,Churston with Galmpton,South Devon,Torbay,Torbay,E05012255,E14001484,E06000027,E06000027
+2024,2024,Clifton with Maidenway,Torbay,Torbay,Torbay,E05012256,E14001551,E06000027,E06000027
+2024,2024,Cockington with Chelston,Torbay,Torbay,Torbay,E05012257,E14001551,E06000027,E06000027
+2024,2024,Collaton St Mary,South Devon,Torbay,Torbay,E05012258,E14001484,E06000027,E06000027
+2024,2024,Ellacombe,Torbay,Torbay,Torbay,E05012259,E14001551,E06000027,E06000027
+2024,2024,Furzeham with Summercombe,South Devon,Torbay,Torbay,E05012260,E14001484,E06000027,E06000027
+2024,2024,Goodrington with Roselands,Torbay,Torbay,Torbay,E05012261,E14001551,E06000027,E06000027
+2024,2024,King's Ash,South Devon,Torbay,Torbay,E05012262,E14001484,E06000027,E06000027
+2024,2024,Preston,Torbay,Torbay,Torbay,E05012263,E14001551,E06000027,E06000027
+2024,2024,Roundham with Hyde,Torbay,Torbay,Torbay,E05012264,E14001551,E06000027,E06000027
+2024,2024,St Marychurch,Torbay,Torbay,Torbay,E05012265,E14001551,E06000027,E06000027
+2024,2024,St Peter's with St Mary's,South Devon,Torbay,Torbay,E05012266,E14001484,E06000027,E06000027
+2024,2024,Shiphay,Torbay,Torbay,Torbay,E05012267,E14001551,E06000027,E06000027
+2024,2024,Tormohun,Torbay,Torbay,Torbay,E05012268,E14001551,E06000027,E06000027
+2024,2024,Wellswood,Torbay,Torbay,Torbay,E05012269,E14001551,E06000027,E06000027
+2024,2024,Central,Swindon South,Swindon,Swindon,E05008954,E14001537,E06000030,E06000030
+2024,2024,Efford and Lipson,Plymouth Sutton and Devonport,Plymouth,Plymouth,E05002082,E14001427,E06000026,E06000026
+2024,2024,Eggbuckland,Plymouth Moor View,Plymouth,Plymouth,E05002083,E14001426,E06000026,E06000026
+2024,2024,Ham,Plymouth Moor View,Plymouth,Plymouth,E05002084,E14001426,E06000026,E06000026
+2024,2024,Honicknowle,Plymouth Moor View,Plymouth,Plymouth,E05002085,E14001426,E06000026,E06000026
+2024,2024,Moor View,Plymouth Moor View,Plymouth,Plymouth,E05002086,E14001426,E06000026,E06000026
+2024,2024,Peverell,Plymouth Moor View,Plymouth,Plymouth,E05002087,E14001426,E06000026,E06000026
+2024,2024,Peverell,Plymouth Sutton and Devonport,Plymouth,Plymouth,E05002087,E14001427,E06000026,E06000026
+2024,2024,Plympton Chaddlewood,South West Devon,Plymouth,Plymouth,E05002088,E14001495,E06000026,E06000026
+2024,2024,Plympton Erle,South West Devon,Plymouth,Plymouth,E05002089,E14001495,E06000026,E06000026
+2024,2024,Plympton St Mary,South West Devon,Plymouth,Plymouth,E05002090,E14001495,E06000026,E06000026
+2024,2024,Plymstock Dunstone,South West Devon,Plymouth,Plymouth,E05002091,E14001495,E06000026,E06000026
+2024,2024,Tunstall,Stoke-on-Trent North,Stoke-on-Trent,Stoke-on-Trent,E05014588,E14001521,E06000021,E06000021
+2024,2024,Plymstock Radford,South West Devon,Plymouth,Plymouth,E05002092,E14001495,E06000026,E06000026
+2024,2024,Bathavon North,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012461,E14001080,E06000022,E06000022
+2024,2024,St Budeaux,Plymouth Moor View,Plymouth,Plymouth,E05002093,E14001426,E06000026,E06000026
+2024,2024,Bathavon South,Frome and East Somerset,Bath and North East Somerset,Bath and North East Somerset,E05012462,E14001241,E06000022,E06000022
+2024,2024,Chiseldon and Lawn,East Wiltshire,Swindon,Swindon,E05008955,E14001217,E06000030,E06000030
+2024,2024,Challney,Luton North,Luton,Luton,E05014740,E14001345,E06000032,E06000032
+2024,2024,Challney,Luton South and South Bedfordshire,Luton,Luton,E05014740,E14001346,E06000032,E06000032
+2024,2024,Dallow,Luton South and South Bedfordshire,Luton,Luton,E05014741,E14001346,E06000032,E06000032
+2024,2024,Farley,Luton South and South Bedfordshire,Luton,Luton,E05014742,E14001346,E06000032,E06000032
+2024,2024,High Town,Luton South and South Bedfordshire,Luton,Luton,E05014743,E14001346,E06000032,E06000032
+2024,2024,Leagrave,Luton North,Luton,Luton,E05014744,E14001345,E06000032,E06000032
+2024,2024,Lewsey,Luton North,Luton,Luton,E05014745,E14001345,E06000032,E06000032
+2024,2024,Northwell,Luton North,Luton,Luton,E05014746,E14001345,E06000032,E06000032
+2024,2024,Poets,Luton North,Luton,Luton,E05014747,E14001345,E06000032,E06000032
+2024,2024,Round Green,Luton South and South Bedfordshire,Luton,Luton,E05014748,E14001346,E06000032,E06000032
+2024,2024,Saints,Luton North,Luton,Luton,E05014749,E14001345,E06000032,E06000032
+2024,2024,Saints,Luton South and South Bedfordshire,Luton,Luton,E05014749,E14001346,E06000032,E06000032
+2024,2024,South,Luton South and South Bedfordshire,Luton,Luton,E05014750,E14001346,E06000032,E06000032
+2024,2024,Stopsley,Luton North,Luton,Luton,E05014751,E14001345,E06000032,E06000032
+2024,2024,Stopsley,Luton South and South Bedfordshire,Luton,Luton,E05014751,E14001346,E06000032,E06000032
+2024,2024,Sundon Park,Luton North,Luton,Luton,E05014752,E14001345,E06000032,E06000032
+2024,2024,Vauxhall,Luton South and South Bedfordshire,Luton,Luton,E05014753,E14001346,E06000032,E06000032
+2024,2024,Wigmore,Luton South and South Bedfordshire,Luton,Luton,E05014754,E14001346,E06000032,E06000032
+2024,2024,Belfairs,Southend West and Leigh,Southend-on-Sea,Southend-on-Sea,E05002212,E14001502,E06000033,E06000033
+2024,2024,Bathwick,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012463,E14001080,E06000022,E06000022
+2024,2024,Chiseldon and Lawn,Swindon South,Swindon,Swindon,E05008955,E14001537,E06000030,E06000030
+2024,2024,Covingham and Dorcan,Swindon South,Swindon,Swindon,E05008956,E14001537,E06000030,E06000030
+2024,2024,St Peter and the Waterfront,Plymouth Sutton and Devonport,Plymouth,Plymouth,E05002094,E14001427,E06000026,E06000026
+2024,2024,Eastcott,Swindon South,Swindon,Swindon,E05008957,E14001537,E06000030,E06000030
+2024,2024,Chew Valley,North East Somerset and Hanham,Bath and North East Somerset,Bath and North East Somerset,E05012464,E14001394,E06000022,E06000022
+2024,2024,Gorse Hill and Pinehurst,Swindon North,Swindon,Swindon,E05008958,E14001536,E06000030,E06000030
+2024,2024,Clutton & Farmborough,North East Somerset and Hanham,Bath and North East Somerset,Bath and North East Somerset,E05012465,E14001394,E06000022,E06000022
+2024,2024,"Liden, Eldene and Park South",Swindon South,Swindon,Swindon,E05008960,E14001537,E06000030,E06000030
+2024,2024,Combe Down,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012466,E14001080,E06000022,E06000022
+2024,2024,Lydiard and Freshbrook,Swindon South,Swindon,Swindon,E05008961,E14001537,E06000030,E06000030
+2024,2024,High Littleton,North East Somerset and Hanham,Bath and North East Somerset,Bath and North East Somerset,E05012467,E14001394,E06000022,E06000022
+2024,2024,Mannington and Western,Swindon South,Swindon,Swindon,E05008962,E14001537,E06000030,E06000030
+2024,2024,Keynsham East,North East Somerset and Hanham,Bath and North East Somerset,Bath and North East Somerset,E05012468,E14001394,E06000022,E06000022
+2024,2024,Old Town,Swindon South,Swindon,Swindon,E05008963,E14001537,E06000030,E06000030
+2024,2024,Keynsham North,North East Somerset and Hanham,Bath and North East Somerset,Bath and North East Somerset,E05012469,E14001394,E06000022,E06000022
+2024,2024,Priory Vale,Swindon North,Swindon,Swindon,E05008965,E14001536,E06000030,E06000030
+2024,2024,Keynsham South,North East Somerset and Hanham,Bath and North East Somerset,Bath and North East Somerset,E05012470,E14001394,E06000022,E06000022
+2024,2024,Ridgeway,East Wiltshire,Swindon,Swindon,E05008966,E14001217,E06000030,E06000030
+2024,2024,Kingsmead,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012471,E14001080,E06000022,E06000022
+2024,2024,Rodbourne Cheney,Swindon North,Swindon,Swindon,E05008967,E14001536,E06000030,E06000030
+2024,2024,Lambridge,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012472,E14001080,E06000022,E06000022
+2024,2024,St Andrews,Swindon North,Swindon,Swindon,E05008968,E14001536,E06000030,E06000030
+2024,2024,Lansdown,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012473,E14001080,E06000022,E06000022
+2024,2024,St Margaret and South Marston,Swindon North,Swindon,Swindon,E05008969,E14001536,E06000030,E06000030
+2024,2024,Mendip,North East Somerset and Hanham,Bath and North East Somerset,Bath and North East Somerset,E05012474,E14001394,E06000022,E06000022
+2024,2024,Shaw,Swindon South,Swindon,Swindon,E05008970,E14001537,E06000030,E06000030
+2024,2024,Midsomer Norton North,Frome and East Somerset,Bath and North East Somerset,Bath and North East Somerset,E05012475,E14001241,E06000022,E06000022
+2024,2024,Walcot and Park North,Swindon South,Swindon,Swindon,E05008971,E14001537,E06000030,E06000030
+2024,2024,Midsomer Norton Redfield,Frome and East Somerset,Bath and North East Somerset,Bath and North East Somerset,E05012476,E14001241,E06000022,E06000022
+2024,2024,Wroughton and Wichelstowe,East Wiltshire,Swindon,Swindon,E05008972,E14001217,E06000030,E06000030
+2024,2024,Moorlands,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012477,E14001080,E06000022,E06000022
+2024,2024,Blunsdon and Highworth,Swindon North,Swindon,Swindon,E05010755,E14001536,E06000030,E06000030
+2024,2024,Newbridge,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012478,E14001080,E06000022,E06000022
+2024,2024,Odd Down,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012479,E14001080,E06000022,E06000022
+2024,2024,Oldfield Park,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012480,E14001080,E06000022,E06000022
+2024,2024,Paulton,North East Somerset and Hanham,Bath and North East Somerset,Bath and North East Somerset,E05012481,E14001394,E06000022,E06000022
+2024,2024,Peasedown,Frome and East Somerset,Bath and North East Somerset,Bath and North East Somerset,E05012482,E14001241,E06000022,E06000022
+2024,2024,Publow & Whitchurch,North East Somerset and Hanham,Bath and North East Somerset,Bath and North East Somerset,E05012483,E14001394,E06000022,E06000022
+2024,2024,Radstock,Frome and East Somerset,Bath and North East Somerset,Bath and North East Somerset,E05012484,E14001241,E06000022,E06000022
+2024,2024,Saltford,North East Somerset and Hanham,Bath and North East Somerset,Bath and North East Somerset,E05012485,E14001394,E06000022,E06000022
+2024,2024,Southdown,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012486,E14001080,E06000022,E06000022
+2024,2024,Timsbury,North East Somerset and Hanham,Bath and North East Somerset,Bath and North East Somerset,E05012487,E14001394,E06000022,E06000022
+2024,2024,Twerton,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012488,E14001080,E06000022,E06000022
+2024,2024,Walcot,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012489,E14001080,E06000022,E06000022
+2024,2024,Westfield,Frome and East Somerset,Bath and North East Somerset,Bath and North East Somerset,E05012490,E14001241,E06000022,E06000022
+2024,2024,Westmoreland,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012491,E14001080,E06000022,E06000022
+2024,2024,Weston,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012492,E14001080,E06000022,E06000022
+2024,2024,Widcombe & Lyncombe,Bath,Bath and North East Somerset,Bath and North East Somerset,E05012493,E14001080,E06000022,E06000022
+2024,2024,Ashley,Bristol Central,"Bristol, City of","Bristol, City of",E05010885,E14001131,E06000023,E06000023
+2024,2024,Avonmouth and Lawrence Weston,Bristol North West,"Bristol, City of","Bristol, City of",E05010886,E14001134,E06000023,E06000023
+2024,2024,Bedminster,Bristol South,"Bristol, City of","Bristol, City of",E05010887,E14001135,E06000023,E06000023
+2024,2024,Bishopston and Ashley Down,Bristol North West,"Bristol, City of","Bristol, City of",E05010888,E14001134,E06000023,E06000023
+2024,2024,Bishopsworth,Bristol South,"Bristol, City of","Bristol, City of",E05010889,E14001135,E06000023,E06000023
+2024,2024,Brislington East,Bristol East,"Bristol, City of","Bristol, City of",E05010890,E14001132,E06000023,E06000023
+2024,2024,Brislington West,Bristol East,"Bristol, City of","Bristol, City of",E05010891,E14001132,E06000023,E06000023
+2024,2024,Central,Bristol Central,"Bristol, City of","Bristol, City of",E05010892,E14001131,E06000023,E06000023
+2024,2024,Clifton,Bristol Central,"Bristol, City of","Bristol, City of",E05010893,E14001131,E06000023,E06000023
+2024,2024,Clifton Down,Bristol Central,"Bristol, City of","Bristol, City of",E05010894,E14001131,E06000023,E06000023
+2024,2024,Cotham,Bristol Central,"Bristol, City of","Bristol, City of",E05010895,E14001131,E06000023,E06000023
+2024,2024,Easton,Bristol East,"Bristol, City of","Bristol, City of",E05010896,E14001132,E06000023,E06000023
+2024,2024,Eastville,Bristol North East,"Bristol, City of","Bristol, City of",E05010897,E14001133,E06000023,E06000023
+2024,2024,Filwood,Bristol South,"Bristol, City of","Bristol, City of",E05010898,E14001135,E06000023,E06000023
+2024,2024,Blenheim Park,Southend West and Leigh,Southend-on-Sea,Southend-on-Sea,E05002213,E14001502,E06000033,E06000033
+2024,2024,Haydon Wick,Swindon North,Swindon,Swindon,E05010756,E14001536,E06000030,E06000030
+2024,2024,Penhill and Upper Stratton,Swindon North,Swindon,Swindon,E05010757,E14001536,E06000030,E06000030
+2024,2024,Barnack,North West Cambridgeshire,Peterborough,Peterborough,E05010805,E14001401,E06000031,E06000031
+2024,2024,Bretton,Peterborough,Peterborough,Peterborough,E05010806,E14001425,E06000031,E06000031
+2024,2024,Central,Peterborough,Peterborough,Peterborough,E05010807,E14001425,E06000031,E06000031
+2024,2024,Dogsthorpe,Peterborough,Peterborough,Peterborough,E05010808,E14001425,E06000031,E06000031
+2024,2024,East,Peterborough,Peterborough,Peterborough,E05010809,E14001425,E06000031,E06000031
+2024,2024,"Eye, Thorney and Newborough",Peterborough,Peterborough,Peterborough,E05010810,E14001425,E06000031,E06000031
+2024,2024,Fletton and Stanground,North West Cambridgeshire,Peterborough,Peterborough,E05010811,E14001401,E06000031,E06000031
+2024,2024,Fletton and Woodston,North West Cambridgeshire,Peterborough,Peterborough,E05010812,E14001401,E06000031,E06000031
+2024,2024,Glinton and Castor,North West Cambridgeshire,Peterborough,Peterborough,E05010813,E14001401,E06000031,E06000031
+2024,2024,Gunthorpe,Peterborough,Peterborough,Peterborough,E05010814,E14001425,E06000031,E06000031
+2024,2024,Chalkwell,Southend West and Leigh,Southend-on-Sea,Southend-on-Sea,E05002214,E14001502,E06000033,E06000033
+2024,2024,Eastwood Park,Southend West and Leigh,Southend-on-Sea,Southend-on-Sea,E05002215,E14001502,E06000033,E06000033
+2024,2024,Kursaal,Southend East and Rochford,Southend-on-Sea,Southend-on-Sea,E05002216,E14001501,E06000033,E06000033
+2024,2024,Leigh,Southend West and Leigh,Southend-on-Sea,Southend-on-Sea,E05002217,E14001502,E06000033,E06000033
+2024,2024,Milton,Southend East and Rochford,Southend-on-Sea,Southend-on-Sea,E05002218,E14001501,E06000033,E06000033
+2024,2024,Prittlewell,Southend West and Leigh,Southend-on-Sea,Southend-on-Sea,E05002219,E14001502,E06000033,E06000033
+2024,2024,St Laurence,Southend West and Leigh,Southend-on-Sea,Southend-on-Sea,E05002220,E14001502,E06000033,E06000033
+2024,2024,St. Luke's,Southend West and Leigh,Southend-on-Sea,Southend-on-Sea,E05002221,E14001502,E06000033,E06000033
+2024,2024,Shoeburyness,Southend East and Rochford,Southend-on-Sea,Southend-on-Sea,E05002222,E14001501,E06000033,E06000033
+2024,2024,Southchurch,Southend East and Rochford,Southend-on-Sea,Southend-on-Sea,E05002223,E14001501,E06000033,E06000033
+2024,2024,Thorpe,Southend East and Rochford,Southend-on-Sea,Southend-on-Sea,E05002224,E14001501,E06000033,E06000033
+2024,2024,Frome Vale,Bristol North East,"Bristol, City of","Bristol, City of",E05010899,E14001133,E06000023,E06000023
+2024,2024,Victoria,Southend East and Rochford,Southend-on-Sea,Southend-on-Sea,E05002225,E14001501,E06000033,E06000033
+2024,2024,Westborough,Southend West and Leigh,Southend-on-Sea,Southend-on-Sea,E05002226,E14001502,E06000033,E06000033
+2024,2024,West Leigh,Southend West and Leigh,Southend-on-Sea,Southend-on-Sea,E05002227,E14001502,E06000033,E06000033
+2024,2024,West Shoebury,Southend East and Rochford,Southend-on-Sea,Southend-on-Sea,E05002228,E14001501,E06000033,E06000033
+2024,2024,Aveley and Uplands,Thurrock,Thurrock,Thurrock,E05002229,E14001546,E06000034,E06000034
+2024,2024,Belhus,Thurrock,Thurrock,Thurrock,E05002230,E14001546,E06000034,E06000034
+2024,2024,Chadwell St Mary,South Basildon and East Thurrock,Thurrock,Thurrock,E05002231,E14001480,E06000034,E06000034
+2024,2024,Chafford and North Stifford,Thurrock,Thurrock,Thurrock,E05002232,E14001546,E06000034,E06000034
+2024,2024,Corringham and Fobbing,South Basildon and East Thurrock,Thurrock,Thurrock,E05002233,E14001480,E06000034,E06000034
+2024,2024,East Tilbury,South Basildon and East Thurrock,Thurrock,Thurrock,E05002234,E14001480,E06000034,E06000034
+2024,2024,Grays Riverside,Thurrock,Thurrock,Thurrock,E05002235,E14001546,E06000034,E06000034
+2024,2024,Grays Thurrock,Thurrock,Thurrock,Thurrock,E05002236,E14001546,E06000034,E06000034
+2024,2024,Little Thurrock Blackshots,Thurrock,Thurrock,Thurrock,E05002237,E14001546,E06000034,E06000034
+2024,2024,Little Thurrock Rectory,Thurrock,Thurrock,Thurrock,E05002238,E14001546,E06000034,E06000034
+2024,2024,Ockendon,Thurrock,Thurrock,Thurrock,E05002239,E14001546,E06000034,E06000034
+2024,2024,Orsett,South Basildon and East Thurrock,Thurrock,Thurrock,E05002240,E14001480,E06000034,E06000034
+2024,2024,South Chafford,Thurrock,Thurrock,Thurrock,E05002241,E14001546,E06000034,E06000034
+2024,2024,Stanford East and Corringham Town,South Basildon and East Thurrock,Thurrock,Thurrock,E05002242,E14001480,E06000034,E06000034
+2024,2024,Stanford-le-Hope West,South Basildon and East Thurrock,Thurrock,Thurrock,E05002243,E14001480,E06000034,E06000034
+2024,2024,Stifford Clays,Thurrock,Thurrock,Thurrock,E05002244,E14001546,E06000034,E06000034
+2024,2024,The Homesteads,South Basildon and East Thurrock,Thurrock,Thurrock,E05002245,E14001480,E06000034,E06000034
+2024,2024,Tilbury Riverside and Thurrock Park,Thurrock,Thurrock,Thurrock,E05002246,E14001546,E06000034,E06000034
+2024,2024,Tilbury St Chads,Thurrock,Thurrock,Thurrock,E05002247,E14001546,E06000034,E06000034
+2024,2024,West Thurrock and South Stifford,Thurrock,Thurrock,Thurrock,E05002248,E14001546,E06000034,E06000034
+2024,2024,All Saints,Rochester and Strood,Medway,Medway,E05014449,E14001447,E06000035,E06000035
+2024,2024,Chatham Central & Brompton,Chatham and Aylesford,Medway,Medway,E05014450,E14001157,E06000035,E06000035
+2024,2024,Chatham Central & Brompton,Gillingham and Rainham,Medway,Medway,E05014450,E14001246,E06000035,E06000035
+2024,2024,Chatham Central & Brompton,Rochester and Strood,Medway,Medway,E05014450,E14001447,E06000035,E06000035
+2024,2024,"Cuxton, Halling & Riverside",Rochester and Strood,Medway,Medway,E05014451,E14001447,E06000035,E06000035
+2024,2024,Fort Horsted,Chatham and Aylesford,Medway,Medway,E05014452,E14001157,E06000035,E06000035
+2024,2024,Fort Pitt,Chatham and Aylesford,Medway,Medway,E05014453,E14001157,E06000035,E06000035
+2024,2024,Fort Pitt,Rochester and Strood,Medway,Medway,E05014453,E14001447,E06000035,E06000035
+2024,2024,Gillingham North,Gillingham and Rainham,Medway,Medway,E05014454,E14001246,E06000035,E06000035
+2024,2024,Gillingham North,Rochester and Strood,Medway,Medway,E05014454,E14001447,E06000035,E06000035
+2024,2024,Gillingham South,Gillingham and Rainham,Medway,Medway,E05014455,E14001246,E06000035,E06000035
+2024,2024,Hempstead & Wigmore,Chatham and Aylesford,Medway,Medway,E05014456,E14001157,E06000035,E06000035
+2024,2024,Hempstead & Wigmore,Gillingham and Rainham,Medway,Medway,E05014456,E14001246,E06000035,E06000035
+2024,2024,Hoo St Werburgh & High Halstow,Rochester and Strood,Medway,Medway,E05014457,E14001447,E06000035,E06000035
+2024,2024,Lordswood & Walderslade,Chatham and Aylesford,Medway,Medway,E05014458,E14001157,E06000035,E06000035
+2024,2024,Luton,Chatham and Aylesford,Medway,Medway,E05014459,E14001157,E06000035,E06000035
+2024,2024,Princes Park,Chatham and Aylesford,Medway,Medway,E05014460,E14001157,E06000035,E06000035
+2024,2024,Rainham North,Gillingham and Rainham,Medway,Medway,E05014461,E14001246,E06000035,E06000035
+2024,2024,Rainham South East,Gillingham and Rainham,Medway,Medway,E05014462,E14001246,E06000035,E06000035
+2024,2024,Rainham South West,Gillingham and Rainham,Medway,Medway,E05014463,E14001246,E06000035,E06000035
+2024,2024,Rochester East & Warren Wood,Chatham and Aylesford,Medway,Medway,E05014464,E14001157,E06000035,E06000035
+2024,2024,Rochester East & Warren Wood,Rochester and Strood,Medway,Medway,E05014464,E14001447,E06000035,E06000035
+2024,2024,Rochester West & Borstal,Rochester and Strood,Medway,Medway,E05014465,E14001447,E06000035,E06000035
+2024,2024,St Mary's Island,Rochester and Strood,Medway,Medway,E05014466,E14001447,E06000035,E06000035
+2024,2024,Strood North & Frindsbury,Rochester and Strood,Medway,Medway,E05014467,E14001447,E06000035,E06000035
+2024,2024,Strood Rural,Rochester and Strood,Medway,Medway,E05014468,E14001447,E06000035,E06000035
+2024,2024,Hartcliffe and Withywood,Bristol South,"Bristol, City of","Bristol, City of",E05010900,E14001135,E06000023,E06000023
+2024,2024,Henbury and Brentry,Bristol North West,"Bristol, City of","Bristol, City of",E05010901,E14001134,E06000023,E06000023
+2024,2024,Hengrove and Whitchurch Park,Bristol South,"Bristol, City of","Bristol, City of",E05010902,E14001135,E06000023,E06000023
+2024,2024,Hillfields,Bristol North East,"Bristol, City of","Bristol, City of",E05010903,E14001133,E06000023,E06000023
+2024,2024,Horfield,Bristol North West,"Bristol, City of","Bristol, City of",E05010904,E14001134,E06000023,E06000023
+2024,2024,Hotwells and Harbourside,Bristol Central,"Bristol, City of","Bristol, City of",E05010905,E14001131,E06000023,E06000023
+2024,2024,Knowle,Bristol East,"Bristol, City of","Bristol, City of",E05010906,E14001132,E06000023,E06000023
+2024,2024,Lawrence Hill,Bristol East,"Bristol, City of","Bristol, City of",E05010907,E14001132,E06000023,E06000023
+2024,2024,Lockleaze,Bristol North East,"Bristol, City of","Bristol, City of",E05010908,E14001133,E06000023,E06000023
+2024,2024,Redland,Bristol Central,"Bristol, City of","Bristol, City of",E05010909,E14001131,E06000023,E06000023
+2024,2024,St George Central,Bristol East,"Bristol, City of","Bristol, City of",E05010910,E14001132,E06000023,E06000023
+2024,2024,St George Troopers Hill,Bristol East,"Bristol, City of","Bristol, City of",E05010911,E14001132,E06000023,E06000023
+2024,2024,St George West,Bristol East,"Bristol, City of","Bristol, City of",E05010912,E14001132,E06000023,E06000023
+2024,2024,Southmead,Bristol North West,"Bristol, City of","Bristol, City of",E05010913,E14001134,E06000023,E06000023
+2024,2024,Southville,Bristol South,"Bristol, City of","Bristol, City of",E05010914,E14001135,E06000023,E06000023
+2024,2024,Stockwood,Bristol East,"Bristol, City of","Bristol, City of",E05010915,E14001132,E06000023,E06000023
+2024,2024,Stoke Bishop,Bristol North West,"Bristol, City of","Bristol, City of",E05010916,E14001134,E06000023,E06000023
+2024,2024,Westbury-on-Trym and Henleaze,Bristol North West,"Bristol, City of","Bristol, City of",E05010917,E14001134,E06000023,E06000023
+2024,2024,Windmill Hill,Bristol South,"Bristol, City of","Bristol, City of",E05010918,E14001135,E06000023,E06000023
+2024,2024,Backwell,North Somerset,North Somerset,North Somerset,E05010276,E14001399,E06000024,E06000024
+2024,2024,Banwell & Winscombe,Wells and Mendip Hills,North Somerset,North Somerset,E05010277,E14001572,E06000024,E06000024
+2024,2024,Blagdon & Churchill,Wells and Mendip Hills,North Somerset,North Somerset,E05010278,E14001572,E06000024,E06000024
+2024,2024,Clevedon East,North Somerset,North Somerset,North Somerset,E05010279,E14001399,E06000024,E06000024
+2024,2024,Clevedon South,North Somerset,North Somerset,North Somerset,E05010280,E14001399,E06000024,E06000024
+2024,2024,Clevedon Walton,North Somerset,North Somerset,North Somerset,E05010281,E14001399,E06000024,E06000024
+2024,2024,Clevedon West,North Somerset,North Somerset,North Somerset,E05010282,E14001399,E06000024,E06000024
+2024,2024,Clevedon Yeo,North Somerset,North Somerset,North Somerset,E05010283,E14001399,E06000024,E06000024
+2024,2024,Congresbury & Puxton,Wells and Mendip Hills,North Somerset,North Somerset,E05010284,E14001572,E06000024,E06000024
+2024,2024,Gordano Valley,North Somerset,North Somerset,North Somerset,E05010285,E14001399,E06000024,E06000024
+2024,2024,Hutton & Locking,Weston-super-Mare,North Somerset,North Somerset,E05010286,E14001581,E06000024,E06000024
+2024,2024,Long Ashton,North Somerset,North Somerset,North Somerset,E05010287,E14001399,E06000024,E06000024
+2024,2024,Nailsea Golden Valley,North Somerset,North Somerset,North Somerset,E05010288,E14001399,E06000024,E06000024
+2024,2024,Nailsea West End,North Somerset,North Somerset,North Somerset,E05010289,E14001399,E06000024,E06000024
+2024,2024,Nailsea Yeo,North Somerset,North Somerset,North Somerset,E05010290,E14001399,E06000024,E06000024
+2024,2024,Nailsea Youngwood,North Somerset,North Somerset,North Somerset,E05010291,E14001399,E06000024,E06000024
+2024,2024,Pill,North Somerset,North Somerset,North Somerset,E05010292,E14001399,E06000024,E06000024
+2024,2024,Portishead East,North Somerset,North Somerset,North Somerset,E05010293,E14001399,E06000024,E06000024
+2024,2024,Portishead North,North Somerset,North Somerset,North Somerset,E05010294,E14001399,E06000024,E06000024
+2024,2024,Portishead South,North Somerset,North Somerset,North Somerset,E05010295,E14001399,E06000024,E06000024
+2024,2024,Portishead West,North Somerset,North Somerset,North Somerset,E05010296,E14001399,E06000024,E06000024
+2024,2024,Weston-super-Mare South,Weston-super-Mare,North Somerset,North Somerset,E05010297,E14001581,E06000024,E06000024
+2024,2024,Weston-super-Mare Central,Weston-super-Mare,North Somerset,North Somerset,E05010298,E14001581,E06000024,E06000024
+2024,2024,Weston-super-Mare Hillside,Weston-super-Mare,North Somerset,North Somerset,E05010299,E14001581,E06000024,E06000024
+2024,2024,Weston-super-Mare Kewstoke,Weston-super-Mare,North Somerset,North Somerset,E05010300,E14001581,E06000024,E06000024
+2024,2024,Weston-super-Mare Mid Worle,Weston-super-Mare,North Somerset,North Somerset,E05010301,E14001581,E06000024,E06000024
+2024,2024,Weston-super-Mare Milton,Weston-super-Mare,North Somerset,North Somerset,E05010302,E14001581,E06000024,E06000024
+2024,2024,Weston-super-Mare North Worle,Weston-super-Mare,North Somerset,North Somerset,E05010303,E14001581,E06000024,E06000024
+2024,2024,Weston-super-Mare South Worle,Weston-super-Mare,North Somerset,North Somerset,E05010304,E14001581,E06000024,E06000024
+2024,2024,Weston-super-Mare Uphill,Weston-super-Mare,North Somerset,North Somerset,E05010305,E14001581,E06000024,E06000024
+2024,2024,Weston-super-Mare Winterstoke,Weston-super-Mare,North Somerset,North Somerset,E05010306,E14001581,E06000024,E06000024
+2024,2024,"Datchet, Horton & Wraysbury",Windsor,Windsor and Maidenhead,Windsor and Maidenhead,E05012503,E14001588,E06000040,E06000040
+2024,2024,Eton & Castle,Windsor,Windsor and Maidenhead,Windsor and Maidenhead,E05012504,E14001588,E06000040,E06000040
+2024,2024,Furze Platt,Maidenhead,Windsor and Maidenhead,Windsor and Maidenhead,E05012505,E14001348,E06000040,E06000040
+2024,2024,Hurley & Walthams,Maidenhead,Windsor and Maidenhead,Windsor and Maidenhead,E05012506,E14001348,E06000040,E06000040
+2024,2024,Old Windsor,Windsor,Windsor and Maidenhead,Windsor and Maidenhead,E05012507,E14001588,E06000040,E06000040
+2024,2024,Oldfield,Maidenhead,Windsor and Maidenhead,Windsor and Maidenhead,E05012508,E14001348,E06000040,E06000040
+2024,2024,Pinkneys Green,Maidenhead,Windsor and Maidenhead,Windsor and Maidenhead,E05012509,E14001348,E06000040,E06000040
+2024,2024,Riverside,Maidenhead,Windsor and Maidenhead,Windsor and Maidenhead,E05012510,E14001348,E06000040,E06000040
+2024,2024,St Mary's,Maidenhead,Windsor and Maidenhead,Windsor and Maidenhead,E05012511,E14001348,E06000040,E06000040
+2024,2024,Sunningdale & Cheapside,Windsor,Windsor and Maidenhead,Windsor and Maidenhead,E05012512,E14001588,E06000040,E06000040
+2024,2024,Barkham & Arborfield,Wokingham,Wokingham,Wokingham,E05015783,E14001593,E06000041,E06000041
+2024,2024,Bulmershe & Coronation,Earley and Woodley,Wokingham,Wokingham,E05015784,E14001210,E06000041,E06000041
+2024,2024,Emmbrook,Wokingham,Wokingham,Wokingham,E05015785,E14001593,E06000041,E06000041
+2024,2024,Evendons,Wokingham,Wokingham,Wokingham,E05015786,E14001593,E06000041,E06000041
+2024,2024,Finchampstead,Wokingham,Wokingham,Wokingham,E05015787,E14001593,E06000041,E06000041
+2024,2024,Hawkedon,Earley and Woodley,Wokingham,Wokingham,E05015788,E14001210,E06000041,E06000041
+2024,2024,Hillside,Earley and Woodley,Wokingham,Wokingham,E05015789,E14001210,E06000041,E06000041
+2024,2024,Loddon,Earley and Woodley,Wokingham,Wokingham,E05015790,E14001210,E06000041,E06000041
+2024,2024,Maiden Erlegh & Whitegates,Earley and Woodley,Wokingham,Wokingham,E05015791,E14001210,E06000041,E06000041
+2024,2024,Norreys,Wokingham,Wokingham,Wokingham,E05015792,E14001593,E06000041,E06000041
+2024,2024,Shinfield,Earley and Woodley,Wokingham,Wokingham,E05015793,E14001210,E06000041,E06000041
+2024,2024,South Lake,Earley and Woodley,Wokingham,Wokingham,E05015794,E14001210,E06000041,E06000041
+2024,2024,Spencers Wood & Swallowfield,Earley and Woodley,Wokingham,Wokingham,E05015795,E14001210,E06000041,E06000041
+2024,2024,Spencers Wood & Swallowfield,Wokingham,Wokingham,Wokingham,E05015795,E14001593,E06000041,E06000041
+2024,2024,Thames,Earley and Woodley,Wokingham,Wokingham,E05015796,E14001210,E06000041,E06000041
+2024,2024,Thames,Wokingham,Wokingham,Wokingham,E05015796,E14001593,E06000041,E06000041
+2024,2024,"Twyford, Ruscombe & Hurst",Wokingham,Wokingham,Wokingham,E05015797,E14001593,E06000041,E06000041
+2024,2024,Wescott,Wokingham,Wokingham,Wokingham,E05015798,E14001593,E06000041,E06000041
+2024,2024,Winnersh,Wokingham,Wokingham,Wokingham,E05015799,E14001593,E06000041,E06000041
+2024,2024,Wokingham Without,Wokingham,Wokingham,Wokingham,E05015800,E14001593,E06000041,E06000041
+2024,2024,Bletchley East,Buckingham and Bletchley,Milton Keynes,Milton Keynes,E05009406,E14001141,E06000042,E06000042
+2024,2024,Bletchley Park,Buckingham and Bletchley,Milton Keynes,Milton Keynes,E05009407,E14001141,E06000042,E06000042
+2024,2024,Bletchley West,Buckingham and Bletchley,Milton Keynes,Milton Keynes,E05009408,E14001141,E06000042,E06000042
+2024,2024,Bradwell,Milton Keynes North,Milton Keynes,Milton Keynes,E05009409,E14001370,E06000042,E06000042
+2024,2024,Broughton,Milton Keynes Central,Milton Keynes,Milton Keynes,E05009410,E14001369,E06000042,E06000042
+2024,2024,Campbell Park & Old Woughton,Milton Keynes Central,Milton Keynes,Milton Keynes,E05009411,E14001369,E06000042,E06000042
+2024,2024,Central Milton Keynes,Milton Keynes Central,Milton Keynes,Milton Keynes,E05009412,E14001369,E06000042,E06000042
+2024,2024,Danesborough & Walton,Milton Keynes Central,Milton Keynes,Milton Keynes,E05009413,E14001369,E06000042,E06000042
+2024,2024,Loughton & Shenley,Milton Keynes Central,Milton Keynes,Milton Keynes,E05009414,E14001369,E06000042,E06000042
+2024,2024,Monkston,Milton Keynes Central,Milton Keynes,Milton Keynes,E05009415,E14001369,E06000042,E06000042
+2024,2024,Newport Pagnell North & Hanslope,Milton Keynes North,Milton Keynes,Milton Keynes,E05009416,E14001370,E06000042,E06000042
+2024,2024,Newport Pagnell South,Milton Keynes North,Milton Keynes,Milton Keynes,E05009417,E14001370,E06000042,E06000042
+2024,2024,Olney,Milton Keynes North,Milton Keynes,Milton Keynes,E05009418,E14001370,E06000042,E06000042
+2024,2024,Shenley Brook End,Milton Keynes Central,Milton Keynes,Milton Keynes,E05009419,E14001369,E06000042,E06000042
+2024,2024,Stantonbury,Milton Keynes North,Milton Keynes,Milton Keynes,E05009420,E14001370,E06000042,E06000042
+2024,2024,Stony Stratford,Milton Keynes North,Milton Keynes,Milton Keynes,E05009421,E14001370,E06000042,E06000042
+2024,2024,Tattenhoe,Buckingham and Bletchley,Milton Keynes,Milton Keynes,E05009422,E14001141,E06000042,E06000042
+2024,2024,Wolverton,Milton Keynes North,Milton Keynes,Milton Keynes,E05009423,E14001370,E06000042,E06000042
+2024,2024,Woughton & Fishermead,Milton Keynes Central,Milton Keynes,Milton Keynes,E05009424,E14001369,E06000042,E06000042
+2024,2024,Brunswick & Adelaide,Hove and Portslade,Brighton and Hove,Brighton and Hove,E05015398,E14001296,E06000043,E06000043
+2024,2024,Sherburn,City of Durham,County Durham,County Durham,E05009079,E14001173,E06000047,E06000047
+2024,2024,Shildon and Dene Valley,Bishop Auckland,County Durham,County Durham,E05009080,E14001101,E06000047,E06000047
+2024,2024,Shotton and South Hetton,Easington,County Durham,County Durham,E05009081,E14001211,E06000047,E06000047
+2024,2024,Spennymoor,Newton Aycliffe and Spennymoor,County Durham,County Durham,E05009082,E14001382,E06000047,E06000047
+2024,2024,Stanley,North Durham,County Durham,County Durham,E05009083,E14001389,E06000047,E06000047
+2024,2024,Tanfield,North Durham,County Durham,County Durham,E05009084,E14001389,E06000047,E06000047
+2024,2024,Tow Law,Bishop Auckland,County Durham,County Durham,E05009085,E14001101,E06000047,E06000047
+2024,2024,Trimdon and Thornley,Easington,County Durham,County Durham,E05009086,E14001211,E06000047,E06000047
+2024,2024,Trimdon and Thornley,Newton Aycliffe and Spennymoor,County Durham,County Durham,E05009086,E14001382,E06000047,E06000047
+2024,2024,Tudhoe,Newton Aycliffe and Spennymoor,County Durham,County Durham,E05009087,E14001382,E06000047,E06000047
+2024,2024,Weardale,Bishop Auckland,County Durham,County Durham,E05009088,E14001101,E06000047,E06000047
+2024,2024,West Auckland,Bishop Auckland,County Durham,County Durham,E05009089,E14001101,E06000047,E06000047
+2024,2024,Willington and Hunwick,City of Durham,County Durham,County Durham,E05009090,E14001173,E06000047,E06000047
+2024,2024,Wingate,Easington,County Durham,County Durham,E05009091,E14001211,E06000047,E06000047
+2024,2024,Woodhouse Close,Bishop Auckland,County Durham,County Durham,E05009092,E14001101,E06000047,E06000047
+2024,2024,Alderley Edge,Tatton,Cheshire East,Cheshire East,E05008610,E14001539,E06000049,E06000049
+2024,2024,Alsager,Congleton,Cheshire East,Cheshire East,E05008611,E14001178,E06000049,E06000049
+2024,2024,Audlem,Chester South and Eddisbury,Cheshire East,Cheshire East,E05008612,E14001164,E06000049,E06000049
+2024,2024,Bollington,Macclesfield,Cheshire East,Cheshire East,E05008613,E14001347,E06000049,E06000049
+2024,2024,Brereton Rural,Congleton,Cheshire East,Cheshire East,E05008614,E14001178,E06000049,E06000049
+2024,2024,Broken Cross and Upton,Macclesfield,Cheshire East,Cheshire East,E05008615,E14001347,E06000049,E06000049
+2024,2024,Bunbury,Chester South and Eddisbury,Cheshire East,Cheshire East,E05008616,E14001164,E06000049,E06000049
+2024,2024,Chelford,Tatton,Cheshire East,Cheshire East,E05008617,E14001539,E06000049,E06000049
+2024,2024,Congleton East,Congleton,Cheshire East,Cheshire East,E05008618,E14001178,E06000049,E06000049
+2024,2024,Congleton West,Congleton,Cheshire East,Cheshire East,E05008619,E14001178,E06000049,E06000049
+2024,2024,Crewe Central,Crewe and Nantwich,Cheshire East,Cheshire East,E05008620,E14001185,E06000049,E06000049
+2024,2024,Crewe East,Crewe and Nantwich,Cheshire East,Cheshire East,E05008621,E14001185,E06000049,E06000049
+2024,2024,Crewe North,Crewe and Nantwich,Cheshire East,Cheshire East,E05008622,E14001185,E06000049,E06000049
+2024,2024,Crewe St Barnabas,Crewe and Nantwich,Cheshire East,Cheshire East,E05008623,E14001185,E06000049,E06000049
+2024,2024,Crewe South,Crewe and Nantwich,Cheshire East,Cheshire East,E05008624,E14001185,E06000049,E06000049
+2024,2024,Crewe West,Crewe and Nantwich,Cheshire East,Cheshire East,E05008625,E14001185,E06000049,E06000049
+2024,2024,Dane Valley,Congleton,Cheshire East,Cheshire East,E05008626,E14001178,E06000049,E06000049
+2024,2024,Disley,Macclesfield,Cheshire East,Cheshire East,E05008627,E14001347,E06000049,E06000049
+2024,2024,Gawsworth,Macclesfield,Cheshire East,Cheshire East,E05008628,E14001347,E06000049,E06000049
+2024,2024,Handforth,Tatton,Cheshire East,Cheshire East,E05008629,E14001539,E06000049,E06000049
+2024,2024,Haslington,Crewe and Nantwich,Cheshire East,Cheshire East,E05008630,E14001185,E06000049,E06000049
+2024,2024,High Legh,Tatton,Cheshire East,Cheshire East,E05008631,E14001539,E06000049,E06000049
+2024,2024,Knutsford,Tatton,Cheshire East,Cheshire East,E05008632,E14001539,E06000049,E06000049
+2024,2024,Leighton,Crewe and Nantwich,Cheshire East,Cheshire East,E05008633,E14001185,E06000049,E06000049
+2024,2024,Macclesfield Central,Macclesfield,Cheshire East,Cheshire East,E05008634,E14001347,E06000049,E06000049
+2024,2024,Macclesfield East,Macclesfield,Cheshire East,Cheshire East,E05008635,E14001347,E06000049,E06000049
+2024,2024,Macclesfield Hurdsfield,Macclesfield,Cheshire East,Cheshire East,E05008636,E14001347,E06000049,E06000049
+2024,2024,Macclesfield South,Macclesfield,Cheshire East,Cheshire East,E05008637,E14001347,E06000049,E06000049
+2024,2024,Macclesfield Tytherington,Macclesfield,Cheshire East,Cheshire East,E05008638,E14001347,E06000049,E06000049
+2024,2024,Macclesfield West and Ivy,Macclesfield,Cheshire East,Cheshire East,E05008639,E14001347,E06000049,E06000049
+2024,2024,Middlewich,Mid Cheshire,Cheshire East,Cheshire East,E05008640,E14001361,E06000049,E06000049
+2024,2024,Strood West,Rochester and Strood,Medway,Medway,E05014469,E14001447,E06000035,E06000035
+2024,2024,Mobberley,Tatton,Cheshire East,Cheshire East,E05008641,E14001539,E06000049,E06000049
+2024,2024,Nantwich North and West,Crewe and Nantwich,Cheshire East,Cheshire East,E05008642,E14001185,E06000049,E06000049
+2024,2024,Nantwich South and Stapeley,Crewe and Nantwich,Cheshire East,Cheshire East,E05008643,E14001185,E06000049,E06000049
+2024,2024,Odd Rode,Congleton,Cheshire East,Cheshire East,E05008644,E14001178,E06000049,E06000049
+2024,2024,Harefield,Southampton Itchen,Southampton,Southampton,E05015497,E14001499,E06000045,E06000045
+2024,2024,Battle,Reading West and Mid Berkshire,Reading,Reading,E05013865,E14001439,E06000038,E06000038
+2024,2024,Central Hove,Hove and Portslade,Brighton and Hove,Brighton and Hove,E05015399,E14001296,E06000043,E06000043
+2024,2024,Coldean & Stanmer,Brighton Kemptown and Peacehaven,Brighton and Hove,Brighton and Hove,E05015400,E14001129,E06000043,E06000043
+2024,2024,Coldean & Stanmer,Brighton Pavilion,Brighton and Hove,Brighton and Hove,E05015400,E14001130,E06000043,E06000043
+2024,2024,Goldsmid,Hove and Portslade,Brighton and Hove,Brighton and Hove,E05015401,E14001296,E06000043,E06000043
+2024,2024,Hangleton & Knoll,Hove and Portslade,Brighton and Hove,Brighton and Hove,E05015402,E14001296,E06000043,E06000043
+2024,2024,Hanover & Elm Grove,Brighton Kemptown and Peacehaven,Brighton and Hove,Brighton and Hove,E05015403,E14001129,E06000043,E06000043
+2024,2024,Hanover & Elm Grove,Brighton Pavilion,Brighton and Hove,Brighton and Hove,E05015403,E14001130,E06000043,E06000043
+2024,2024,Hollingdean & Fiveways,Brighton Pavilion,Brighton and Hove,Brighton and Hove,E05015404,E14001130,E06000043,E06000043
+2024,2024,Kemptown,Brighton Kemptown and Peacehaven,Brighton and Hove,Brighton and Hove,E05015405,E14001129,E06000043,E06000043
+2024,2024,Moulsecoomb & Bevendean,Brighton Kemptown and Peacehaven,Brighton and Hove,Brighton and Hove,E05015406,E14001129,E06000043,E06000043
+2024,2024,Moulsecoomb & Bevendean,Brighton Pavilion,Brighton and Hove,Brighton and Hove,E05015406,E14001130,E06000043,E06000043
+2024,2024,North Portslade,Hove and Portslade,Brighton and Hove,Brighton and Hove,E05015407,E14001296,E06000043,E06000043
+2024,2024,Patcham & Hollingbury,Brighton Pavilion,Brighton and Hove,Brighton and Hove,E05015408,E14001130,E06000043,E06000043
+2024,2024,Preston Park,Brighton Pavilion,Brighton and Hove,Brighton and Hove,E05015409,E14001130,E06000043,E06000043
+2024,2024,Queen's Park,Brighton Kemptown and Peacehaven,Brighton and Hove,Brighton and Hove,E05015410,E14001129,E06000043,E06000043
+2024,2024,Regency,Brighton Pavilion,Brighton and Hove,Brighton and Hove,E05015411,E14001130,E06000043,E06000043
+2024,2024,Rottingdean & West Saltdean,Brighton Kemptown and Peacehaven,Brighton and Hove,Brighton and Hove,E05015412,E14001129,E06000043,E06000043
+2024,2024,Round Hill,Brighton Pavilion,Brighton and Hove,Brighton and Hove,E05015413,E14001130,E06000043,E06000043
+2024,2024,South Portslade,Hove and Portslade,Brighton and Hove,Brighton and Hove,E05015414,E14001296,E06000043,E06000043
+2024,2024,West Hill & North Laine,Brighton Pavilion,Brighton and Hove,Brighton and Hove,E05015415,E14001130,E06000043,E06000043
+2024,2024,Westbourne & Poets' Corner,Hove and Portslade,Brighton and Hove,Brighton and Hove,E05015416,E14001296,E06000043,E06000043
+2024,2024,Westdene & Hove Park,Brighton Pavilion,Brighton and Hove,Brighton and Hove,E05015417,E14001130,E06000043,E06000043
+2024,2024,Westdene & Hove Park,Hove and Portslade,Brighton and Hove,Brighton and Hove,E05015417,E14001296,E06000043,E06000043
+2024,2024,Whitehawk & Marina,Brighton Kemptown and Peacehaven,Brighton and Hove,Brighton and Hove,E05015418,E14001129,E06000043,E06000043
+2024,2024,Wish,Hove and Portslade,Brighton and Hove,Brighton and Hove,E05015419,E14001296,E06000043,E06000043
+2024,2024,Woodingdean,Brighton Kemptown and Peacehaven,Brighton and Hove,Brighton and Hove,E05015420,E14001129,E06000043,E06000043
+2024,2024,Baffins,Portsmouth North,Portsmouth,Portsmouth,E05002441,E14001431,E06000044,E06000044
+2024,2024,Central Southsea,Portsmouth South,Portsmouth,Portsmouth,E05002442,E14001432,E06000044,E06000044
+2024,2024,Charles Dickens,Portsmouth South,Portsmouth,Portsmouth,E05002443,E14001432,E06000044,E06000044
+2024,2024,Copnor,Portsmouth North,Portsmouth,Portsmouth,E05002444,E14001431,E06000044,E06000044
+2024,2024,Cosham,Portsmouth North,Portsmouth,Portsmouth,E05002445,E14001431,E06000044,E06000044
+2024,2024,Drayton and Farlington,Portsmouth North,Portsmouth,Portsmouth,E05002446,E14001431,E06000044,E06000044
+2024,2024,Eastney and Craneswater,Portsmouth South,Portsmouth,Portsmouth,E05002447,E14001432,E06000044,E06000044
+2024,2024,Fratton,Portsmouth South,Portsmouth,Portsmouth,E05002448,E14001432,E06000044,E06000044
+2024,2024,Hilsea,Portsmouth North,Portsmouth,Portsmouth,E05002449,E14001431,E06000044,E06000044
+2024,2024,Milton,Portsmouth South,Portsmouth,Portsmouth,E05002450,E14001432,E06000044,E06000044
+2024,2024,Nelson,Portsmouth North,Portsmouth,Portsmouth,E05002451,E14001431,E06000044,E06000044
+2024,2024,Paulsgrove,Portsmouth North,Portsmouth,Portsmouth,E05002452,E14001431,E06000044,E06000044
+2024,2024,St Jude,Portsmouth South,Portsmouth,Portsmouth,E05002453,E14001432,E06000044,E06000044
+2024,2024,St Thomas,Portsmouth South,Portsmouth,Portsmouth,E05002454,E14001432,E06000044,E06000044
+2024,2024,Banister & Polygon,Southampton Itchen,Southampton,Southampton,E05015490,E14001499,E06000045,E06000045
+2024,2024,Banister & Polygon,Southampton Test,Southampton,Southampton,E05015490,E14001500,E06000045,E06000045
+2024,2024,Bargate,Southampton Itchen,Southampton,Southampton,E05015491,E14001499,E06000045,E06000045
+2024,2024,Bassett,Romsey and Southampton North,Southampton,Southampton,E05015492,E14001449,E06000045,E06000045
+2024,2024,Bassett,Southampton Test,Southampton,Southampton,E05015492,E14001500,E06000045,E06000045
+2024,2024,Bevois,Southampton Test,Southampton,Southampton,E05015493,E14001500,E06000045,E06000045
+2024,2024,Bitterne Park,Romsey and Southampton North,Southampton,Southampton,E05015494,E14001449,E06000045,E06000045
+2024,2024,Bitterne Park,Southampton Itchen,Southampton,Southampton,E05015494,E14001499,E06000045,E06000045
+2024,2024,Coxford,Southampton Test,Southampton,Southampton,E05015495,E14001500,E06000045,E06000045
+2024,2024,Freemantle,Southampton Test,Southampton,Southampton,E05015496,E14001500,E06000045,E06000045
+2024,2024,Poynton East and Pott Shrigley,Macclesfield,Cheshire East,Cheshire East,E05008645,E14001347,E06000049,E06000049
+2024,2024,Caversham,Reading Central,Reading,Reading,E05013866,E14001438,E06000038,E06000038
+2024,2024,Millbrook,Southampton Test,Southampton,Southampton,E05015498,E14001500,E06000045,E06000045
+2024,2024,Twydall,Gillingham and Rainham,Medway,Medway,E05014470,E14001246,E06000035,E06000035
+2024,2024,Watling,Gillingham and Rainham,Medway,Medway,E05014471,E14001246,E06000035,E06000035
+2024,2024,Wayfield & Weeds Wood,Chatham and Aylesford,Medway,Medway,E05014472,E14001157,E06000035,E06000035
+2024,2024,Binfield North & Warfield West,Bracknell,Bracknell Forest,Bracknell Forest,E05014755,E14001117,E06000036,E06000036
+2024,2024,Binfield North & Warfield West,Maidenhead,Bracknell Forest,Bracknell Forest,E05014755,E14001348,E06000036,E06000036
+2024,2024,Binfield South & Jennett's Park,Bracknell,Bracknell Forest,Bracknell Forest,E05014756,E14001117,E06000036,E06000036
+2024,2024,Binfield South & Jennett's Park,Maidenhead,Bracknell Forest,Bracknell Forest,E05014756,E14001348,E06000036,E06000036
+2024,2024,Bullbrook,Bracknell,Bracknell Forest,Bracknell Forest,E05014757,E14001117,E06000036,E06000036
+2024,2024,Easthampstead & Wildridings,Bracknell,Bracknell Forest,Bracknell Forest,E05014759,E14001117,E06000036,E06000036
+2024,2024,Great Hollands,Bracknell,Bracknell Forest,Bracknell Forest,E05014760,E14001117,E06000036,E06000036
+2024,2024,Hanworth,Bracknell,Bracknell Forest,Bracknell Forest,E05014761,E14001117,E06000036,E06000036
+2024,2024,Owlsmoor & College Town,Bracknell,Bracknell Forest,Bracknell Forest,E05014763,E14001117,E06000036,E06000036
+2024,2024,Priestwood & Garth,Bracknell,Bracknell Forest,Bracknell Forest,E05014764,E14001117,E06000036,E06000036
+2024,2024,Town Centre & The Parks,Bracknell,Bracknell Forest,Bracknell Forest,E05014767,E14001117,E06000036,E06000036
+2024,2024,Crowthorne,Bracknell,Bracknell Forest,Bracknell Forest,E05015571,E14001117,E06000036,E06000036
+2024,2024,Harmans Water & Crown Wood,Bracknell,Bracknell Forest,Bracknell Forest,E05015572,E14001117,E06000036,E06000036
+2024,2024,Sandhurst,Bracknell,Bracknell Forest,Bracknell Forest,E05015573,E14001117,E06000036,E06000036
+2024,2024,Swinley Forest,Bracknell,Bracknell Forest,Bracknell Forest,E05015574,E14001117,E06000036,E06000036
+2024,2024,Swinley Forest,Maidenhead,Bracknell Forest,Bracknell Forest,E05015574,E14001348,E06000036,E06000036
+2024,2024,Whitegrove,Bracknell,Bracknell Forest,Bracknell Forest,E05015575,E14001117,E06000036,E06000036
+2024,2024,Whitegrove,Maidenhead,Bracknell Forest,Bracknell Forest,E05015575,E14001348,E06000036,E06000036
+2024,2024,Winkfield & Warfield East,Maidenhead,Bracknell Forest,Bracknell Forest,E05015576,E14001348,E06000036,E06000036
+2024,2024,Aldermaston,Reading West and Mid Berkshire,West Berkshire,West Berkshire,E05012132,E14001439,E06000037,E06000037
+2024,2024,Basildon,Reading West and Mid Berkshire,West Berkshire,West Berkshire,E05012133,E14001439,E06000037,E06000037
+2024,2024,Bradfield,Reading West and Mid Berkshire,West Berkshire,West Berkshire,E05012134,E14001439,E06000037,E06000037
+2024,2024,Bucklebury,Reading West and Mid Berkshire,West Berkshire,West Berkshire,E05012135,E14001439,E06000037,E06000037
+2024,2024,Burghfield & Mortimer,Reading West and Mid Berkshire,West Berkshire,West Berkshire,E05012136,E14001439,E06000037,E06000037
+2024,2024,Chieveley & Cold Ash,Newbury,West Berkshire,West Berkshire,E05012137,E14001376,E06000037,E06000037
+2024,2024,Downlands,Newbury,West Berkshire,West Berkshire,E05012138,E14001376,E06000037,E06000037
+2024,2024,Downlands,Reading West and Mid Berkshire,West Berkshire,West Berkshire,E05012138,E14001439,E06000037,E06000037
+2024,2024,Hungerford & Kintbury,Newbury,West Berkshire,West Berkshire,E05012139,E14001376,E06000037,E06000037
+2024,2024,Lambourn,Newbury,West Berkshire,West Berkshire,E05012140,E14001376,E06000037,E06000037
+2024,2024,Newbury Central,Newbury,West Berkshire,West Berkshire,E05012141,E14001376,E06000037,E06000037
+2024,2024,Newbury Clay Hill,Newbury,West Berkshire,West Berkshire,E05012142,E14001376,E06000037,E06000037
+2024,2024,Newbury Greenham,Newbury,West Berkshire,West Berkshire,E05012143,E14001376,E06000037,E06000037
+2024,2024,Newbury Speen,Newbury,West Berkshire,West Berkshire,E05012144,E14001376,E06000037,E06000037
+2024,2024,Newbury Wash Common,Newbury,West Berkshire,West Berkshire,E05012145,E14001376,E06000037,E06000037
+2024,2024,Pangbourne,Reading West and Mid Berkshire,West Berkshire,West Berkshire,E05012146,E14001439,E06000037,E06000037
+2024,2024,Ridgeway,Reading West and Mid Berkshire,West Berkshire,West Berkshire,E05012147,E14001439,E06000037,E06000037
+2024,2024,Thatcham Central,Newbury,West Berkshire,West Berkshire,E05012148,E14001376,E06000037,E06000037
+2024,2024,Thatcham Colthrop & Crookham,Newbury,West Berkshire,West Berkshire,E05012149,E14001376,E06000037,E06000037
+2024,2024,Thatcham North East,Newbury,West Berkshire,West Berkshire,E05012150,E14001376,E06000037,E06000037
+2024,2024,Thatcham West,Newbury,West Berkshire,West Berkshire,E05012151,E14001376,E06000037,E06000037
+2024,2024,Theale,Reading West and Mid Berkshire,West Berkshire,West Berkshire,E05012152,E14001439,E06000037,E06000037
+2024,2024,Tilehurst & Purley,Reading West and Mid Berkshire,West Berkshire,West Berkshire,E05012153,E14001439,E06000037,E06000037
+2024,2024,Tilehurst Birch Copse,Reading West and Mid Berkshire,West Berkshire,West Berkshire,E05012154,E14001439,E06000037,E06000037
+2024,2024,Tilehurst South & Holybrook,Reading West and Mid Berkshire,West Berkshire,West Berkshire,E05012155,E14001439,E06000037,E06000037
+2024,2024,Abbey,Reading Central,Reading,Reading,E05013864,E14001438,E06000038,E06000038
+2024,2024,Battle,Reading Central,Reading,Reading,E05013865,E14001438,E06000038,E06000038
+2024,2024,Poynton West and Adlington,Macclesfield,Cheshire East,Cheshire East,E05008646,E14001347,E06000049,E06000049
+2024,2024,Caversham Heights,Reading Central,Reading,Reading,E05013867,E14001438,E06000038,E06000038
+2024,2024,Prestbury,Macclesfield,Cheshire East,Cheshire East,E05008647,E14001347,E06000049,E06000049
+2024,2024,Church,Earley and Woodley,Reading,Reading,E05013868,E14001210,E06000038,E06000038
+2024,2024,Sandbach Elworth,Congleton,Cheshire East,Cheshire East,E05008648,E14001178,E06000049,E06000049
+2024,2024,Coley,Reading Central,Reading,Reading,E05013869,E14001438,E06000038,E06000038
+2024,2024,Sandbach Ettiley Heath and Wheelock,Congleton,Cheshire East,Cheshire East,E05008649,E14001178,E06000049,E06000049
+2024,2024,Emmer Green,Reading Central,Reading,Reading,E05013870,E14001438,E06000038,E06000038
+2024,2024,Sandbach Heath and East,Congleton,Cheshire East,Cheshire East,E05008650,E14001178,E06000049,E06000049
+2024,2024,Katesgrove,Reading Central,Reading,Reading,E05013871,E14001438,E06000038,E06000038
+2024,2024,Peartree,Southampton Itchen,Southampton,Southampton,E05015499,E14001499,E06000045,E06000045
+2024,2024,Sandbach Town,Congleton,Cheshire East,Cheshire East,E05008651,E14001178,E06000049,E06000049
+2024,2024,Kentwood,Reading West and Mid Berkshire,Reading,Reading,E05013872,E14001439,E06000038,E06000038
+2024,2024,Shavington,Crewe and Nantwich,Cheshire East,Cheshire East,E05008652,E14001185,E06000049,E06000049
+2024,2024,Norcot,Reading Central,Reading,Reading,E05013873,E14001438,E06000038,E06000038
+2024,2024,Portswood,Romsey and Southampton North,Southampton,Southampton,E05015500,E14001449,E06000045,E06000045
+2024,2024,Sutton,Macclesfield,Cheshire East,Cheshire East,E05008653,E14001347,E06000049,E06000049
+2024,2024,Norcot,Reading West and Mid Berkshire,Reading,Reading,E05013873,E14001439,E06000038,E06000038
+2024,2024,Portswood,Southampton Test,Southampton,Southampton,E05015500,E14001500,E06000045,E06000045
+2024,2024,Willaston and Rope,Crewe and Nantwich,Cheshire East,Cheshire East,E05008654,E14001185,E06000049,E06000049
+2024,2024,Park,Reading Central,Reading,Reading,E05013874,E14001438,E06000038,E06000038
+2024,2024,Redbridge,Southampton Test,Southampton,Southampton,E05015501,E14001500,E06000045,E06000045
+2024,2024,Wilmslow Dean Row,Tatton,Cheshire East,Cheshire East,E05008655,E14001539,E06000049,E06000049
+2024,2024,Redlands,Earley and Woodley,Reading,Reading,E05013875,E14001210,E06000038,E06000038
+2024,2024,Shirley,Southampton Test,Southampton,Southampton,E05015502,E14001500,E06000045,E06000045
+2024,2024,Wilmslow East,Tatton,Cheshire East,Cheshire East,E05008656,E14001539,E06000049,E06000049
+2024,2024,Redlands,Reading Central,Reading,Reading,E05013875,E14001438,E06000038,E06000038
+2024,2024,Sholing,Southampton Itchen,Southampton,Southampton,E05015503,E14001499,E06000045,E06000045
+2024,2024,Wilmslow Lacey Green,Tatton,Cheshire East,Cheshire East,E05008657,E14001539,E06000049,E06000049
+2024,2024,Southcote,Reading Central,Reading,Reading,E05013876,E14001438,E06000038,E06000038
+2024,2024,Swaythling,Romsey and Southampton North,Southampton,Southampton,E05015504,E14001449,E06000045,E06000045
+2024,2024,Wilmslow West and Chorley,Tatton,Cheshire East,Cheshire East,E05008658,E14001539,E06000049,E06000049
+2024,2024,Southcote,Reading West and Mid Berkshire,Reading,Reading,E05013876,E14001439,E06000038,E06000038
+2024,2024,Swaythling,Southampton Test,Southampton,Southampton,E05015504,E14001500,E06000045,E06000045
+2024,2024,Wistaston,Crewe and Nantwich,Cheshire East,Cheshire East,E05008659,E14001185,E06000049,E06000049
+2024,2024,Thames,Reading Central,Reading,Reading,E05013877,E14001438,E06000038,E06000038
+2024,2024,Thornhill,Southampton Itchen,Southampton,Southampton,E05015505,E14001499,E06000045,E06000045
+2024,2024,Wrenbury,Chester South and Eddisbury,Cheshire East,Cheshire East,E05008660,E14001164,E06000049,E06000049
+2024,2024,Tilehurst,Reading West and Mid Berkshire,Reading,Reading,E05013878,E14001439,E06000038,E06000038
+2024,2024,Woolston,Southampton Itchen,Southampton,Southampton,E05015506,E14001499,E06000045,E06000045
+2024,2024,Wybunbury,Chester South and Eddisbury,Cheshire East,Cheshire East,E05008661,E14001164,E06000049,E06000049
+2024,2024,Whitley,Earley and Woodley,Reading,Reading,E05013879,E14001210,E06000038,E06000038
+2024,2024,Bembridge,Isle of Wight East,Isle of Wight,Isle of Wight,E05013359,E14001303,E06000046,E06000046
+2024,2024,Blacon,Chester North and Neston,Cheshire West and Chester,Cheshire West and Chester,E05012209,E14001163,E06000050,E06000050
+2024,2024,Baylis & Salt Hill,Slough,Slough,Slough,E05015525,E14001477,E06000039,E06000039
+2024,2024,Binstead & Fishbourne,Isle of Wight East,Isle of Wight,Isle of Wight,E05013360,E14001303,E06000046,E06000046
+2024,2024,Britwell,Slough,Slough,Slough,E05015526,E14001477,E06000039,E06000039
+2024,2024,Central & Grange,Ellesmere Port and Bromborough,Cheshire West and Chester,Cheshire West and Chester,E05012210,E14001222,E06000050,E06000050
+2024,2024,Chalvey,Slough,Slough,Slough,E05015527,E14001477,E06000039,E06000039
+2024,2024,Chester City & the Garden Quarter,Chester North and Neston,Cheshire West and Chester,Cheshire West and Chester,E05012211,E14001163,E06000050,E06000050
+2024,2024,Cippenham Green,Slough,Slough,Slough,E05015528,E14001477,E06000039,E06000039
+2024,2024,Christleton & Huntington,Chester South and Eddisbury,Cheshire West and Chester,Cheshire West and Chester,E05012212,E14001164,E06000050,E06000050
+2024,2024,Cippenham Manor,Slough,Slough,Slough,E05015529,E14001477,E06000039,E06000039
+2024,2024,"Davenham, Moulton & Kingsmead",Mid Cheshire,Cheshire West and Chester,Cheshire West and Chester,E05012213,E14001361,E06000050,E06000050
+2024,2024,Cippenham Village,Slough,Slough,Slough,E05015530,E14001477,E06000039,E06000039
+2024,2024,Farndon,Chester South and Eddisbury,Cheshire West and Chester,Cheshire West and Chester,E05012214,E14001164,E06000050,E06000050
+2024,2024,Colnbrook & Poyle,Windsor,Slough,Slough,E05015531,E14001588,E06000039,E06000039
+2024,2024,Frodsham,Runcorn and Helsby,Cheshire West and Chester,Cheshire West and Chester,E05012215,E14001455,E06000050,E06000050
+2024,2024,Elliman,Slough,Slough,Slough,E05015532,E14001477,E06000039,E06000039
+2024,2024,Gowy Rural,Runcorn and Helsby,Cheshire West and Chester,Cheshire West and Chester,E05012216,E14001455,E06000050,E06000050
+2024,2024,Farnham,Slough,Slough,Slough,E05015533,E14001477,E06000039,E06000039
+2024,2024,Great Boughton,Chester North and Neston,Cheshire West and Chester,Cheshire West and Chester,E05012217,E14001163,E06000050,E06000050
+2024,2024,Haymill,Slough,Slough,Slough,E05015534,E14001477,E06000039,E06000039
+2024,2024,Handbridge Park,Chester South and Eddisbury,Cheshire West and Chester,Cheshire West and Chester,E05012218,E14001164,E06000050,E06000050
+2024,2024,Herschel Park,Slough,Slough,Slough,E05015535,E14001477,E06000039,E06000039
+2024,2024,Hartford & Greenbank,Mid Cheshire,Cheshire West and Chester,Cheshire West and Chester,E05012219,E14001361,E06000050,E06000050
+2024,2024,Langley Foxborough,Windsor,Slough,Slough,E05015536,E14001588,E06000039,E06000039
+2024,2024,Helsby,Runcorn and Helsby,Cheshire West and Chester,Cheshire West and Chester,E05012220,E14001455,E06000050,E06000050
+2024,2024,Langley Marish,Slough,Slough,Slough,E05015537,E14001477,E06000039,E06000039
+2024,2024,Lache,Chester South and Eddisbury,Cheshire West and Chester,Cheshire West and Chester,E05012221,E14001164,E06000050,E06000050
+2024,2024,Langley Marish,Windsor,Slough,Slough,E05015537,E14001588,E06000039,E06000039
+2024,2024,Ledsham & Manor,Ellesmere Port and Bromborough,Cheshire West and Chester,Cheshire West and Chester,E05012222,E14001222,E06000050,E06000050
+2024,2024,Langley Meads,Slough,Slough,Slough,E05015538,E14001477,E06000039,E06000039
+2024,2024,Little Neston,Chester North and Neston,Cheshire West and Chester,Cheshire West and Chester,E05012223,E14001163,E06000050,E06000050
+2024,2024,Langley St Mary's,Slough,Slough,Slough,E05015539,E14001477,E06000039,E06000039
+2024,2024,Malpas,Chester South and Eddisbury,Cheshire West and Chester,Cheshire West and Chester,E05012224,E14001164,E06000050,E06000050
+2024,2024,Langley St Mary's,Windsor,Slough,Slough,E05015539,E14001588,E06000039,E06000039
+2024,2024,Marbury,Tatton,Cheshire West and Chester,Cheshire West and Chester,E05012225,E14001539,E06000050,E06000050
+2024,2024,Neston,Chester North and Neston,Cheshire West and Chester,Cheshire West and Chester,E05012226,E14001163,E06000050,E06000050
+2024,2024,Brading & St Helens,Isle of Wight East,Isle of Wight,Isle of Wight,E05013361,E14001303,E06000046,E06000046
+2024,2024,"Brighstone, Calbourne & Shalfleet",Isle of Wight West,Isle of Wight,Isle of Wight,E05013362,E14001304,E06000046,E06000046
+2024,2024,Carisbrooke & Gunville,Isle of Wight West,Isle of Wight,Isle of Wight,E05013363,E14001304,E06000046,E06000046
+2024,2024,Central Rural,Isle of Wight West,Isle of Wight,Isle of Wight,E05013364,E14001304,E06000046,E06000046
+2024,2024,"Chale, Niton & Shorwell",Isle of Wight West,Isle of Wight,Isle of Wight,E05013365,E14001304,E06000046,E06000046
+2024,2024,Cowes Medina,Isle of Wight West,Isle of Wight,Isle of Wight,E05013366,E14001304,E06000046,E06000046
+2024,2024,Cowes North,Isle of Wight West,Isle of Wight,Isle of Wight,E05013367,E14001304,E06000046,E06000046
+2024,2024,Cowes South & Northwood,Isle of Wight West,Isle of Wight,Isle of Wight,E05013368,E14001304,E06000046,E06000046
+2024,2024,Cowes West & Gurnard,Isle of Wight West,Isle of Wight,Isle of Wight,E05013369,E14001304,E06000046,E06000046
+2024,2024,East Cowes,Isle of Wight West,Isle of Wight,Isle of Wight,E05013370,E14001304,E06000046,E06000046
+2024,2024,Fairlee & Whippingham,Isle of Wight West,Isle of Wight,Isle of Wight,E05013371,E14001304,E06000046,E06000046
+2024,2024,Freshwater North & Yarmouth,Isle of Wight West,Isle of Wight,Isle of Wight,E05013372,E14001304,E06000046,E06000046
+2024,2024,Freshwater South,Isle of Wight West,Isle of Wight,Isle of Wight,E05013373,E14001304,E06000046,E06000046
+2024,2024,Haylands & Swanmore,Isle of Wight East,Isle of Wight,Isle of Wight,E05013374,E14001303,E06000046,E06000046
+2024,2024,Lake North,Isle of Wight East,Isle of Wight,Isle of Wight,E05013375,E14001303,E06000046,E06000046
+2024,2024,Lake South,Isle of Wight East,Isle of Wight,Isle of Wight,E05013376,E14001303,E06000046,E06000046
+2024,2024,Mountjoy & Shide,Isle of Wight West,Isle of Wight,Isle of Wight,E05013377,E14001304,E06000046,E06000046
+2024,2024,Nettlestone & Seaview,Isle of Wight East,Isle of Wight,Isle of Wight,E05013378,E14001303,E06000046,E06000046
+2024,2024,"Newchurch, Havenstreet & Ashey",Isle of Wight East,Isle of Wight,Isle of Wight,E05013379,E14001303,E06000046,E06000046
+2024,2024,Newport Central,Isle of Wight West,Isle of Wight,Isle of Wight,E05013380,E14001304,E06000046,E06000046
+2024,2024,Newport West,Isle of Wight West,Isle of Wight,Isle of Wight,E05013381,E14001304,E06000046,E06000046
+2024,2024,Osborne,Isle of Wight West,Isle of Wight,Isle of Wight,E05013382,E14001304,E06000046,E06000046
+2024,2024,Pan & Barton,Isle of Wight West,Isle of Wight,Isle of Wight,E05013383,E14001304,E06000046,E06000046
+2024,2024,Parkhurst & Hunnyhill,Isle of Wight West,Isle of Wight,Isle of Wight,E05013384,E14001304,E06000046,E06000046
+2024,2024,Ryde Appley & Elmfield,Isle of Wight East,Isle of Wight,Isle of Wight,E05013385,E14001303,E06000046,E06000046
+2024,2024,Ryde Monktonmead,Isle of Wight East,Isle of Wight,Isle of Wight,E05013386,E14001303,E06000046,E06000046
+2024,2024,Ryde North West,Isle of Wight East,Isle of Wight,Isle of Wight,E05013387,E14001303,E06000046,E06000046
+2024,2024,Ryde South East,Isle of Wight East,Isle of Wight,Isle of Wight,E05013388,E14001303,E06000046,E06000046
+2024,2024,Ryde West,Isle of Wight East,Isle of Wight,Isle of Wight,E05013389,E14001303,E06000046,E06000046
+2024,2024,Sandown North,Isle of Wight East,Isle of Wight,Isle of Wight,E05013390,E14001303,E06000046,E06000046
+2024,2024,Sandown South,Isle of Wight East,Isle of Wight,Isle of Wight,E05013391,E14001303,E06000046,E06000046
+2024,2024,Shanklin Central,Isle of Wight East,Isle of Wight,Isle of Wight,E05013392,E14001303,E06000046,E06000046
+2024,2024,Manor Park & Stoke,Slough,Slough,Slough,E05015540,E14001477,E06000039,E06000039
+2024,2024,Shanklin South,Isle of Wight East,Isle of Wight,Isle of Wight,E05013393,E14001303,E06000046,E06000046
+2024,2024,Northborough & Lynch Hill Valley,Slough,Slough,Slough,E05015541,E14001477,E06000039,E06000039
+2024,2024,Slough Central,Slough,Slough,Slough,E05015542,E14001477,E06000039,E06000039
+2024,2024,Netherpool,Ellesmere Port and Bromborough,Cheshire West and Chester,Cheshire West and Chester,E05012227,E14001222,E06000050,E06000050
+2024,2024,Upton,Slough,Slough,Slough,E05015543,E14001477,E06000039,E06000039
+2024,2024,Newton & Hoole,Chester North and Neston,Cheshire West and Chester,Cheshire West and Chester,E05012228,E14001163,E06000050,E06000050
+2024,2024,Upton Lea,Slough,Slough,Slough,E05015544,E14001477,E06000039,E06000039
+2024,2024,Northwich Leftwich,Mid Cheshire,Cheshire West and Chester,Cheshire West and Chester,E05012229,E14001361,E06000050,E06000050
+2024,2024,Wexham Court,Slough,Slough,Slough,E05015545,E14001477,E06000039,E06000039
+2024,2024,Northwich Winnington & Castle,Mid Cheshire,Cheshire West and Chester,Cheshire West and Chester,E05012230,E14001361,E06000050,E06000050
+2024,2024,Ascot & Sunninghill,Windsor,Windsor and Maidenhead,Windsor and Maidenhead,E05012494,E14001588,E06000040,E06000040
+2024,2024,Northwich Witton,Mid Cheshire,Cheshire West and Chester,Cheshire West and Chester,E05012231,E14001361,E06000050,E06000050
+2024,2024,Belmont,Maidenhead,Windsor and Maidenhead,Windsor and Maidenhead,E05012495,E14001348,E06000040,E06000040
+2024,2024,Parkgate,Chester North and Neston,Cheshire West and Chester,Cheshire West and Chester,E05012232,E14001163,E06000050,E06000050
+2024,2024,Bisham & Cookham,Maidenhead,Windsor and Maidenhead,Windsor and Maidenhead,E05012496,E14001348,E06000040,E06000040
+2024,2024,Rudheath,Mid Cheshire,Cheshire West and Chester,Cheshire West and Chester,E05012233,E14001361,E06000050,E06000050
+2024,2024,Boyn Hill,Maidenhead,Windsor and Maidenhead,Windsor and Maidenhead,E05012497,E14001348,E06000040,E06000040
+2024,2024,Sandstone,Runcorn and Helsby,Cheshire West and Chester,Cheshire West and Chester,E05012234,E14001455,E06000050,E06000050
+2024,2024,Bray,Maidenhead,Windsor and Maidenhead,Windsor and Maidenhead,E05012498,E14001348,E06000040,E06000040
+2024,2024,Saughall & Mollington,Chester North and Neston,Cheshire West and Chester,Cheshire West and Chester,E05012235,E14001163,E06000050,E06000050
+2024,2024,Clewer & Dedworth East,Windsor,Windsor and Maidenhead,Windsor and Maidenhead,E05012499,E14001588,E06000040,E06000040
+2024,2024,Shakerley,Tatton,Cheshire West and Chester,Cheshire West and Chester,E05012236,E14001539,E06000050,E06000050
+2024,2024,Clewer & Dedworth West,Windsor,Windsor and Maidenhead,Windsor and Maidenhead,E05012500,E14001588,E06000040,E06000040
+2024,2024,Totland & Colwell,Isle of Wight West,Isle of Wight,Isle of Wight,E05013394,E14001304,E06000046,E06000046
+2024,2024,Ventnor & St Lawrence,Isle of Wight East,Isle of Wight,Isle of Wight,E05013395,E14001303,E06000046,E06000046
+2024,2024,Wootton Bridge,Isle of Wight East,Isle of Wight,Isle of Wight,E05013396,E14001303,E06000046,E06000046
+2024,2024,Strawberry,Ellesmere Port and Bromborough,Cheshire West and Chester,Cheshire West and Chester,E05012237,E14001222,E06000050,E06000050
+2024,2024,Sutton Villages,Ellesmere Port and Bromborough,Cheshire West and Chester,Cheshire West and Chester,E05012238,E14001222,E06000050,E06000050
+2024,2024,Tarporley,Chester South and Eddisbury,Cheshire West and Chester,Cheshire West and Chester,E05012239,E14001164,E06000050,E06000050
+2024,2024,Tarvin & Kelsall,Chester South and Eddisbury,Cheshire West and Chester,Cheshire West and Chester,E05012240,E14001164,E06000050,E06000050
+2024,2024,Tattenhall,Chester South and Eddisbury,Cheshire West and Chester,Cheshire West and Chester,E05012241,E14001164,E06000050,E06000050
+2024,2024,Clewer East,Windsor,Windsor and Maidenhead,Windsor and Maidenhead,E05012501,E14001588,E06000040,E06000040
+2024,2024,Cox Green,Maidenhead,Windsor and Maidenhead,Windsor and Maidenhead,E05012502,E14001348,E06000040,E06000040
+2024,2024,"Wroxall, Lowtherville & Bonchurch",Isle of Wight East,Isle of Wight,Isle of Wight,E05013397,E14001303,E06000046,E06000046
+2024,2024,Annfield Plain,North Durham,County Durham,County Durham,E05009030,E14001389,E06000047,E06000047
+2024,2024,Aycliffe East,Newton Aycliffe and Spennymoor,County Durham,County Durham,E05009031,E14001382,E06000047,E06000047
+2024,2024,Aycliffe North and Middridge,Newton Aycliffe and Spennymoor,County Durham,County Durham,E05009032,E14001382,E06000047,E06000047
+2024,2024,Aycliffe West,Newton Aycliffe and Spennymoor,County Durham,County Durham,E05009033,E14001382,E06000047,E06000047
+2024,2024,Barnard Castle East,Bishop Auckland,County Durham,County Durham,E05009034,E14001101,E06000047,E06000047
+2024,2024,Barnard Castle West,Bishop Auckland,County Durham,County Durham,E05009035,E14001101,E06000047,E06000047
+2024,2024,Belmont,City of Durham,County Durham,County Durham,E05009036,E14001173,E06000047,E06000047
+2024,2024,Benfieldside,Blaydon and Consett,County Durham,County Durham,E05009037,E14001106,E06000047,E06000047
+2024,2024,Bishop Auckland Town,Bishop Auckland,County Durham,County Durham,E05009038,E14001101,E06000047,E06000047
+2024,2024,Bishop Middleham and Cornforth,Newton Aycliffe and Spennymoor,County Durham,County Durham,E05009039,E14001382,E06000047,E06000047
+2024,2024,Blackhalls,Easington,County Durham,County Durham,E05009040,E14001211,E06000047,E06000047
+2024,2024,Brandon,City of Durham,County Durham,County Durham,E05009041,E14001173,E06000047,E06000047
+2024,2024,Burnopfield and Dipton,Blaydon and Consett,County Durham,County Durham,E05009042,E14001106,E06000047,E06000047
+2024,2024,Chester-le-Street East,North Durham,County Durham,County Durham,E05009043,E14001389,E06000047,E06000047
+2024,2024,Chester-le-Street North,North Durham,County Durham,County Durham,E05009044,E14001389,E06000047,E06000047
+2024,2024,Chester-le-Street South,North Durham,County Durham,County Durham,E05009045,E14001389,E06000047,E06000047
+2024,2024,Chester-le-Street West Central,North Durham,County Durham,County Durham,E05009046,E14001389,E06000047,E06000047
+2024,2024,Chilton,Newton Aycliffe and Spennymoor,County Durham,County Durham,E05009047,E14001382,E06000047,E06000047
+2024,2024,Consett North,Blaydon and Consett,County Durham,County Durham,E05009048,E14001106,E06000047,E06000047
+2024,2024,Consett South,Blaydon and Consett,County Durham,County Durham,E05009049,E14001106,E06000047,E06000047
+2024,2024,Coundon,Bishop Auckland,County Durham,County Durham,E05009050,E14001101,E06000047,E06000047
+2024,2024,Coxhoe,Newton Aycliffe and Spennymoor,County Durham,County Durham,E05009051,E14001382,E06000047,E06000047
+2024,2024,Craghead and South Moor,North Durham,County Durham,County Durham,E05009052,E14001389,E06000047,E06000047
+2024,2024,Crook,Bishop Auckland,County Durham,County Durham,E05009053,E14001101,E06000047,E06000047
+2024,2024,Dawdon,Easington,County Durham,County Durham,E05009054,E14001211,E06000047,E06000047
+2024,2024,Deerness,City of Durham,County Durham,County Durham,E05009055,E14001173,E06000047,E06000047
+2024,2024,Delves Lane,Blaydon and Consett,County Durham,County Durham,E05009056,E14001106,E06000047,E06000047
+2024,2024,Deneside,Easington,County Durham,County Durham,E05009057,E14001211,E06000047,E06000047
+2024,2024,Durham South,City of Durham,County Durham,County Durham,E05009058,E14001173,E06000047,E06000047
+2024,2024,Easington,Easington,County Durham,County Durham,E05009059,E14001211,E06000047,E06000047
+2024,2024,Elvet and Gilesgate,City of Durham,County Durham,County Durham,E05009060,E14001173,E06000047,E06000047
+2024,2024,Esh and Witton Gilbert,City of Durham,County Durham,County Durham,E05009061,E14001173,E06000047,E06000047
+2024,2024,Evenwood,Bishop Auckland,County Durham,County Durham,E05009062,E14001101,E06000047,E06000047
+2024,2024,Ferryhill,Newton Aycliffe and Spennymoor,County Durham,County Durham,E05009063,E14001382,E06000047,E06000047
+2024,2024,Framwellgate and Newton Hall,City of Durham,County Durham,County Durham,E05009064,E14001173,E06000047,E06000047
+2024,2024,Horden,Easington,County Durham,County Durham,E05009065,E14001211,E06000047,E06000047
+2024,2024,Lanchester,North Durham,County Durham,County Durham,E05009066,E14001389,E06000047,E06000047
+2024,2024,Leadgate and Medomsley,Blaydon and Consett,County Durham,County Durham,E05009067,E14001106,E06000047,E06000047
+2024,2024,Lumley,North Durham,County Durham,County Durham,E05009068,E14001389,E06000047,E06000047
+2024,2024,Murton,Easington,County Durham,County Durham,E05009069,E14001211,E06000047,E06000047
+2024,2024,Neville's Cross,City of Durham,County Durham,County Durham,E05009070,E14001173,E06000047,E06000047
+2024,2024,North Lodge,North Durham,County Durham,County Durham,E05009071,E14001389,E06000047,E06000047
+2024,2024,Passfield,Easington,County Durham,County Durham,E05009072,E14001211,E06000047,E06000047
+2024,2024,Pelton,North Durham,County Durham,County Durham,E05009073,E14001389,E06000047,E06000047
+2024,2024,Peterlee East,Easington,County Durham,County Durham,E05009074,E14001211,E06000047,E06000047
+2024,2024,Peterlee West,Easington,County Durham,County Durham,E05009075,E14001211,E06000047,E06000047
+2024,2024,Sacriston,North Durham,County Durham,County Durham,E05009076,E14001389,E06000047,E06000047
+2024,2024,Seaham,Easington,County Durham,County Durham,E05009077,E14001211,E06000047,E06000047
+2024,2024,Sedgefield,Newton Aycliffe and Spennymoor,County Durham,County Durham,E05009078,E14001382,E06000047,E06000047
+2024,2024,Devizes North,Melksham and Devizes,Wiltshire,Wiltshire,E05013429,E14001356,E06000054,E06000054
+2024,2024,Devizes Rural West,Melksham and Devizes,Wiltshire,Wiltshire,E05013430,E14001356,E06000054,E06000054
+2024,2024,Devizes South,Melksham and Devizes,Wiltshire,Wiltshire,E05013431,E14001356,E06000054,E06000054
+2024,2024,Downton & Ebble Valley,Salisbury,Wiltshire,Wiltshire,E05013432,E14001460,E06000054,E06000054
+2024,2024,Durrington,East Wiltshire,Wiltshire,Wiltshire,E05013433,E14001217,E06000054,E06000054
+2024,2024,Ethandune,South West Wiltshire,Wiltshire,Wiltshire,E05013434,E14001498,E06000054,E06000054
+2024,2024,Fovant & Chalke Valley,Salisbury,Wiltshire,Wiltshire,E05013435,E14001460,E06000054,E06000054
+2024,2024,Hilperton,South West Wiltshire,Wiltshire,Wiltshire,E05013436,E14001498,E06000054,E06000054
+2024,2024,Holt,Melksham and Devizes,Wiltshire,Wiltshire,E05013437,E14001356,E06000054,E06000054
+2024,2024,Kington,South Cotswolds,Wiltshire,Wiltshire,E05013438,E14001482,E06000054,E06000054
+2024,2024,Laverstock,Salisbury,Wiltshire,Wiltshire,E05013439,E14001460,E06000054,E06000054
+2024,2024,Ludgershall North & Rural,East Wiltshire,Wiltshire,Wiltshire,E05013440,E14001217,E06000054,E06000054
+2024,2024,Lyneham,Chippenham,Wiltshire,Wiltshire,E05013441,E14001168,E06000054,E06000054
+2024,2024,Malmesbury,South Cotswolds,Wiltshire,Wiltshire,E05013442,E14001482,E06000054,E06000054
+2024,2024,Marlborough East,East Wiltshire,Wiltshire,Wiltshire,E05013443,E14001217,E06000054,E06000054
+2024,2024,Marlborough West,East Wiltshire,Wiltshire,Wiltshire,E05013444,E14001217,E06000054,E06000054
+2024,2024,Melksham Forest,Melksham and Devizes,Wiltshire,Wiltshire,E05013446,E14001356,E06000054,E06000054
+2024,2024,Melksham South,Melksham and Devizes,Wiltshire,Wiltshire,E05013447,E14001356,E06000054,E06000054
+2024,2024,Melksham Without North & Shurnhold,Melksham and Devizes,Wiltshire,Wiltshire,E05013448,E14001356,E06000054,E06000054
+2024,2024,Melksham Without West & Rural,Melksham and Devizes,Wiltshire,Wiltshire,E05013449,E14001356,E06000054,E06000054
+2024,2024,Mere,South West Wiltshire,Wiltshire,Wiltshire,E05013450,E14001498,E06000054,E06000054
+2024,2024,Minety,South Cotswolds,Wiltshire,Wiltshire,E05013451,E14001482,E06000054,E06000054
+2024,2024,Nadder Valley,Salisbury,Wiltshire,Wiltshire,E05013452,E14001460,E06000054,E06000054
+2024,2024,Old Sarum & Lower Bourne Valley,Salisbury,Wiltshire,Wiltshire,E05013453,E14001460,E06000054,E06000054
+2024,2024,Pewsey Vale East,East Wiltshire,Wiltshire,Wiltshire,E05013455,E14001217,E06000054,E06000054
+2024,2024,Purton,South Cotswolds,Wiltshire,Wiltshire,E05013457,E14001482,E06000054,E06000054
+2024,2024,Redlynch & Landford,Salisbury,Wiltshire,Wiltshire,E05013458,E14001460,E06000054,E06000054
+2024,2024,Royal Wootton Bassett East,Chippenham,Wiltshire,Wiltshire,E05013459,E14001168,E06000054,E06000054
+2024,2024,Royal Wootton Bassett North,Chippenham,Wiltshire,Wiltshire,E05013460,E14001168,E06000054,E06000054
+2024,2024,Royal Wootton Bassett South & West,Chippenham,Wiltshire,Wiltshire,E05013461,E14001168,E06000054,E06000054
+2024,2024,Salisbury Bemerton Heath,Salisbury,Wiltshire,Wiltshire,E05013462,E14001460,E06000054,E06000054
+2024,2024,Salisbury Fisherton & Bemerton Village,Salisbury,Wiltshire,Wiltshire,E05013463,E14001460,E06000054,E06000054
+2024,2024,Salisbury Harnham East,Salisbury,Wiltshire,Wiltshire,E05013464,E14001460,E06000054,E06000054
+2024,2024,Salisbury Harnham West,Salisbury,Wiltshire,Wiltshire,E05013465,E14001460,E06000054,E06000054
+2024,2024,Salisbury Milford,Salisbury,Wiltshire,Wiltshire,E05013466,E14001460,E06000054,E06000054
+2024,2024,Salisbury St Edmund's,Salisbury,Wiltshire,Wiltshire,E05013467,E14001460,E06000054,E06000054
+2024,2024,Salisbury St Francis & Stratford,Salisbury,Wiltshire,Wiltshire,E05013468,E14001460,E06000054,E06000054
+2024,2024,Salisbury St Paul's,Salisbury,Wiltshire,Wiltshire,E05013469,E14001460,E06000054,E06000054
+2024,2024,Sherston,South Cotswolds,Wiltshire,Wiltshire,E05013470,E14001482,E06000054,E06000054
+2024,2024,Southwick,South West Wiltshire,Wiltshire,Wiltshire,E05013471,E14001498,E06000054,E06000054
+2024,2024,The Lavingtons,Melksham and Devizes,Wiltshire,Wiltshire,E05013472,E14001356,E06000054,E06000054
+2024,2024,Tidworth East & Ludgershall South,East Wiltshire,Wiltshire,Wiltshire,E05013473,E14001217,E06000054,E06000054
+2024,2024,Tidworth North & West,East Wiltshire,Wiltshire,Wiltshire,E05013474,E14001217,E06000054,E06000054
+2024,2024,Till Valley,East Wiltshire,Wiltshire,Wiltshire,E05013475,E14001217,E06000054,E06000054
+2024,2024,Tisbury,Salisbury,Wiltshire,Wiltshire,E05013476,E14001460,E06000054,E06000054
+2024,2024,Trowbridge Adcroft,South West Wiltshire,Wiltshire,Wiltshire,E05013477,E14001498,E06000054,E06000054
+2024,2024,Trowbridge Central,South West Wiltshire,Wiltshire,Wiltshire,E05013478,E14001498,E06000054,E06000054
+2024,2024,Trowbridge Drynham,South West Wiltshire,Wiltshire,Wiltshire,E05013479,E14001498,E06000054,E06000054
+2024,2024,Trowbridge Grove,South West Wiltshire,Wiltshire,Wiltshire,E05013480,E14001498,E06000054,E06000054
+2024,2024,Trowbridge Lambrok,South West Wiltshire,Wiltshire,Wiltshire,E05013481,E14001498,E06000054,E06000054
+2024,2024,Upton,Chester North and Neston,Cheshire West and Chester,Cheshire West and Chester,E05012242,E14001163,E06000050,E06000050
+2024,2024,"Looe West, Pelynt, Lansallos & Lanteglos",South East Cornwall,Cornwall,Cornwall,E05013306,E14001486,E06000052,E06000052
+2024,2024,Much Wenlock,South Shropshire,Shropshire,Shropshire,E05008174,E14001493,E06000051,E06000051
+2024,2024,Weaver & Cuddington,Chester South and Eddisbury,Cheshire West and Chester,Cheshire West and Chester,E05012243,E14001164,E06000050,E06000050
+2024,2024,Westminster,Ellesmere Port and Bromborough,Cheshire West and Chester,Cheshire West and Chester,E05012244,E14001222,E06000050,E06000050
+2024,2024,Whitby Groves,Ellesmere Port and Bromborough,Cheshire West and Chester,Cheshire West and Chester,E05012245,E14001222,E06000050,E06000050
+2024,2024,Whitby Park,Ellesmere Port and Bromborough,Cheshire West and Chester,Cheshire West and Chester,E05012246,E14001222,E06000050,E06000050
+2024,2024,Willaston & Thornton,Chester North and Neston,Cheshire West and Chester,Cheshire West and Chester,E05012247,E14001163,E06000050,E06000050
+2024,2024,Winsford Dene,Mid Cheshire,Cheshire West and Chester,Cheshire West and Chester,E05012248,E14001361,E06000050,E06000050
+2024,2024,Winsford Gravel,Mid Cheshire,Cheshire West and Chester,Cheshire West and Chester,E05012249,E14001361,E06000050,E06000050
+2024,2024,Winsford Over & Verdin,Mid Cheshire,Cheshire West and Chester,Cheshire West and Chester,E05012250,E14001361,E06000050,E06000050
+2024,2024,Winsford Swanlow,Mid Cheshire,Cheshire West and Chester,Cheshire West and Chester,E05012251,E14001361,E06000050,E06000050
+2024,2024,Winsford Wharton,Mid Cheshire,Cheshire West and Chester,Cheshire West and Chester,E05012252,E14001361,E06000050,E06000050
+2024,2024,Wolverham,Ellesmere Port and Bromborough,Cheshire West and Chester,Cheshire West and Chester,E05012253,E14001222,E06000050,E06000050
+2024,2024,Abbey,Shrewsbury,Shropshire,Shropshire,E05008136,E14001473,E06000051,E06000051
+2024,2024,Albrighton,The Wrekin,Shropshire,Shropshire,E05008137,E14001543,E06000051,E06000051
+2024,2024,Alveley and Claverley,South Shropshire,Shropshire,Shropshire,E05008138,E14001493,E06000051,E06000051
+2024,2024,Bagley,Shrewsbury,Shropshire,Shropshire,E05008139,E14001473,E06000051,E06000051
+2024,2024,Battlefield,Shrewsbury,Shropshire,Shropshire,E05008140,E14001473,E06000051,E06000051
+2024,2024,"Bayston Hill, Column and Sutton",Shrewsbury,Shropshire,Shropshire,E05008141,E14001473,E06000051,E06000051
+2024,2024,Belle Vue,Shrewsbury,Shropshire,Shropshire,E05008142,E14001473,E06000051,E06000051
+2024,2024,Bishop's Castle,South Shropshire,Shropshire,Shropshire,E05008143,E14001493,E06000051,E06000051
+2024,2024,Bowbrook,Shrewsbury,Shropshire,Shropshire,E05008144,E14001473,E06000051,E06000051
+2024,2024,Bridgnorth East and Astley Abbotts,South Shropshire,Shropshire,Shropshire,E05008145,E14001493,E06000051,E06000051
+2024,2024,Bridgnorth West and Tasley,South Shropshire,Shropshire,Shropshire,E05008146,E14001493,E06000051,E06000051
+2024,2024,Broseley,South Shropshire,Shropshire,Shropshire,E05008147,E14001493,E06000051,E06000051
+2024,2024,Brown Clee,South Shropshire,Shropshire,Shropshire,E05008148,E14001493,E06000051,E06000051
+2024,2024,Burnell,South Shropshire,Shropshire,Shropshire,E05008149,E14001493,E06000051,E06000051
+2024,2024,Castlefields and Ditherington,Shrewsbury,Shropshire,Shropshire,E05008150,E14001473,E06000051,E06000051
+2024,2024,Cheswardine,The Wrekin,Shropshire,Shropshire,E05008151,E14001543,E06000051,E06000051
+2024,2024,Chirbury and Worthen,South Shropshire,Shropshire,Shropshire,E05008152,E14001493,E06000051,E06000051
+2024,2024,Church Stretton and Craven Arms,South Shropshire,Shropshire,Shropshire,E05008153,E14001493,E06000051,E06000051
+2024,2024,Clee,South Shropshire,Shropshire,Shropshire,E05008154,E14001493,E06000051,E06000051
+2024,2024,Cleobury Mortimer,South Shropshire,Shropshire,Shropshire,E05008155,E14001493,E06000051,E06000051
+2024,2024,Clun,South Shropshire,Shropshire,Shropshire,E05008156,E14001493,E06000051,E06000051
+2024,2024,Copthorne,Shrewsbury,Shropshire,Shropshire,E05008157,E14001473,E06000051,E06000051
+2024,2024,Corvedale,South Shropshire,Shropshire,Shropshire,E05008158,E14001493,E06000051,E06000051
+2024,2024,Ellesmere Urban,North Shropshire,Shropshire,Shropshire,E05008159,E14001398,E06000051,E06000051
+2024,2024,Harlescott,Shrewsbury,Shropshire,Shropshire,E05008160,E14001473,E06000051,E06000051
+2024,2024,Highley,South Shropshire,Shropshire,Shropshire,E05008161,E14001493,E06000051,E06000051
+2024,2024,Hodnet,The Wrekin,Shropshire,Shropshire,E05008162,E14001543,E06000051,E06000051
+2024,2024,Llanymynech,North Shropshire,Shropshire,Shropshire,E05008163,E14001398,E06000051,E06000051
+2024,2024,Longden,Shrewsbury,Shropshire,Shropshire,E05008164,E14001473,E06000051,E06000051
+2024,2024,Loton,Shrewsbury,Shropshire,Shropshire,E05008165,E14001473,E06000051,E06000051
+2024,2024,Ludlow East,South Shropshire,Shropshire,Shropshire,E05008166,E14001493,E06000051,E06000051
+2024,2024,Ludlow North,South Shropshire,Shropshire,Shropshire,E05008167,E14001493,E06000051,E06000051
+2024,2024,Ludlow South,South Shropshire,Shropshire,Shropshire,E05008168,E14001493,E06000051,E06000051
+2024,2024,Market Drayton East,North Shropshire,Shropshire,Shropshire,E05008169,E14001398,E06000051,E06000051
+2024,2024,Market Drayton West,North Shropshire,Shropshire,Shropshire,E05008170,E14001398,E06000051,E06000051
+2024,2024,Meole,Shrewsbury,Shropshire,Shropshire,E05008171,E14001473,E06000051,E06000051
+2024,2024,Rea Valley,Shrewsbury,Shropshire,Shropshire,E05008172,E14001473,E06000051,E06000051
+2024,2024,Monkmoor,Shrewsbury,Shropshire,Shropshire,E05008173,E14001473,E06000051,E06000051
+2024,2024,Lostwithiel & Lanreath,South East Cornwall,Cornwall,Cornwall,E05013307,E14001486,E06000052,E06000052
+2024,2024,Porthill,Shrewsbury,Shropshire,Shropshire,E05008178,E14001473,E06000051,E06000051
+2024,2024,Wyboston,North Bedfordshire,Bedford,Bedford,E05014518,E14001384,E06000055,E06000055
+2024,2024,Perranporth,Truro and Falmouth,Cornwall,Cornwall,E05013849,E14001554,E06000052,E06000052
+2024,2024,Trowbridge Park,South West Wiltshire,Wiltshire,Wiltshire,E05013482,E14001498,E06000054,E06000054
+2024,2024,Prees,North Shropshire,Shropshire,Shropshire,E05008179,E14001398,E06000051,E06000051
+2024,2024,Quarry and Coton Hill,Shrewsbury,Shropshire,Shropshire,E05008180,E14001473,E06000051,E06000051
+2024,2024,Radbrook,Shrewsbury,Shropshire,Shropshire,E05008181,E14001473,E06000051,E06000051
+2024,2024,St Martin's,North Shropshire,Shropshire,Shropshire,E05008183,E14001398,E06000051,E06000051
+2024,2024,Severn Valley,South Shropshire,Shropshire,Shropshire,E05008186,E14001493,E06000051,E06000051
+2024,2024,Shawbury,North Shropshire,Shropshire,Shropshire,E05008187,E14001398,E06000051,E06000051
+2024,2024,Shifnal North,The Wrekin,Shropshire,Shropshire,E05008188,E14001543,E06000051,E06000051
+2024,2024,Shifnal South and Cosford,The Wrekin,Shropshire,Shropshire,E05008189,E14001543,E06000051,E06000051
+2024,2024,Sundorne,Shrewsbury,Shropshire,Shropshire,E05008190,E14001473,E06000051,E06000051
+2024,2024,Tern,Shrewsbury,Shropshire,Shropshire,E05008191,E14001473,E06000051,E06000051
+2024,2024,The Meres,North Shropshire,Shropshire,Shropshire,E05008192,E14001398,E06000051,E06000051
+2024,2024,Underdale,Shrewsbury,Shropshire,Shropshire,E05008193,E14001473,E06000051,E06000051
+2024,2024,Wem,North Shropshire,Shropshire,Shropshire,E05008194,E14001398,E06000051,E06000051
+2024,2024,Whitchurch North,North Shropshire,Shropshire,Shropshire,E05008195,E14001398,E06000051,E06000051
+2024,2024,Whitchurch South,North Shropshire,Shropshire,Shropshire,E05008196,E14001398,E06000051,E06000051
+2024,2024,Worfield,South Shropshire,Shropshire,Shropshire,E05008198,E14001493,E06000051,E06000051
+2024,2024,"Gobowen, Selattyn and Weston Rhyn",North Shropshire,Shropshire,Shropshire,E05009281,E14001398,E06000051,E06000051
+2024,2024,Oswestry East,North Shropshire,Shropshire,Shropshire,E05009282,E14001398,E06000051,E06000051
+2024,2024,Oswestry South,North Shropshire,Shropshire,Shropshire,E05009283,E14001398,E06000051,E06000051
+2024,2024,Oswestry West,North Shropshire,Shropshire,Shropshire,E05009284,E14001398,E06000051,E06000051
+2024,2024,Ruyton and Baschurch,North Shropshire,Shropshire,Shropshire,E05009285,E14001398,E06000051,E06000051
+2024,2024,St Oswald,North Shropshire,Shropshire,Shropshire,E05009286,E14001398,E06000051,E06000051
+2024,2024,Whittington,North Shropshire,Shropshire,Shropshire,E05009287,E14001398,E06000051,E06000051
+2024,2024,Bodmin St Mary's & St Leonard,North Cornwall,Cornwall,Cornwall,E05013273,E14001385,E06000052,E06000052
+2024,2024,Bodmin St Petroc's,North Cornwall,Cornwall,Cornwall,E05013274,E14001385,E06000052,E06000052
+2024,2024,Bude,North Cornwall,Cornwall,Cornwall,E05013275,E14001385,E06000052,E06000052
+2024,2024,Callington & St Dominic,South East Cornwall,Cornwall,Cornwall,E05013276,E14001486,E06000052,E06000052
+2024,2024,Calstock,South East Cornwall,Cornwall,Cornwall,E05013277,E14001486,E06000052,E06000052
+2024,2024,Camborne Roskear & Tuckingmill,Camborne and Redruth,Cornwall,Cornwall,E05013278,E14001148,E06000052,E06000052
+2024,2024,Camborne Trelowarren,Camborne and Redruth,Cornwall,Cornwall,E05013279,E14001148,E06000052,E06000052
+2024,2024,Camborne West & Treswithian,Camborne and Redruth,Cornwall,Cornwall,E05013280,E14001148,E06000052,E06000052
+2024,2024,Camelford & Boscastle,North Cornwall,Cornwall,Cornwall,E05013281,E14001385,E06000052,E06000052
+2024,2024,"Constantine, Mabe & Mawnan",Camborne and Redruth,Cornwall,Cornwall,E05013282,E14001148,E06000052,E06000052
+2024,2024,Falmouth Arwenack,Truro and Falmouth,Cornwall,Cornwall,E05013284,E14001554,E06000052,E06000052
+2024,2024,Falmouth Penwerris,Truro and Falmouth,Cornwall,Cornwall,E05013286,E14001554,E06000052,E06000052
+2024,2024,Feock & Kea,Truro and Falmouth,Cornwall,Cornwall,E05013288,E14001554,E06000052,E06000052
+2024,2024,"Four Lanes, Beacon & Troon",Camborne and Redruth,Cornwall,Cornwall,E05013289,E14001148,E06000052,E06000052
+2024,2024,"Fowey, Tywardreath & Par",St Austell and Newquay,Cornwall,Cornwall,E05013290,E14001508,E06000052,E06000052
+2024,2024,Ampthill,Mid Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014394,E14001359,E06000056,E06000056
+2024,2024,"Ludgvan, Madron, Gulval & Heamoor",St Ives,Cornwall,Cornwall,E05013308,E14001511,E06000052,E06000052
+2024,2024,Probus & St Erme,Truro and Falmouth,Cornwall,Cornwall,E05013850,E14001554,E06000052,E06000052
+2024,2024,Trowbridge Paxcroft,South West Wiltshire,Wiltshire,Wiltshire,E05013483,E14001498,E06000054,E06000054
+2024,2024,"Gloweth, Malabar & Shortlanesend",Truro and Falmouth,Cornwall,Cornwall,E05013291,E14001554,E06000052,E06000052
+2024,2024,Gwinear-Gwithian & Hayle East,Camborne and Redruth,Cornwall,Cornwall,E05013292,E14001148,E06000052,E06000052
+2024,2024,Hayle West,Camborne and Redruth,Cornwall,Cornwall,E05013293,E14001148,E06000052,E06000052
+2024,2024,Helston South & Meneage,St Ives,Cornwall,Cornwall,E05013295,E14001511,E06000052,E06000052
+2024,2024,Land's End,St Ives,Cornwall,Cornwall,E05013297,E14001511,E06000052,E06000052
+2024,2024,"Lanivet, Blisland & Bodmin St Lawrence",North Cornwall,Cornwall,Cornwall,E05013298,E14001385,E06000052,E06000052
+2024,2024,Launceston South,North Cornwall,Cornwall,Cornwall,E05013301,E14001385,E06000052,E06000052
+2024,2024,Liskeard Central,South East Cornwall,Cornwall,Cornwall,E05013302,E14001486,E06000052,E06000052
+2024,2024,Liskeard South & Dobwalls,South East Cornwall,Cornwall,Cornwall,E05013303,E14001486,E06000052,E06000052
+2024,2024,Looe East & Deviock,South East Cornwall,Cornwall,Cornwall,E05013305,E14001486,E06000052,E06000052
+2024,2024,Urchfont & Bishops Cannings,Melksham and Devizes,Wiltshire,Wiltshire,E05013484,E14001356,E06000054,E06000054
+2024,2024,Warminster Broadway,South West Wiltshire,Wiltshire,Wiltshire,E05013485,E14001498,E06000054,E06000054
+2024,2024,Warminster East,South West Wiltshire,Wiltshire,Wiltshire,E05013486,E14001498,E06000054,E06000054
+2024,2024,Warminster North & Rural,South West Wiltshire,Wiltshire,Wiltshire,E05013487,E14001498,E06000054,E06000054
+2024,2024,Warminster West,South West Wiltshire,Wiltshire,Wiltshire,E05013488,E14001498,E06000054,E06000054
+2024,2024,Westbury East,South West Wiltshire,Wiltshire,Wiltshire,E05013489,E14001498,E06000054,E06000054
+2024,2024,Westbury North,South West Wiltshire,Wiltshire,Wiltshire,E05013490,E14001498,E06000054,E06000054
+2024,2024,Westbury West,South West Wiltshire,Wiltshire,Wiltshire,E05013491,E14001498,E06000054,E06000054
+2024,2024,Wilton,Salisbury,Wiltshire,Wiltshire,E05013492,E14001460,E06000054,E06000054
+2024,2024,Lynher,South East Cornwall,Cornwall,Cornwall,E05013309,E14001486,E06000052,E06000052
+2024,2024,Winsley & Westwood,Melksham and Devizes,Wiltshire,Wiltshire,E05013493,E14001356,E06000054,E06000054
+2024,2024,Winterslow & Upper Bourne Valley,Salisbury,Wiltshire,Wiltshire,E05013494,E14001460,E06000054,E06000054
+2024,2024,"Mousehole, Newlyn & St Buryan",St Ives,Cornwall,Cornwall,E05013311,E14001511,E06000052,E06000052
+2024,2024,Wylye Valley,South West Wiltshire,Wiltshire,Wiltshire,E05013495,E14001498,E06000054,E06000054
+2024,2024,Mullion & St Keverne,St Ives,Cornwall,Cornwall,E05013312,E14001511,E06000052,E06000052
+2024,2024,Bowerhill,Melksham and Devizes,Wiltshire,Wiltshire,E05013832,E14001356,E06000054,E06000054
+2024,2024,"Mylor, Perranarworthal & Ponsanooth",Truro and Falmouth,Cornwall,Cornwall,E05013313,E14001554,E06000052,E06000052
+2024,2024,Melksham East,Melksham and Devizes,Wiltshire,Wiltshire,E05013833,E14001356,E06000054,E06000054
+2024,2024,Newquay Central & Pentire,St Austell and Newquay,Cornwall,Cornwall,E05013314,E14001508,E06000052,E06000052
+2024,2024,Pewsey,East Wiltshire,Wiltshire,Wiltshire,E05013834,E14001217,E06000054,E06000054
+2024,2024,Newquay Porth & Tretherras,St Austell and Newquay,Cornwall,Cornwall,E05013315,E14001508,E06000052,E06000052
+2024,2024,Pewsey Vale West,East Wiltshire,Wiltshire,Wiltshire,E05013835,E14001217,E06000054,E06000054
+2024,2024,Padstow,North Cornwall,Cornwall,Cornwall,E05013317,E14001385,E06000052,E06000052
+2024,2024,Biddenham,North Bedfordshire,Bedford,Bedford,E05014491,E14001384,E06000055,E06000055
+2024,2024,Penwithick & Boscoppa,St Austell and Newquay,Cornwall,Cornwall,E05013319,E14001508,E06000052,E06000052
+2024,2024,Arlesey & Fairfield,Hitchin,Central Bedfordshire,Central Bedfordshire,E05014395,E14001289,E06000056,E06000056
+2024,2024,Penzance East,St Ives,Cornwall,Cornwall,E05013320,E14001511,E06000052,E06000052
+2024,2024,Brickhill,Bedford,Bedford,Bedford,E05014492,E14001084,E06000055,E06000055
+2024,2024,Penzance Promenade,St Ives,Cornwall,Cornwall,E05013321,E14001511,E06000052,E06000052
+2024,2024,Aspley & Woburn,Mid Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014396,E14001359,E06000056,E06000056
+2024,2024,"Redruth Central, Carharrack & St Day",Camborne and Redruth,Cornwall,Cornwall,E05013851,E14001148,E06000052,E06000052
+2024,2024,Pool & Tehidy,Camborne and Redruth,Cornwall,Cornwall,E05013323,E14001148,E06000052,E06000052
+2024,2024,St Agnes,Camborne and Redruth,Cornwall,Cornwall,E05013852,E14001148,E06000052,E06000052
+2024,2024,"Porthleven, Breage & Germoe",St Ives,Cornwall,Cornwall,E05013324,E14001511,E06000052,E06000052
+2024,2024,St Austell Bethel & Holmbush,St Austell and Newquay,Cornwall,Cornwall,E05013853,E14001508,E06000052,E06000052
+2024,2024,Barton-le-Clay & Silsoe,Mid Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014397,E14001359,E06000056,E06000056
+2024,2024,Poundstock,North Cornwall,Cornwall,Cornwall,E05013325,E14001385,E06000052,E06000052
+2024,2024,St Austell Central & Gover,St Austell and Newquay,Cornwall,Cornwall,E05013854,E14001508,E06000052,E06000052
+2024,2024,Biggleswade East,North Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014398,E14001384,E06000056,E06000056
+2024,2024,Brickhill,North Bedfordshire,Bedford,Bedford,E05014492,E14001384,E06000055,E06000055
+2024,2024,Rame Peninsula & St Germans,South East Cornwall,Cornwall,Cornwall,E05013327,E14001486,E06000052,E06000052
+2024,2024,St Columb Minor & Colan,St Austell and Newquay,Cornwall,Cornwall,E05013855,E14001508,E06000052,E06000052
+2024,2024,Biggleswade West,North Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014399,E14001384,E06000056,E06000056
+2024,2024,Bromham,North Bedfordshire,Bedford,Bedford,E05014493,E14001384,E06000055,E06000055
+2024,2024,Redruth North,Camborne and Redruth,Cornwall,Cornwall,E05013329,E14001148,E06000052,E06000052
+2024,2024,St Dennis & St Enoder,St Austell and Newquay,Cornwall,Cornwall,E05013856,E14001508,E06000052,E06000052
+2024,2024,Caddington,Luton South and South Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014400,E14001346,E06000056,E06000056
+2024,2024,Castle & Newnham,Bedford,Bedford,Bedford,E05014494,E14001084,E06000055,E06000055
+2024,2024,Redruth South,Camborne and Redruth,Cornwall,Cornwall,E05013330,E14001148,E06000052,E06000052
+2024,2024,"St Ives East, Lelant & Carbis Bay",St Ives,Cornwall,Cornwall,E05013857,E14001511,E06000052,E06000052
+2024,2024,"Clifton, Henlow & Langford",Hitchin,Central Bedfordshire,Central Bedfordshire,E05014401,E14001289,E06000056,E06000056
+2024,2024,Cauldwell,Bedford,Bedford,Bedford,E05014495,E14001084,E06000055,E06000055
+2024,2024,Roche & Bugle,St Austell and Newquay,Cornwall,Cornwall,E05013331,E14001508,E06000052,E06000052
+2024,2024,St Ives West & Towednack,St Ives,Cornwall,Cornwall,E05013858,E14001511,E06000052,E06000052
+2024,2024,Cranfield & Marston Moretaine,Mid Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014402,E14001359,E06000056,E06000056
+2024,2024,Cauldwell,Mid Bedfordshire,Bedford,Bedford,E05014495,E14001359,E06000055,E06000055
+2024,2024,St Blazey,St Austell and Newquay,Cornwall,Cornwall,E05013336,E14001508,E06000052,E06000052
+2024,2024,St Mewan & Grampound,St Austell and Newquay,Cornwall,Cornwall,E05013859,E14001508,E06000052,E06000052
+2024,2024,Dunstable Central,Dunstable and Leighton Buzzard,Central Bedfordshire,Central Bedfordshire,E05014403,E14001206,E06000056,E06000056
+2024,2024,Clapham & Oakley,North Bedfordshire,Bedford,Bedford,E05014496,E14001384,E06000055,E06000055
+2024,2024,St Cleer & Menheniot,South East Cornwall,Cornwall,Cornwall,E05013337,E14001486,E06000052,E06000052
+2024,2024,St Mewan & Grampound,Truro and Falmouth,Cornwall,Cornwall,E05013859,E14001554,E06000052,E06000052
+2024,2024,Dunstable East,Dunstable and Leighton Buzzard,Central Bedfordshire,Central Bedfordshire,E05014404,E14001206,E06000056,E06000056
+2024,2024,De Parys,Bedford,Bedford,Bedford,E05014497,E14001084,E06000055,E06000055
+2024,2024,"St Columb Major, St Mawgan & St Wenn",North Cornwall,Cornwall,Cornwall,E05013338,E14001385,E06000052,E06000052
+2024,2024,Goldington,Bedford,Bedford,Bedford,E05014498,E14001084,E06000055,E06000055
+2024,2024,Dunstable North,Dunstable and Leighton Buzzard,Central Bedfordshire,Central Bedfordshire,E05014405,E14001206,E06000056,E06000056
+2024,2024,"St Goran, Tregony & the Roseland",Truro and Falmouth,Cornwall,Cornwall,E05013341,E14001554,E06000052,E06000052
+2024,2024,Great Barford,North Bedfordshire,Bedford,Bedford,E05014499,E14001384,E06000055,E06000055
+2024,2024,Dunstable South,Dunstable and Leighton Buzzard,Central Bedfordshire,Central Bedfordshire,E05014406,E14001206,E06000056,E06000056
+2024,2024,"St Newlyn East, Cubert & Goonhavern",St Austell and Newquay,Cornwall,Cornwall,E05013860,E14001508,E06000052,E06000052
+2024,2024,St Stephen-in-Brannel,St Austell and Newquay,Cornwall,Cornwall,E05013346,E14001508,E06000052,E06000052
+2024,2024,Great Denham,North Bedfordshire,Bedford,Bedford,E05014500,E14001384,E06000055,E06000055
+2024,2024,Dunstable West,Dunstable and Leighton Buzzard,Central Bedfordshire,Central Bedfordshire,E05014407,E14001206,E06000056,E06000056
+2024,2024,"St Newlyn East, Cubert & Goonhavern",Truro and Falmouth,Cornwall,Cornwall,E05013860,E14001554,E06000052,E06000052
+2024,2024,St Teath & Tintagel,North Cornwall,Cornwall,Cornwall,E05013347,E14001385,E06000052,E06000052
+2024,2024,Greyfriars,Bedford,Bedford,Bedford,E05014501,E14001084,E06000055,E06000055
+2024,2024,Eaton Bray,Luton South and South Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014408,E14001346,E06000056,E06000056
+2024,2024,Threemilestone & Chacewater,Truro and Falmouth,Cornwall,Cornwall,E05013861,E14001554,E06000052,E06000052
+2024,2024,Saltash Essa,South East Cornwall,Cornwall,Cornwall,E05013348,E14001486,E06000052,E06000052
+2024,2024,Harpur,Bedford,Bedford,Bedford,E05014502,E14001084,E06000055,E06000055
+2024,2024,Flitwick,Mid Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014409,E14001359,E06000056,E06000056
+2024,2024,Bryher,St Ives,Isles of Scilly,Isles of Scilly,E05011090,E14001511,E06000053,E06000053
+2024,2024,Saltash Tamar,South East Cornwall,Cornwall,Cornwall,E05013349,E14001486,E06000052,E06000052
+2024,2024,Harpur,North Bedfordshire,Bedford,Bedford,E05014502,E14001384,E06000055,E06000055
+2024,2024,Heath & Reach,Dunstable and Leighton Buzzard,Central Bedfordshire,Central Bedfordshire,E05014410,E14001206,E06000056,E06000056
+2024,2024,St Agnes,St Ives,Isles of Scilly,Isles of Scilly,E05011091,E14001511,E06000053,E06000053
+2024,2024,Saltash Trematon & Landrake,South East Cornwall,Cornwall,Cornwall,E05013350,E14001486,E06000052,E06000052
+2024,2024,Harrold,North Bedfordshire,Bedford,Bedford,E05014503,E14001384,E06000055,E06000055
+2024,2024,Houghton Conquest & Haynes,Mid Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014411,E14001359,E06000056,E06000056
+2024,2024,St Martin's,St Ives,Isles of Scilly,Isles of Scilly,E05011092,E14001511,E06000053,E06000053
+2024,2024,"Stratton, Kilkhampton & Morwenstow",North Cornwall,Cornwall,Cornwall,E05013351,E14001385,E06000052,E06000052
+2024,2024,Kempston Central & East,Bedford,Bedford,Bedford,E05014504,E14001084,E06000055,E06000055
+2024,2024,Houghton Regis East,Dunstable and Leighton Buzzard,Central Bedfordshire,Central Bedfordshire,E05014412,E14001206,E06000056,E06000056
+2024,2024,Torpoint,South East Cornwall,Cornwall,Cornwall,E05013353,E14001486,E06000052,E06000052
+2024,2024,Houghton Regis West,Dunstable and Leighton Buzzard,Central Bedfordshire,Central Bedfordshire,E05014413,E14001206,E06000056,E06000056
+2024,2024,Kempston North,Bedford,Bedford,Bedford,E05014505,E14001084,E06000055,E06000055
+2024,2024,St Mary's,St Ives,Isles of Scilly,Isles of Scilly,E05011093,E14001511,E06000053,E06000053
+2024,2024,Truro Boscawen & Redannick,Truro and Falmouth,Cornwall,Cornwall,E05013354,E14001554,E06000052,E06000052
+2024,2024,Tresco,St Ives,Isles of Scilly,Isles of Scilly,E05011094,E14001511,E06000053,E06000053
+2024,2024,Truro Moresk & Trehaverne,Truro and Falmouth,Cornwall,Cornwall,E05013355,E14001554,E06000052,E06000052
+2024,2024,Aldbourne & Ramsbury,East Wiltshire,Wiltshire,Wiltshire,E05013398,E14001217,E06000054,E06000054
+2024,2024,Kempston South,Bedford,Bedford,Bedford,E05014506,E14001084,E06000055,E06000055
+2024,2024,Truro Tregolls,Truro and Falmouth,Cornwall,Cornwall,E05013356,E14001554,E06000052,E06000052
+2024,2024,Alderbury & Whiteparish,Salisbury,Wiltshire,Wiltshire,E05013399,E14001460,E06000054,E06000054
+2024,2024,Kempston West,Bedford,Bedford,Bedford,E05014507,E14001084,E06000055,E06000055
+2024,2024,Leighton-Linslade North,Dunstable and Leighton Buzzard,Central Bedfordshire,Central Bedfordshire,E05014414,E14001206,E06000056,E06000056
+2024,2024,Wadebridge East & St Minver,North Cornwall,Cornwall,Cornwall,E05013357,E14001385,E06000052,E06000052
+2024,2024,Amesbury East & Bulford,East Wiltshire,Wiltshire,Wiltshire,E05013400,E14001217,E06000054,E06000054
+2024,2024,Kempston West,North Bedfordshire,Bedford,Bedford,E05014507,E14001384,E06000055,E06000055
+2024,2024,Leighton-Linslade South,Dunstable and Leighton Buzzard,Central Bedfordshire,Central Bedfordshire,E05014415,E14001206,E06000056,E06000056
+2024,2024,Wadebridge West & St Mabyn,North Cornwall,Cornwall,Cornwall,E05013358,E14001385,E06000052,E06000052
+2024,2024,Amesbury South,East Wiltshire,Wiltshire,Wiltshire,E05013401,E14001217,E06000054,E06000054
+2024,2024,Kingsbrook,Bedford,Bedford,Bedford,E05014508,E14001084,E06000055,E06000055
+2024,2024,Leighton-Linslade West,Dunstable and Leighton Buzzard,Central Bedfordshire,Central Bedfordshire,E05014416,E14001206,E06000056,E06000056
+2024,2024,St Austell Poltair & Mount Charles,St Austell and Newquay,Cornwall,Cornwall,E05013836,E14001508,E06000052,E06000052
+2024,2024,Amesbury West,East Wiltshire,Wiltshire,Wiltshire,E05013402,E14001217,E06000054,E06000054
+2024,2024,Putnoe,Bedford,Bedford,Bedford,E05014509,E14001084,E06000055,E06000055
+2024,2024,Meppershall & Shillington,Hitchin,Central Bedfordshire,Central Bedfordshire,E05014417,E14001289,E06000056,E06000056
+2024,2024,Altarnun & Stoke Climsland,North Cornwall,Cornwall,Cornwall,E05013837,E14001385,E06000052,E06000052
+2024,2024,Avon Valley,East Wiltshire,Wiltshire,Wiltshire,E05013403,E14001217,E06000054,E06000054
+2024,2024,Queens Park,Bedford,Bedford,Bedford,E05014510,E14001084,E06000055,E06000055
+2024,2024,Meppershall & Shillington,Mid Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014417,E14001359,E06000056,E06000056
+2024,2024,"Crowan, Sithney & Wendron",St Ives,Cornwall,Cornwall,E05013838,E14001511,E06000052,E06000052
+2024,2024,Box & Colerne,Melksham and Devizes,Wiltshire,Wiltshire,E05013405,E14001356,E06000054,E06000054
+2024,2024,Renhold & Ravensden,Bedford,Bedford,Bedford,E05014511,E14001084,E06000055,E06000055
+2024,2024,Northill,North Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014418,E14001384,E06000056,E06000056
+2024,2024,Falmouth Boslowick,Truro and Falmouth,Cornwall,Cornwall,E05013839,E14001554,E06000052,E06000052
+2024,2024,Bradford-on-Avon North,Melksham and Devizes,Wiltshire,Wiltshire,E05013406,E14001356,E06000054,E06000054
+2024,2024,Renhold & Ravensden,North Bedfordshire,Bedford,Bedford,E05014511,E14001384,E06000055,E06000055
+2024,2024,Potton,North Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014419,E14001384,E06000056,E06000056
+2024,2024,Falmouth Trescobeas & Budock,Truro and Falmouth,Cornwall,Cornwall,E05013840,E14001554,E06000052,E06000052
+2024,2024,Sandy,North Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014420,E14001384,E06000056,E06000056
+2024,2024,Riseley,North Bedfordshire,Bedford,Bedford,E05014512,E14001384,E06000055,E06000055
+2024,2024,Helston North,St Ives,Cornwall,Cornwall,E05013841,E14001511,E06000052,E06000052
+2024,2024,Shefford,Hitchin,Central Bedfordshire,Central Bedfordshire,E05014421,E14001289,E06000056,E06000056
+2024,2024,Riverfield,Bedford,Bedford,Bedford,E05014513,E14001084,E06000055,E06000055
+2024,2024,Bradford-on-Avon South,Melksham and Devizes,Wiltshire,Wiltshire,E05013407,E14001356,E06000054,E06000054
+2024,2024,Illogan & Portreath,Camborne and Redruth,Cornwall,Cornwall,E05013842,E14001148,E06000052,E06000052
+2024,2024,Stotfold,Hitchin,Central Bedfordshire,Central Bedfordshire,E05014422,E14001289,E06000056,E06000056
+2024,2024,Sharnbrook,North Bedfordshire,Bedford,Bedford,E05014514,E14001384,E06000055,E06000055
+2024,2024,Brinkworth,South Cotswolds,Wiltshire,Wiltshire,E05013408,E14001482,E06000054,E06000054
+2024,2024,"Lanner, Stithians & Gwennap",Camborne and Redruth,Cornwall,Cornwall,E05013843,E14001148,E06000052,E06000052
+2024,2024,Toddington,Mid Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014423,E14001359,E06000056,E06000056
+2024,2024,Shortstown,North Bedfordshire,Bedford,Bedford,E05014515,E14001384,E06000055,E06000055
+2024,2024,"Bromham, Rowde & Roundway",Melksham and Devizes,Wiltshire,Wiltshire,E05013409,E14001356,E06000054,E06000054
+2024,2024,Launceston North & North Petherwin,North Cornwall,Cornwall,Cornwall,E05013844,E14001385,E06000052,E06000052
+2024,2024,"Westoning, Flitton & Greenfield",Mid Bedfordshire,Central Bedfordshire,Central Bedfordshire,E05014424,E14001359,E06000056,E06000056
+2024,2024,Wixams & Wilstead,Mid Bedfordshire,Bedford,Bedford,E05014516,E14001359,E06000055,E06000055
+2024,2024,By Brook,South Cotswolds,Wiltshire,Wiltshire,E05013410,E14001482,E06000054,E06000054
+2024,2024,"Long Rock, Marazion & St Erth",St Ives,Cornwall,Cornwall,E05013845,E14001511,E06000052,E06000052
+2024,2024,Alnwick,North Northumberland,Northumberland,Northumberland,E05009093,E14001397,E06000057,E06000057
+2024,2024,Wootton & Kempston Rural,North Bedfordshire,Bedford,Bedford,E05014517,E14001384,E06000055,E06000055
+2024,2024,Calne Central,Chippenham,Wiltshire,Wiltshire,E05013411,E14001168,E06000054,E06000054
+2024,2024,Mevagissey & St Austell Bay,St Austell and Newquay,Cornwall,Cornwall,E05013846,E14001508,E06000052,E06000052
+2024,2024,Amble,North Northumberland,Northumberland,Northumberland,E05009094,E14001397,E06000057,E06000057
+2024,2024,Calne Chilvester & Abberd,Chippenham,Wiltshire,Wiltshire,E05013412,E14001168,E06000054,E06000054
+2024,2024,Newquay Trenance,St Austell and Newquay,Cornwall,Cornwall,E05013847,E14001508,E06000052,E06000052
+2024,2024,Amble West with Warkworth,North Northumberland,Northumberland,Northumberland,E05009095,E14001397,E06000057,E06000057
+2024,2024,Calne North,Chippenham,Wiltshire,Wiltshire,E05013413,E14001168,E06000054,E06000054
+2024,2024,Calne Rural,Chippenham,Wiltshire,Wiltshire,E05013414,E14001168,E06000054,E06000054
+2024,2024,Penryn,Truro and Falmouth,Cornwall,Cornwall,E05013848,E14001554,E06000052,E06000052
+2024,2024,Perranporth,Camborne and Redruth,Cornwall,Cornwall,E05013849,E14001148,E06000052,E06000052
+2024,2024,Calne South,Melksham and Devizes,Wiltshire,Wiltshire,E05013415,E14001356,E06000054,E06000054
+2024,2024,Ashington Central,Blyth and Ashington,Northumberland,Northumberland,E05009096,E14001107,E06000057,E06000057
+2024,2024,Bamburgh,North Northumberland,Northumberland,Northumberland,E05009097,E14001397,E06000057,E06000057
+2024,2024,Bedlington Central,Blyth and Ashington,Northumberland,Northumberland,E05009098,E14001107,E06000057,E06000057
+2024,2024,Bedlington East,Blyth and Ashington,Northumberland,Northumberland,E05009099,E14001107,E06000057,E06000057
+2024,2024,Bedlington West,Blyth and Ashington,Northumberland,Northumberland,E05009100,E14001107,E06000057,E06000057
+2024,2024,Bellingham,Hexham,Northumberland,Northumberland,E05009101,E14001285,E06000057,E06000057
+2024,2024,Berwick East,North Northumberland,Northumberland,Northumberland,E05009102,E14001397,E06000057,E06000057
+2024,2024,Berwick North,North Northumberland,Northumberland,Northumberland,E05009103,E14001397,E06000057,E06000057
+2024,2024,Berwick West with Ord,North Northumberland,Northumberland,Northumberland,E05009104,E14001397,E06000057,E06000057
+2024,2024,Bywell,Hexham,Northumberland,Northumberland,E05009106,E14001285,E06000057,E06000057
+2024,2024,Choppington,Blyth and Ashington,Northumberland,Northumberland,E05009107,E14001107,E06000057,E06000057
+2024,2024,College,Blyth and Ashington,Northumberland,Northumberland,E05009108,E14001107,E06000057,E06000057
+2024,2024,Corbridge,Hexham,Northumberland,Northumberland,E05009109,E14001285,E06000057,E06000057
+2024,2024,Cowpen,Blyth and Ashington,Northumberland,Northumberland,E05009110,E14001107,E06000057,E06000057
+2024,2024,Chippenham Cepen Park & Derriads,Chippenham,Wiltshire,Wiltshire,E05013416,E14001168,E06000054,E06000054
+2024,2024,Chippenham Cepen Park & Hunters Moon,Chippenham,Wiltshire,Wiltshire,E05013417,E14001168,E06000054,E06000054
+2024,2024,Chippenham Hardenhuish,Chippenham,Wiltshire,Wiltshire,E05013418,E14001168,E06000054,E06000054
+2024,2024,Chippenham Hardens & Central,Chippenham,Wiltshire,Wiltshire,E05013419,E14001168,E06000054,E06000054
+2024,2024,Chippenham Lowden & Rowden,Chippenham,Wiltshire,Wiltshire,E05013420,E14001168,E06000054,E06000054
+2024,2024,Chippenham Monkton,Chippenham,Wiltshire,Wiltshire,E05013421,E14001168,E06000054,E06000054
+2024,2024,Chippenham Pewsham,Chippenham,Wiltshire,Wiltshire,E05013422,E14001168,E06000054,E06000054
+2024,2024,Chippenham Sheldon,Chippenham,Wiltshire,Wiltshire,E05013423,E14001168,E06000054,E06000054
+2024,2024,Corsham Ladbrook,Chippenham,Wiltshire,Wiltshire,E05013424,E14001168,E06000054,E06000054
+2024,2024,Corsham Pickwick,Chippenham,Wiltshire,Wiltshire,E05013425,E14001168,E06000054,E06000054
+2024,2024,Corsham Without,Chippenham,Wiltshire,Wiltshire,E05013426,E14001168,E06000054,E06000054
+2024,2024,Cricklade & Latton,South Cotswolds,Wiltshire,Wiltshire,E05013427,E14001482,E06000054,E06000054
+2024,2024,Devizes East,Melksham and Devizes,Wiltshire,Wiltshire,E05013428,E14001356,E06000054,E06000054
+2024,2024,Cramlington East,Cramlington and Killingworth,Northumberland,Northumberland,E05009111,E14001183,E06000057,E06000057
+2024,2024,Cramlington Eastfield,Cramlington and Killingworth,Northumberland,Northumberland,E05009112,E14001183,E06000057,E06000057
+2024,2024,Cramlington North,Cramlington and Killingworth,Northumberland,Northumberland,E05009113,E14001183,E06000057,E06000057
+2024,2024,Cramlington South East,Cramlington and Killingworth,Northumberland,Northumberland,E05009114,E14001183,E06000057,E06000057
+2024,2024,Cramlington Village,Cramlington and Killingworth,Northumberland,Northumberland,E05009115,E14001183,E06000057,E06000057
+2024,2024,Cramlington West,Cramlington and Killingworth,Northumberland,Northumberland,E05009116,E14001183,E06000057,E06000057
+2024,2024,Croft,Blyth and Ashington,Northumberland,Northumberland,E05009117,E14001107,E06000057,E06000057
+2024,2024,Druridge Bay,North Northumberland,Northumberland,Northumberland,E05009118,E14001397,E06000057,E06000057
+2024,2024,Haltwhistle,Hexham,Northumberland,Northumberland,E05009119,E14001285,E06000057,E06000057
+2024,2024,Hartley,Cramlington and Killingworth,Northumberland,Northumberland,E05009120,E14001183,E06000057,E06000057
+2024,2024,Haydon,Blyth and Ashington,Northumberland,Northumberland,E05009121,E14001107,E06000057,E06000057
+2024,2024,Haydon and Hadrian,Hexham,Northumberland,Northumberland,E05009122,E14001285,E06000057,E06000057
+2024,2024,Hexham Central with Acomb,Hexham,Northumberland,Northumberland,E05009123,E14001285,E06000057,E06000057
+2024,2024,Hexham East,Hexham,Northumberland,Northumberland,E05009124,E14001285,E06000057,E06000057
+2024,2024,Hexham West,Hexham,Northumberland,Northumberland,E05009125,E14001285,E06000057,E06000057
+2024,2024,Hirst,Blyth and Ashington,Northumberland,Northumberland,E05009126,E14001107,E06000057,E06000057
+2024,2024,Holywell,Cramlington and Killingworth,Northumberland,Northumberland,E05009127,E14001183,E06000057,E06000057
+2024,2024,Humshaugh,Hexham,Northumberland,Northumberland,E05009128,E14001285,E06000057,E06000057
+2024,2024,Isabella,Blyth and Ashington,Northumberland,Northumberland,E05009129,E14001107,E06000057,E06000057
+2024,2024,Kitty Brewster,Blyth and Ashington,Northumberland,Northumberland,E05009130,E14001107,E06000057,E06000057
+2024,2024,Longhorsley,Hexham,Northumberland,Northumberland,E05009131,E14001285,E06000057,E06000057
+2024,2024,Longhoughton,North Northumberland,Northumberland,Northumberland,E05009132,E14001397,E06000057,E06000057
+2024,2024,Lynemouth,North Northumberland,Northumberland,Northumberland,E05009133,E14001397,E06000057,E06000057
+2024,2024,Morpeth Kirkhill,North Northumberland,Northumberland,Northumberland,E05009134,E14001397,E06000057,E06000057
+2024,2024,Morpeth North,North Northumberland,Northumberland,Northumberland,E05009135,E14001397,E06000057,E06000057
+2024,2024,Morpeth Stobhill,North Northumberland,Northumberland,Northumberland,E05009136,E14001397,E06000057,E06000057
+2024,2024,Newbiggin Central and East,Blyth and Ashington,Northumberland,Northumberland,E05009137,E14001107,E06000057,E06000057
+2024,2024,Norham and Islandshires,North Northumberland,Northumberland,Northumberland,E05009139,E14001397,E06000057,E06000057
+2024,2024,Plessey,Blyth and Ashington,Northumberland,Northumberland,E05009141,E14001107,E06000057,E06000057
+2024,2024,Ponteland East and Stannington,Hexham,Northumberland,Northumberland,E05009142,E14001285,E06000057,E06000057
+2024,2024,Ponteland North,Hexham,Northumberland,Northumberland,E05009143,E14001285,E06000057,E06000057
+2024,2024,Ponteland South with Heddon,Hexham,Northumberland,Northumberland,E05009144,E14001285,E06000057,E06000057
+2024,2024,Ponteland West,Hexham,Northumberland,Northumberland,E05009145,E14001285,E06000057,E06000057
+2024,2024,Prudhoe North,Hexham,Northumberland,Northumberland,E05009146,E14001285,E06000057,E06000057
+2024,2024,Prudhoe South,Hexham,Northumberland,Northumberland,E05009147,E14001285,E06000057,E06000057
+2024,2024,Rothbury,North Northumberland,Northumberland,Northumberland,E05009148,E14001397,E06000057,E06000057
+2024,2024,Seaton with Newbiggin West,Blyth and Ashington,Northumberland,Northumberland,E05009149,E14001107,E06000057,E06000057
+2024,2024,Shilbottle,North Northumberland,Northumberland,Northumberland,E05009151,E14001397,E06000057,E06000057
+2024,2024,Sleekburn,Blyth and Ashington,Northumberland,Northumberland,E05009152,E14001107,E06000057,E06000057
+2024,2024,South Blyth,Blyth and Ashington,Northumberland,Northumberland,E05009153,E14001107,E06000057,E06000057
+2024,2024,South Tynedale,Hexham,Northumberland,Northumberland,E05009154,E14001285,E06000057,E06000057
+2024,2024,Stakeford,Blyth and Ashington,Northumberland,Northumberland,E05009155,E14001107,E06000057,E06000057
+2024,2024,Stocksfield and Broomhaugh,Hexham,Northumberland,Northumberland,E05009156,E14001285,E06000057,E06000057
+2024,2024,Wensleydale,Blyth and Ashington,Northumberland,Northumberland,E05009157,E14001107,E06000057,E06000057
+2024,2024,Wooler,North Northumberland,Northumberland,Northumberland,E05009158,E14001397,E06000057,E06000057
+2024,2024,Newsham,Blyth and Ashington,Northumberland,Northumberland,E05013270,E14001107,E06000057,E06000057
+2024,2024,Seghill with Seaton Delaval,Cramlington and Killingworth,Northumberland,Northumberland,E05013271,E14001183,E06000057,E06000057
+2024,2024,Bothal,Blyth and Ashington,Northumberland,Northumberland,E05013862,E14001107,E06000057,E06000057
+2024,2024,Pegswood,North Northumberland,Northumberland,Northumberland,E05013863,E14001397,E06000057,E06000057
+2024,2024,Alderney & Bourne Valley,Bournemouth West,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012649,E14001116,E06000058,E06000058
+2024,2024,Bearwood & Merley,Mid Dorset and North Poole,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012650,E14001363,E06000058,E06000058
+2024,2024,Boscombe East & Pokesdown,Bournemouth East,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012651,E14001115,E06000058,E06000058
+2024,2024,Boscombe West,Bournemouth East,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012652,E14001115,E06000058,E06000058
+2024,2024,Bournemouth Central,Bournemouth West,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012653,E14001116,E06000058,E06000058
+2024,2024,Broadstone,Mid Dorset and North Poole,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012654,E14001363,E06000058,E06000058
+2024,2024,Burton & Grange,Christchurch,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012655,E14001171,E06000058,E06000058
+2024,2024,Canford Cliffs,Poole,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012656,E14001429,E06000058,E06000058
+2024,2024,Canford Heath,Mid Dorset and North Poole,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012657,E14001363,E06000058,E06000058
+2024,2024,Christchurch Town,Christchurch,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012658,E14001171,E06000058,E06000058
+2024,2024,Commons,Christchurch,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012659,E14001171,E06000058,E06000058
+2024,2024,Creekmoor,Poole,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012660,E14001429,E06000058,E06000058
+2024,2024,East Cliff & Springbourne,Bournemouth East,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012661,E14001115,E06000058,E06000058
+2024,2024,East Southbourne & Tuckton,Bournemouth East,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012662,E14001115,E06000058,E06000058
+2024,2024,Hamworthy,Poole,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012663,E14001429,E06000058,E06000058
+2024,2024,Highcliffe & Walkford,Christchurch,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012664,E14001171,E06000058,E06000058
+2024,2024,Kinson,Bournemouth West,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012665,E14001116,E06000058,E06000058
+2024,2024,Littledown & Iford,Bournemouth East,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012666,E14001115,E06000058,E06000058
+2024,2024,Moordown,Bournemouth East,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012667,E14001115,E06000058,E06000058
+2024,2024,"Mudeford, Stanpit & West Highcliffe",Christchurch,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012668,E14001171,E06000058,E06000058
+2024,2024,Muscliff & Strouden Park,Bournemouth East,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012669,E14001115,E06000058,E06000058
+2024,2024,Newtown & Heatherlands,Poole,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012670,E14001429,E06000058,E06000058
+2024,2024,Oakdale,Poole,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012671,E14001429,E06000058,E06000058
+2024,2024,Parkstone,Poole,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012672,E14001429,E06000058,E06000058
+2024,2024,Penn Hill,Poole,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012673,E14001429,E06000058,E06000058
+2024,2024,Poole Town,Poole,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012674,E14001429,E06000058,E06000058
+2024,2024,Queen's Park,Bournemouth East,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012675,E14001115,E06000058,E06000058
+2024,2024,Redhill & Northbourne,Bournemouth West,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012676,E14001116,E06000058,E06000058
+2024,2024,Talbot & Branksome Woods,Bournemouth West,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012677,E14001116,E06000058,E06000058
+2024,2024,Wallisdown & Winton West,Bournemouth West,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012678,E14001116,E06000058,E06000058
+2024,2024,West Southbourne,Bournemouth East,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012679,E14001115,E06000058,E06000058
+2024,2024,Westbourne & West Cliff,Bournemouth West,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012680,E14001116,E06000058,E06000058
+2024,2024,Winton East,Bournemouth West,"Bournemouth, Christchurch and Poole","Bournemouth, Christchurch and Poole",E05012681,E14001116,E06000058,E06000058
+2024,2024,Beacon,North Dorset,Dorset,Dorset,E05012682,E14001388,E06000059,E06000059
+2024,2024,Beaminster,West Dorset,Dorset,Dorset,E05012683,E14001575,E06000059,E06000059
+2024,2024,Blackmore Vale,North Dorset,Dorset,Dorset,E05012684,E14001388,E06000059,E06000059
+2024,2024,Blandford,North Dorset,Dorset,Dorset,E05012685,E14001388,E06000059,E06000059
+2024,2024,Chalk Valleys,West Dorset,Dorset,Dorset,E05012687,E14001575,E06000059,E06000059
+2024,2024,Charminster St Mary's,West Dorset,Dorset,Dorset,E05012688,E14001575,E06000059,E06000059
+2024,2024,Chickerell,South Dorset,Dorset,Dorset,E05012690,E14001485,E06000059,E06000059
+2024,2024,Colehill & Wimborne Minster East,Mid Dorset and North Poole,Dorset,Dorset,E05012691,E14001363,E06000059,E06000059
+2024,2024,Corfe Mullen,Mid Dorset and North Poole,Dorset,Dorset,E05012692,E14001363,E06000059,E06000059
+2024,2024,Cranborne & Alderholt,North Dorset,Dorset,Dorset,E05012693,E14001388,E06000059,E06000059
+2024,2024,Cranborne Chase,North Dorset,Dorset,Dorset,E05012694,E14001388,E06000059,E06000059
+2024,2024,Crossways,South Dorset,Dorset,Dorset,E05012695,E14001485,E06000059,E06000059
+2024,2024,Dorchester East,West Dorset,Dorset,Dorset,E05012696,E14001575,E06000059,E06000059
+2024,2024,Dorchester Poundbury,West Dorset,Dorset,Dorset,E05012697,E14001575,E06000059,E06000059
+2024,2024,Dorchester West,West Dorset,Dorset,Dorset,E05012698,E14001575,E06000059,E06000059
+2024,2024,Ferndown North,Christchurch,Dorset,Dorset,E05012700,E14001171,E06000059,E06000059
+2024,2024,Ferndown South,Christchurch,Dorset,Dorset,E05012701,E14001171,E06000059,E06000059
+2024,2024,Gillingham,North Dorset,Dorset,Dorset,E05012702,E14001388,E06000059,E06000059
+2024,2024,Chalfont St Peter,Chesham and Amersham,Buckinghamshire,Buckinghamshire,E05013135,E14001162,E06000060,E06000060
+2024,2024,Irchester,Wellingborough and Rushden,North Northamptonshire,North Northamptonshire,E05013224,E14001571,E06000061,E06000061
+2024,2024,Scotton & Lower Wensleydale,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014312,E14001444,E06000065,E06000065
+2024,2024,Catterick Village & Brompton-on-Swale,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014263,E14001444,E06000065,E06000065
+2024,2024,Cawood & Escrick,Selby,North Yorkshire,North Yorkshire,E05014264,E14001464,E06000065,E06000065
+2024,2024,Cayton,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014265,E14001461,E06000065,E06000065
+2024,2024,Cliffe & North Duffield,Selby,North Yorkshire,North Yorkshire,E05014266,E14001464,E06000065,E06000065
+2024,2024,Coppice Valley & Duchy,Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014267,E14001269,E06000065,E06000065
+2024,2024,Danby & Mulgrave,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014268,E14001461,E06000065,E06000065
+2024,2024,Derwent Valley & Moor,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014269,E14001461,E06000065,E06000065
+2024,2024,Easingwold,Wetherby and Easingwold,North Yorkshire,North Yorkshire,E05014270,E14001582,E06000065,E06000065
+2024,2024,Eastfield,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014271,E14001461,E06000065,E06000065
+2024,2024,Esk Valley & Coast,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014272,E14001461,E06000065,E06000065
+2024,2024,Fairfax & Starbeck,Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014273,E14001269,E06000065,E06000065
+2024,2024,Falsgrave & Stepney,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014274,E14001461,E06000065,E06000065
+2024,2024,Filey,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014275,E14001544,E06000065,E06000065
+2024,2024,Great Ayton,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014276,E14001444,E06000065,E06000065
+2024,2024,"Glusburn, Cross Hills & Sutton-in-Craven",Skipton and Ripon,North Yorkshire,North Yorkshire,E05014277,E14001475,E06000065,E06000065
+2024,2024,Harlow & St. Georges,Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014278,E14001269,E06000065,E06000065
+2024,2024,High Harrogate & Kingsley,Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014279,E14001269,E06000065,E06000065
+2024,2024,Hipswell & Colburn,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014280,E14001444,E06000065,E06000065
+2024,2024,Helmsley & Sinnington,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014281,E14001544,E06000065,E06000065
+2024,2024,Hillside & Raskelf,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014282,E14001544,E06000065,E06000065
+2024,2024,Hillside & Raskelf,Wetherby and Easingwold,North Yorkshire,North Yorkshire,E05014282,E14001582,E06000065,E06000065
+2024,2024,Huby & Tollerton,Wetherby and Easingwold,North Yorkshire,North Yorkshire,E05014283,E14001582,E06000065,E06000065
+2024,2024,Hunmanby & Sherburn,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014284,E14001544,E06000065,E06000065
+2024,2024,Hutton Rudby & Osmotherley,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014285,E14001444,E06000065,E06000065
+2024,2024,"Killinghall, Hampsthwaite & Saltergate",Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014286,E14001269,E06000065,E06000065
+2024,2024,Kirkbymoorside & Dales,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014287,E14001544,E06000065,E06000065
+2024,2024,Knaresborough East,Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014288,E14001269,E06000065,E06000065
+2024,2024,Knaresborough West,Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014289,E14001269,E06000065,E06000065
+2024,2024,Leyburn & Middleham,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014290,E14001444,E06000065,E06000065
+2024,2024,Malton,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014291,E14001544,E06000065,E06000065
+2024,2024,Masham & Fountains,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014292,E14001475,E06000065,E06000065
+2024,2024,Monk Fryston & South Milford,Selby,North Yorkshire,North Yorkshire,E05014293,E14001464,E06000065,E06000065
+2024,2024,Mid Craven,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014294,E14001475,E06000065,E06000065
+2024,2024,Morton-on-Swale & Appleton Wiske,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014295,E14001444,E06000065,E06000065
+2024,2024,Newby,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014296,E14001461,E06000065,E06000065
+2024,2024,North Richmondshire,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014297,E14001444,E06000065,E06000065
+2024,2024,Northallerton North & Brompton,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014298,E14001444,E06000065,E06000065
+2024,2024,Northallerton South,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014299,E14001444,E06000065,E06000065
+2024,2024,Norton,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014300,E14001544,E06000065,E06000065
+2024,2024,Northstead,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014301,E14001461,E06000065,E06000065
+2024,2024,Oatlands & Pannal,Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014302,E14001269,E06000065,E06000065
+2024,2024,Osgoldcross,Selby,North Yorkshire,North Yorkshire,E05014303,E14001464,E06000065,E06000065
+2024,2024,Ouseburn,Wetherby and Easingwold,North Yorkshire,North Yorkshire,E05014304,E14001582,E06000065,E06000065
+2024,2024,Pateley Bridge & Nidderdale,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014305,E14001475,E06000065,E06000065
+2024,2024,Pickering,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014306,E14001544,E06000065,E06000065
+2024,2024,Richmond,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014307,E14001444,E06000065,E06000065
+2024,2024,Ripon Minster & Moorside,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014308,E14001475,E06000065,E06000065
+2024,2024,Ripon Ure Bank & Spa,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014309,E14001475,E06000065,E06000065
+2024,2024,Romanby,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014310,E14001444,E06000065,E06000065
+2024,2024,Scalby & the Coast,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014311,E14001461,E06000065,E06000065
+2024,2024,Belle Vue,Carlisle,Cumberland,Cumberland,E05014173,E14001152,E06000063,E06000063
+2024,2024,Seamer,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014313,E14001461,E06000065,E06000065
+2024,2024,Chesham,Chesham and Amersham,Buckinghamshire,Buckinghamshire,E05013136,E14001162,E06000060,E06000060
+2024,2024,Irthlingborough,Corby and East Northamptonshire,North Northamptonshire,North Northamptonshire,E05013225,E14001179,E06000061,E06000061
+2024,2024,Appleby and Brough,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014218,E14001580,E06000064,E06000064
+2024,2024,Hill Forts & Upper Tarrants,North Dorset,Dorset,Dorset,E05012703,E14001388,E06000059,E06000059
+2024,2024,Irthlingborough,Wellingborough and Rushden,North Northamptonshire,North Northamptonshire,E05013225,E14001571,E06000061,E06000061
+2024,2024,Ise,Kettering,North Northamptonshire,North Northamptonshire,E05013226,E14001311,E06000061,E06000061
+2024,2024,Kingswood,Corby and East Northamptonshire,North Northamptonshire,North Northamptonshire,E05013227,E14001179,E06000061,E06000061
+2024,2024,Lloyds,Corby and East Northamptonshire,North Northamptonshire,North Northamptonshire,E05013228,E14001179,E06000061,E06000061
+2024,2024,Northall,Kettering,North Northamptonshire,North Northamptonshire,E05013229,E14001311,E06000061,E06000061
+2024,2024,Oakley,Corby and East Northamptonshire,North Northamptonshire,North Northamptonshire,E05013230,E14001179,E06000061,E06000061
+2024,2024,Oundle,Corby and East Northamptonshire,North Northamptonshire,North Northamptonshire,E05013231,E14001179,E06000061,E06000061
+2024,2024,Raunds,Corby and East Northamptonshire,North Northamptonshire,North Northamptonshire,E05013232,E14001179,E06000061,E06000061
+2024,2024,Rothwell and Mawsley,Kettering,North Northamptonshire,North Northamptonshire,E05013233,E14001311,E06000061,E06000061
+2024,2024,Rushden Pemberton West,Wellingborough and Rushden,North Northamptonshire,North Northamptonshire,E05013234,E14001571,E06000061,E06000061
+2024,2024,Rushden South,Wellingborough and Rushden,North Northamptonshire,North Northamptonshire,E05013235,E14001571,E06000061,E06000061
+2024,2024,Thrapston,Corby and East Northamptonshire,North Northamptonshire,North Northamptonshire,E05013236,E14001179,E06000061,E06000061
+2024,2024,Wicksteed,Kettering,North Northamptonshire,North Northamptonshire,E05013237,E14001311,E06000061,E06000061
+2024,2024,Windmill,Kettering,North Northamptonshire,North Northamptonshire,E05013238,E14001311,E06000061,E06000061
+2024,2024,Abington and Phippsville,Northampton North,West Northamptonshire,West Northamptonshire,E05013239,E14001406,E06000062,E06000062
+2024,2024,Billing and Rectory Farm,Northampton South,West Northamptonshire,West Northamptonshire,E05013240,E14001407,E06000062,E06000062
+2024,2024,Boothville and Parklands,Northampton North,West Northamptonshire,West Northamptonshire,E05013241,E14001406,E06000062,E06000062
+2024,2024,Brackley,South Northamptonshire,West Northamptonshire,West Northamptonshire,E05013242,E14001490,E06000062,E06000062
+2024,2024,Braunston and Crick,Daventry,West Northamptonshire,West Northamptonshire,E05013243,E14001192,E06000062,E06000062
+2024,2024,Brixworth,Daventry,West Northamptonshire,West Northamptonshire,E05013244,E14001192,E06000062,E06000062
+2024,2024,Bugbrooke,South Northamptonshire,West Northamptonshire,West Northamptonshire,E05013245,E14001490,E06000062,E06000062
+2024,2024,Castle,Northampton North,West Northamptonshire,West Northamptonshire,E05013246,E14001406,E06000062,E06000062
+2024,2024,Dallington Spencer,Northampton North,West Northamptonshire,West Northamptonshire,E05013247,E14001406,E06000062,E06000062
+2024,2024,Daventry East,Daventry,West Northamptonshire,West Northamptonshire,E05013248,E14001192,E06000062,E06000062
+2024,2024,Daventry West,Daventry,West Northamptonshire,West Northamptonshire,E05013249,E14001192,E06000062,E06000062
+2024,2024,Deanshanger,South Northamptonshire,West Northamptonshire,West Northamptonshire,E05013250,E14001490,E06000062,E06000062
+2024,2024,Delapre and Rushmere,Northampton South,West Northamptonshire,West Northamptonshire,E05013251,E14001407,E06000062,E06000062
+2024,2024,Duston East,Northampton South,West Northamptonshire,West Northamptonshire,E05013252,E14001407,E06000062,E06000062
+2024,2024,Duston West and St. Crispin,Northampton South,West Northamptonshire,West Northamptonshire,E05013253,E14001407,E06000062,E06000062
+2024,2024,East Hunsbury and Shelfleys,Northampton South,West Northamptonshire,West Northamptonshire,E05013254,E14001407,E06000062,E06000062
+2024,2024,Hackleton and Grange Park,South Northamptonshire,West Northamptonshire,West Northamptonshire,E05013255,E14001490,E06000062,E06000062
+2024,2024,Headlands,Northampton North,West Northamptonshire,West Northamptonshire,E05013256,E14001406,E06000062,E06000062
+2024,2024,Kingsthorpe North,Northampton North,West Northamptonshire,West Northamptonshire,E05013257,E14001406,E06000062,E06000062
+2024,2024,Kingsthorpe South,Northampton North,West Northamptonshire,West Northamptonshire,E05013258,E14001406,E06000062,E06000062
+2024,2024,Long Buckby,Daventry,West Northamptonshire,West Northamptonshire,E05013259,E14001192,E06000062,E06000062
+2024,2024,Middleton Cheney,South Northamptonshire,West Northamptonshire,West Northamptonshire,E05013260,E14001490,E06000062,E06000062
+2024,2024,Moulton,Daventry,West Northamptonshire,West Northamptonshire,E05013261,E14001192,E06000062,E06000062
+2024,2024,Nene Valley,Northampton South,West Northamptonshire,West Northamptonshire,E05013262,E14001407,E06000062,E06000062
+2024,2024,Riverside Park,Northampton South,West Northamptonshire,West Northamptonshire,E05013263,E14001407,E06000062,E06000062
+2024,2024,St. George,Northampton North,West Northamptonshire,West Northamptonshire,E05013264,E14001406,E06000062,E06000062
+2024,2024,Silverstone,Daventry,West Northamptonshire,West Northamptonshire,E05013265,E14001192,E06000062,E06000062
+2024,2024,Silverstone,South Northamptonshire,West Northamptonshire,West Northamptonshire,E05013265,E14001490,E06000062,E06000062
+2024,2024,Sixfields,Northampton South,West Northamptonshire,West Northamptonshire,E05013266,E14001407,E06000062,E06000062
+2024,2024,Talavera,Northampton North,West Northamptonshire,West Northamptonshire,E05013267,E14001406,E06000062,E06000062
+2024,2024,Towcester and Roade,South Northamptonshire,West Northamptonshire,West Northamptonshire,E05013268,E14001490,E06000062,E06000062
+2024,2024,Woodford and Weedon,Daventry,West Northamptonshire,West Northamptonshire,E05013269,E14001192,E06000062,E06000062
+2024,2024,Aspatria,Penrith and Solway,Cumberland,Cumberland,E05014171,E14001424,E06000063,E06000063
+2024,2024,Belah,Carlisle,Cumberland,Cumberland,E05014172,E14001152,E06000063,E06000063
+2024,2024,Littlemoor & Preston,South Dorset,Dorset,Dorset,E05012704,E14001485,E06000059,E06000059
+2024,2024,Chess Valley,Chesham and Amersham,Buckinghamshire,Buckinghamshire,E05013137,E14001162,E06000060,E06000060
+2024,2024,Bowness and Lyth,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014219,E14001580,E06000064,E06000064
+2024,2024,Botcherby,Carlisle,Cumberland,Cumberland,E05014174,E14001152,E06000063,E06000063
+2024,2024,Selby East,Selby,North Yorkshire,North Yorkshire,E05014314,E14001464,E06000065,E06000065
+2024,2024,Bothel and Wharrels,Penrith and Solway,Cumberland,Cumberland,E05014175,E14001424,E06000063,E06000063
+2024,2024,Brampton,Carlisle,Cumberland,Cumberland,E05014176,E14001152,E06000063,E06000063
+2024,2024,Bransty,Whitehaven and Workington,Cumberland,Cumberland,E05014177,E14001583,E06000063,E06000063
+2024,2024,Castle,Carlisle,Cumberland,Cumberland,E05014178,E14001152,E06000063,E06000063
+2024,2024,Cleator Moor East and Frizington,Whitehaven and Workington,Cumberland,Cumberland,E05014179,E14001583,E06000063,E06000063
+2024,2024,Cleator Moor West,Whitehaven and Workington,Cumberland,Cumberland,E05014180,E14001583,E06000063,E06000063
+2024,2024,Cockermouth North,Penrith and Solway,Cumberland,Cumberland,E05014181,E14001424,E06000063,E06000063
+2024,2024,Cockermouth South,Penrith and Solway,Cumberland,Cumberland,E05014182,E14001424,E06000063,E06000063
+2024,2024,Cockermouth South,Whitehaven and Workington,Cumberland,Cumberland,E05014182,E14001583,E06000063,E06000063
+2024,2024,Corby and Hayton,Carlisle,Cumberland,Cumberland,E05014183,E14001152,E06000063,E06000063
+2024,2024,Currock,Carlisle,Cumberland,Cumberland,E05014184,E14001152,E06000063,E06000063
+2024,2024,Dalston and Burgh,Carlisle,Cumberland,Cumberland,E05014185,E14001152,E06000063,E06000063
+2024,2024,Dalston and Burgh,Penrith and Solway,Cumberland,Cumberland,E05014185,E14001424,E06000063,E06000063
+2024,2024,Dearham and Broughton,Penrith and Solway,Cumberland,Cumberland,E05014186,E14001424,E06000063,E06000063
+2024,2024,Denton Holme,Carlisle,Cumberland,Cumberland,E05014187,E14001152,E06000063,E06000063
+2024,2024,Egremont,Whitehaven and Workington,Cumberland,Cumberland,E05014188,E14001583,E06000063,E06000063
+2024,2024,Egremont North and St Bees,Whitehaven and Workington,Cumberland,Cumberland,E05014189,E14001583,E06000063,E06000063
+2024,2024,Gosforth,Whitehaven and Workington,Cumberland,Cumberland,E05014190,E14001583,E06000063,E06000063
+2024,2024,Harraby North,Carlisle,Cumberland,Cumberland,E05014191,E14001152,E06000063,E06000063
+2024,2024,Harraby South,Carlisle,Cumberland,Cumberland,E05014192,E14001152,E06000063,E06000063
+2024,2024,Harrington,Whitehaven and Workington,Cumberland,Cumberland,E05014193,E14001583,E06000063,E06000063
+2024,2024,Hillcrest and Hensingham,Whitehaven and Workington,Cumberland,Cumberland,E05014194,E14001583,E06000063,E06000063
+2024,2024,Houghton and Irthington,Carlisle,Cumberland,Cumberland,E05014195,E14001152,E06000063,E06000063
+2024,2024,Howgate,Whitehaven and Workington,Cumberland,Cumberland,E05014196,E14001583,E06000063,E06000063
+2024,2024,Kells and Sandwith,Whitehaven and Workington,Cumberland,Cumberland,E05014197,E14001583,E06000063,E06000063
+2024,2024,Keswick,Penrith and Solway,Cumberland,Cumberland,E05014198,E14001424,E06000063,E06000063
+2024,2024,Longtown,Carlisle,Cumberland,Cumberland,E05014199,E14001152,E06000063,E06000063
+2024,2024,Selby West,Selby,North Yorkshire,North Yorkshire,E05014315,E14001464,E06000065,E06000065
+2024,2024,Maryport North,Penrith and Solway,Cumberland,Cumberland,E05014200,E14001424,E06000063,E06000063
+2024,2024,Maryport South,Penrith and Solway,Cumberland,Cumberland,E05014201,E14001424,E06000063,E06000063
+2024,2024,Maryport South,Whitehaven and Workington,Cumberland,Cumberland,E05014201,E14001583,E06000063,E06000063
+2024,2024,Millom,Barrow and Furness,Cumberland,Cumberland,E05014202,E14001076,E06000063,E06000063
+2024,2024,Millom Without,Barrow and Furness,Cumberland,Cumberland,E05014203,E14001076,E06000063,E06000063
+2024,2024,Millom Without,Whitehaven and Workington,Cumberland,Cumberland,E05014203,E14001583,E06000063,E06000063
+2024,2024,Mirehouse,Whitehaven and Workington,Cumberland,Cumberland,E05014204,E14001583,E06000063,E06000063
+2024,2024,Morton,Carlisle,Cumberland,Cumberland,E05014205,E14001152,E06000063,E06000063
+2024,2024,Moss Bay and Moorclose,Whitehaven and Workington,Cumberland,Cumberland,E05014206,E14001583,E06000063,E06000063
+2024,2024,St John's and Great Clifton,Whitehaven and Workington,Cumberland,Cumberland,E05014207,E14001583,E06000063,E06000063
+2024,2024,St Michael's,Whitehaven and Workington,Cumberland,Cumberland,E05014208,E14001583,E06000063,E06000063
+2024,2024,Seaton,Whitehaven and Workington,Cumberland,Cumberland,E05014209,E14001583,E06000063,E06000063
+2024,2024,Solway Coast,Penrith and Solway,Cumberland,Cumberland,E05014210,E14001424,E06000063,E06000063
+2024,2024,Stanwix Urban,Carlisle,Cumberland,Cumberland,E05014211,E14001152,E06000063,E06000063
+2024,2024,Thursby,Penrith and Solway,Cumberland,Cumberland,E05014212,E14001424,E06000063,E06000063
+2024,2024,Upperby,Carlisle,Cumberland,Cumberland,E05014213,E14001152,E06000063,E06000063
+2024,2024,Wetheral,Carlisle,Cumberland,Cumberland,E05014214,E14001152,E06000063,E06000063
+2024,2024,Wetheral,Penrith and Solway,Cumberland,Cumberland,E05014214,E14001424,E06000063,E06000063
+2024,2024,Wigton,Penrith and Solway,Cumberland,Cumberland,E05014215,E14001424,E06000063,E06000063
+2024,2024,Yewdale,Carlisle,Cumberland,Cumberland,E05014216,E14001152,E06000063,E06000063
+2024,2024,Alston and Fellside,Penrith and Solway,Westmorland and Furness,Westmorland and Furness,E05014217,E14001424,E06000064,E06000064
+2024,2024,Chiltern Ridges,Chesham and Amersham,Buckinghamshire,Buckinghamshire,E05013138,E14001162,E06000060,E06000060
+2024,2024,Lyme & Charmouth,West Dorset,Dorset,Dorset,E05012705,E14001575,E06000059,E06000059
+2024,2024,Burton and Holme,Morecambe and Lunesdale,Westmorland and Furness,Westmorland and Furness,E05014220,E14001372,E06000064,E06000064
+2024,2024,Chiltern Ridges,Mid Buckinghamshire,Buckinghamshire,Buckinghamshire,E05013138,E14001360,E06000060,E06000060
+2024,2024,Chiltern Villages,Wycombe,Buckinghamshire,Buckinghamshire,E05013139,E14001600,E06000060,E06000060
+2024,2024,Cliveden,Beaconsfield,Buckinghamshire,Buckinghamshire,E05013140,E14001082,E06000060,E06000060
+2024,2024,Denham,Beaconsfield,Buckinghamshire,Buckinghamshire,E05013141,E14001082,E06000060,E06000060
+2024,2024,Denham,Chesham and Amersham,Buckinghamshire,Buckinghamshire,E05013141,E14001162,E06000060,E06000060
+2024,2024,Downley,Wycombe,Buckinghamshire,Buckinghamshire,E05013142,E14001600,E06000060,E06000060
+2024,2024,Farnham Common and Burnham Beeches,Beaconsfield,Buckinghamshire,Buckinghamshire,E05013143,E14001082,E06000060,E06000060
+2024,2024,"Flackwell Heath, Little Marlow and Marlow South East",Beaconsfield,Buckinghamshire,Buckinghamshire,E05013144,E14001082,E06000060,E06000060
+2024,2024,Gerrards Cross,Beaconsfield,Buckinghamshire,Buckinghamshire,E05013145,E14001082,E06000060,E06000060
+2024,2024,Gerrards Cross,Chesham and Amersham,Buckinghamshire,Buckinghamshire,E05013145,E14001162,E06000060,E06000060
+2024,2024,Great Brickhill,Buckingham and Bletchley,Buckinghamshire,Buckinghamshire,E05013146,E14001141,E06000060,E06000060
+2024,2024,Great Missenden,Mid Buckinghamshire,Buckinghamshire,Buckinghamshire,E05013147,E14001360,E06000060,E06000060
+2024,2024,Grendon Underwood,Mid Buckinghamshire,Buckinghamshire,Buckinghamshire,E05013148,E14001360,E06000060,E06000060
+2024,2024,Hazlemere,Chesham and Amersham,Buckinghamshire,Buckinghamshire,E05013149,E14001162,E06000060,E06000060
+2024,2024,Coniston and Hawkshead,Barrow and Furness,Westmorland and Furness,Westmorland and Furness,E05014221,E14001076,E06000064,E06000064
+2024,2024,Iver,Beaconsfield,Buckinghamshire,Buckinghamshire,E05013150,E14001082,E06000060,E06000060
+2024,2024,Ivinghoe,Aylesbury,Buckinghamshire,Buckinghamshire,E05013151,E14001071,E06000060,E06000060
+2024,2024,Coniston and Hawkshead,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014221,E14001580,E06000064,E06000064
+2024,2024,Little Chalfont and Amersham Common,Chesham and Amersham,Buckinghamshire,Buckinghamshire,E05013152,E14001162,E06000060,E06000060
+2024,2024,Lytchett Matravers & Upton,Mid Dorset and North Poole,Dorset,Dorset,E05012706,E14001363,E06000059,E06000059
+2024,2024,Settle & Penyghent,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014316,E14001475,E06000065,E06000065
+2024,2024,Dalton North,Barrow and Furness,Westmorland and Furness,Westmorland and Furness,E05014222,E14001076,E06000064,E06000064
+2024,2024,Sherburn in Elmet,Selby,North Yorkshire,North Yorkshire,E05014317,E14001464,E06000065,E06000065
+2024,2024,Dalton South,Barrow and Furness,Westmorland and Furness,Westmorland and Furness,E05014223,E14001076,E06000064,E06000064
+2024,2024,Sheriff Hutton & Derwent,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014318,E14001544,E06000065,E06000065
+2024,2024,Eamont and Shap,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014224,E14001580,E06000064,E06000064
+2024,2024,Skipton East & South,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014319,E14001475,E06000065,E06000065
+2024,2024,Eden and Lyvennet Vale,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014225,E14001580,E06000064,E06000064
+2024,2024,Skipton North & Embsay-with-Eastby,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014320,E14001475,E06000065,E06000065
+2024,2024,Grange and Cartmel,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014226,E14001580,E06000064,E06000064
+2024,2024,Skipton West & West Craven,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014321,E14001475,E06000065,E06000065
+2024,2024,Greystoke and Ullswater,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014227,E14001580,E06000064,E06000064
+2024,2024,Sowerby & Topcliffe,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014322,E14001544,E06000065,E06000065
+2024,2024,Hawcoat and Newbarns,Barrow and Furness,Westmorland and Furness,Westmorland and Furness,E05014228,E14001076,E06000064,E06000064
+2024,2024,Melcombe Regis,South Dorset,Dorset,Dorset,E05012708,E14001485,E06000059,E06000059
+2024,2024,Hesket and Lazonby,Penrith and Solway,Westmorland and Furness,Westmorland and Furness,E05014229,E14001424,E06000064,E06000064
+2024,2024,Spofforth with Lower Wharfedale & Tockwith,Wetherby and Easingwold,North Yorkshire,North Yorkshire,E05014323,E14001582,E06000065,E06000065
+2024,2024,Marlow,Beaconsfield,Buckinghamshire,Buckinghamshire,E05013153,E14001082,E06000060,E06000060
+2024,2024,Penn Wood and Old Amersham,Chesham and Amersham,Buckinghamshire,Buckinghamshire,E05013154,E14001162,E06000060,E06000060
+2024,2024,Ridgeway East,Mid Buckinghamshire,Buckinghamshire,Buckinghamshire,E05013155,E14001360,E06000060,E06000060
+2024,2024,Ridgeway West,Mid Buckinghamshire,Buckinghamshire,Buckinghamshire,E05013156,E14001360,E06000060,E06000060
+2024,2024,Ryemead and Micklefield,Wycombe,Buckinghamshire,Buckinghamshire,E05013157,E14001600,E06000060,E06000060
+2024,2024,Stoke Poges and Wexham,Beaconsfield,Buckinghamshire,Buckinghamshire,E05013158,E14001082,E06000060,E06000060
+2024,2024,Stone and Waddesdon,Mid Buckinghamshire,Buckinghamshire,Buckinghamshire,E05013159,E14001360,E06000060,E06000060
+2024,2024,Terriers and Amersham Hill,Wycombe,Buckinghamshire,Buckinghamshire,E05013160,E14001600,E06000060,E06000060
+2024,2024,The Risboroughs,Mid Buckinghamshire,Buckinghamshire,Buckinghamshire,E05013161,E14001360,E06000060,E06000060
+2024,2024,"The Wooburns, Bourne End and Hedsor",Beaconsfield,Buckinghamshire,Buckinghamshire,E05013162,E14001082,E06000060,E06000060
+2024,2024,Totteridge and Bowerdean,Wycombe,Buckinghamshire,Buckinghamshire,E05013163,E14001600,E06000060,E06000060
+2024,2024,Tylers Green and Loudwater,Wycombe,Buckinghamshire,Buckinghamshire,E05013164,E14001600,E06000060,E06000060
+2024,2024,"Wendover, Halton and Stoke Mandeville",Mid Buckinghamshire,Buckinghamshire,Buckinghamshire,E05013165,E14001360,E06000060,E06000060
+2024,2024,West Wycombe,Wycombe,Buckinghamshire,Buckinghamshire,E05013166,E14001600,E06000060,E06000060
+2024,2024,Wing,Aylesbury,Buckinghamshire,Buckinghamshire,E05013167,E14001071,E06000060,E06000060
+2024,2024,Winslow,Buckingham and Bletchley,Buckinghamshire,Buckinghamshire,E05013168,E14001141,E06000060,E06000060
+2024,2024,Brickhill and Queensway,Wellingborough and Rushden,North Northamptonshire,North Northamptonshire,E05013213,E14001571,E06000061,E06000061
+2024,2024,Burton and Broughton,Kettering,North Northamptonshire,North Northamptonshire,E05013214,E14001311,E06000061,E06000061
+2024,2024,Clover Hill,Kettering,North Northamptonshire,North Northamptonshire,E05013215,E14001311,E06000061,E06000061
+2024,2024,Corby Rural,Corby and East Northamptonshire,North Northamptonshire,North Northamptonshire,E05013216,E14001179,E06000061,E06000061
+2024,2024,Corby Rural,Kettering,North Northamptonshire,North Northamptonshire,E05013216,E14001311,E06000061,E06000061
+2024,2024,Corby West,Corby and East Northamptonshire,North Northamptonshire,North Northamptonshire,E05013217,E14001179,E06000061,E06000061
+2024,2024,Croyland and Swanspool,Wellingborough and Rushden,North Northamptonshire,North Northamptonshire,E05013218,E14001571,E06000061,E06000061
+2024,2024,Desborough,Kettering,North Northamptonshire,North Northamptonshire,E05013219,E14001311,E06000061,E06000061
+2024,2024,Earls Barton,Daventry,North Northamptonshire,North Northamptonshire,E05013220,E14001192,E06000061,E06000061
+2024,2024,Finedon,Wellingborough and Rushden,North Northamptonshire,North Northamptonshire,E05013221,E14001571,E06000061,E06000061
+2024,2024,Hatton Park,Wellingborough and Rushden,North Northamptonshire,North Northamptonshire,E05013222,E14001571,E06000061,E06000061
+2024,2024,Higham Ferrers,Wellingborough and Rushden,North Northamptonshire,North Northamptonshire,E05013223,E14001571,E06000061,E06000061
+2024,2024,Irchester,South Northamptonshire,North Northamptonshire,North Northamptonshire,E05013224,E14001490,E06000061,E06000061
+2024,2024,Portland,South Dorset,Dorset,Dorset,E05012709,E14001485,E06000059,E06000059
+2024,2024,"Stray, Woodlands & Hookstone",Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014324,E14001269,E06000065,E06000065
+2024,2024,High Furness,Barrow and Furness,Westmorland and Furness,Westmorland and Furness,E05014230,E14001076,E06000064,E06000064
+2024,2024,Kendal Castle,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014231,E14001580,E06000064,E06000064
+2024,2024,Kendal Highgate,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014232,E14001580,E06000064,E06000064
+2024,2024,Kendal Nether,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014233,E14001580,E06000064,E06000064
+2024,2024,Kendal South,Morecambe and Lunesdale,Westmorland and Furness,Westmorland and Furness,E05014234,E14001372,E06000064,E06000064
+2024,2024,Kendal South,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014234,E14001580,E06000064,E06000064
+2024,2024,Kendal Strickland and Fell,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014235,E14001580,E06000064,E06000064
+2024,2024,Kent Estuary,Morecambe and Lunesdale,Westmorland and Furness,Westmorland and Furness,E05014236,E14001372,E06000064,E06000064
+2024,2024,Kirkby Stephen and Tebay,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014237,E14001580,E06000064,E06000064
+2024,2024,Levens and Crooklands,Morecambe and Lunesdale,Westmorland and Furness,Westmorland and Furness,E05014238,E14001372,E06000064,E06000064
+2024,2024,Levens and Crooklands,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014238,E14001580,E06000064,E06000064
+2024,2024,Low Furness,Barrow and Furness,Westmorland and Furness,Westmorland and Furness,E05014239,E14001076,E06000064,E06000064
+2024,2024,Old Barrow and Hindpool,Barrow and Furness,Westmorland and Furness,Westmorland and Furness,E05014240,E14001076,E06000064,E06000064
+2024,2024,Ormsgill and Parkside,Barrow and Furness,Westmorland and Furness,Westmorland and Furness,E05014241,E14001076,E06000064,E06000064
+2024,2024,Penrith North,Penrith and Solway,Westmorland and Furness,Westmorland and Furness,E05014242,E14001424,E06000064,E06000064
+2024,2024,Penrith South,Penrith and Solway,Westmorland and Furness,Westmorland and Furness,E05014243,E14001424,E06000064,E06000064
+2024,2024,Risedale and Roosecote,Barrow and Furness,Westmorland and Furness,Westmorland and Furness,E05014244,E14001076,E06000064,E06000064
+2024,2024,Sedbergh and Kirkby Lonsdale,Morecambe and Lunesdale,Westmorland and Furness,Westmorland and Furness,E05014245,E14001372,E06000064,E06000064
+2024,2024,Sedbergh and Kirkby Lonsdale,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014245,E14001580,E06000064,E06000064
+2024,2024,Ulverston,Barrow and Furness,Westmorland and Furness,Westmorland and Furness,E05014246,E14001076,E06000064,E06000064
+2024,2024,Upper Kent,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014247,E14001580,E06000064,E06000064
+2024,2024,Walney Island,Barrow and Furness,Westmorland and Furness,Westmorland and Furness,E05014248,E14001076,E06000064,E06000064
+2024,2024,Windermere and Ambleside,Westmorland and Lonsdale,Westmorland and Furness,Westmorland and Furness,E05014249,E14001580,E06000064,E06000064
+2024,2024,Aire Valley,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014250,E14001475,E06000065,E06000065
+2024,2024,Aiskew & Leeming,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014251,E14001544,E06000065,E06000065
+2024,2024,Amotherby & Ampleforth,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014252,E14001544,E06000065,E06000065
+2024,2024,Appleton Roebuck & Church Fenton,Wetherby and Easingwold,North Yorkshire,North Yorkshire,E05014253,E14001582,E06000065,E06000065
+2024,2024,Barlby & Riccall,Selby,North Yorkshire,North Yorkshire,E05014254,E14001464,E06000065,E06000065
+2024,2024,Bedale,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014255,E14001544,E06000065,E06000065
+2024,2024,Bentham & Ingleton,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014256,E14001475,E06000065,E06000065
+2024,2024,Bilton Grange & New Park,Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014257,E14001269,E06000065,E06000065
+2024,2024,Bilton & Nidd Gorge,Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014258,E14001269,E06000065,E06000065
+2024,2024,Boroughbridge & Claro,Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014259,E14001269,E06000065,E06000065
+2024,2024,Boroughbridge & Claro,Wetherby and Easingwold,North Yorkshire,North Yorkshire,E05014259,E14001582,E06000065,E06000065
+2024,2024,Brayton & Barlow,Selby,North Yorkshire,North Yorkshire,E05014260,E14001464,E06000065,E06000065
+2024,2024,Camblesforth & Carlton,Selby,North Yorkshire,North Yorkshire,E05014261,E14001464,E06000065,E06000065
+2024,2024,Castle,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014262,E14001461,E06000065,E06000065
+2024,2024,Stokesley,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014325,E14001444,E06000065,E06000065
+2024,2024,Puddletown & Lower Winterborne,North Dorset,Dorset,Dorset,E05012710,E14001388,E06000059,E06000059
+2024,2024,Tadcaster,Wetherby and Easingwold,North Yorkshire,North Yorkshire,E05014326,E14001582,E06000065,E06000065
+2024,2024,Thirsk,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014327,E14001544,E06000065,E06000065
+2024,2024,Thornton Dale & Wolds,Thirsk and Malton,North Yorkshire,North Yorkshire,E05014328,E14001544,E06000065,E06000065
+2024,2024,Thorpe Willoughby & Hambleton,Selby,North Yorkshire,North Yorkshire,E05014329,E14001464,E06000065,E06000065
+2024,2024,Upper Dales,Richmond and Northallerton,North Yorkshire,North Yorkshire,E05014330,E14001444,E06000065,E06000065
+2024,2024,Valley Gardens & Central Harrogate,Harrogate and Knaresborough,North Yorkshire,North Yorkshire,E05014331,E14001269,E06000065,E06000065
+2024,2024,Washburn & Birstwith,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014332,E14001475,E06000065,E06000065
+2024,2024,Wathvale & Bishop Monkton,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014333,E14001475,E06000065,E06000065
+2024,2024,Wathvale & Bishop Monkton,Wetherby and Easingwold,North Yorkshire,North Yorkshire,E05014333,E14001582,E06000065,E06000065
+2024,2024,Weaponness & Ramshill,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014334,E14001461,E06000065,E06000065
+2024,2024,Wharfedale,Skipton and Ripon,North Yorkshire,North Yorkshire,E05014335,E14001475,E06000065,E06000065
+2024,2024,Whitby Streonshalh,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014336,E14001461,E06000065,E06000065
+2024,2024,Whitby West,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014337,E14001461,E06000065,E06000065
+2024,2024,Woodlands,Scarborough and Whitby,North Yorkshire,North Yorkshire,E05014338,E14001461,E06000065,E06000065
+2024,2024,Bishop's Hull & Taunton West,Taunton and Wellington,Somerset,Somerset,E05014339,E14001540,E06000066,E06000066
+2024,2024,Blackdown & Neroche,Taunton and Wellington,Somerset,Somerset,E05014340,E14001540,E06000066,E06000066
+2024,2024,Blackmoor Vale,Glastonbury and Somerton,Somerset,Somerset,E05014341,E14001247,E06000066,E06000066
+2024,2024,Brent,Bridgwater,Somerset,Somerset,E05014342,E14001126,E06000066,E06000066
+2024,2024,Brent,Wells and Mendip Hills,Somerset,Somerset,E05014342,E14001572,E06000066,E06000066
+2024,2024,Radipole,South Dorset,Dorset,Dorset,E05012711,E14001485,E06000059,E06000059
+2024,2024,Bridgwater East & Bawdrip,Bridgwater,Somerset,Somerset,E05014343,E14001126,E06000066,E06000066
+2024,2024,Rodwell & Wyke,South Dorset,Dorset,Dorset,E05012712,E14001485,E06000059,E06000059
+2024,2024,Bridgwater North & Central,Bridgwater,Somerset,Somerset,E05014344,E14001126,E06000066,E06000066
+2024,2024,St Leonards & St Ives,Christchurch,Dorset,Dorset,E05012713,E14001171,E06000059,E06000059
+2024,2024,Bridgwater South,Bridgwater,Somerset,Somerset,E05014345,E14001126,E06000066,E06000066
+2024,2024,Shaftesbury Town,North Dorset,Dorset,Dorset,E05012714,E14001388,E06000059,E06000059
+2024,2024,Bridgwater West,Bridgwater,Somerset,Somerset,E05014346,E14001126,E06000066,E06000066
+2024,2024,Sherborne East,West Dorset,Dorset,Dorset,E05012715,E14001575,E06000059,E06000059
+2024,2024,Brympton,Glastonbury and Somerton,Somerset,Somerset,E05014347,E14001247,E06000066,E06000066
+2024,2024,Sherborne Rural,West Dorset,Dorset,Dorset,E05012716,E14001575,E06000059,E06000059
+2024,2024,Brympton,Yeovil,Somerset,Somerset,E05014347,E14001603,E06000066,E06000066
+2024,2024,Sherborne West,West Dorset,Dorset,Dorset,E05012717,E14001575,E06000059,E06000059
+2024,2024,Burnham on Sea North,Bridgwater,Somerset,Somerset,E05014348,E14001126,E06000066,E06000066
+2024,2024,South East Purbeck,South Dorset,Dorset,Dorset,E05012718,E14001485,E06000059,E06000059
+2024,2024,Cannington,Bridgwater,Somerset,Somerset,E05014349,E14001126,E06000066,E06000066
+2024,2024,Stalbridge & Marnhull,North Dorset,Dorset,Dorset,E05012719,E14001388,E06000059,E06000059
+2024,2024,Castle Cary,Glastonbury and Somerton,Somerset,Somerset,E05014350,E14001247,E06000066,E06000066
+2024,2024,Stour & Allen Vale,Mid Dorset and North Poole,Dorset,Dorset,E05012720,E14001363,E06000059,E06000059
+2024,2024,Chard North,Yeovil,Somerset,Somerset,E05014351,E14001603,E06000066,E06000066
+2024,2024,Sturminster Newton,North Dorset,Dorset,Dorset,E05012721,E14001388,E06000059,E06000059
+2024,2024,Chard South,Yeovil,Somerset,Somerset,E05014352,E14001603,E06000066,E06000066
+2024,2024,Swanage,South Dorset,Dorset,Dorset,E05012722,E14001485,E06000059,E06000059
+2024,2024,Cheddar,Wells and Mendip Hills,Somerset,Somerset,E05014353,E14001572,E06000066,E06000066
+2024,2024,Upwey & Broadwey,South Dorset,Dorset,Dorset,E05012723,E14001485,E06000059,E06000059
+2024,2024,Coker,Glastonbury and Somerton,Somerset,Somerset,E05014354,E14001247,E06000066,E06000066
+2024,2024,Verwood,North Dorset,Dorset,Dorset,E05012724,E14001388,E06000059,E06000059
+2024,2024,Coker,Yeovil,Somerset,Somerset,E05014354,E14001603,E06000066,E06000066
+2024,2024,Wareham,Mid Dorset and North Poole,Dorset,Dorset,E05012725,E14001363,E06000059,E06000059
+2024,2024,Comeytrowe & Trull,Taunton and Wellington,Somerset,Somerset,E05014355,E14001540,E06000066,E06000066
+2024,2024,West Moors & Three Legged Cross,Christchurch,Dorset,Dorset,E05012726,E14001171,E06000059,E06000059
+2024,2024,Crewkerne,Yeovil,Somerset,Somerset,E05014356,E14001603,E06000066,E06000066
+2024,2024,West Parley,Christchurch,Dorset,Dorset,E05012727,E14001171,E06000059,E06000059
+2024,2024,Curry Rivel & Langport,Glastonbury and Somerton,Somerset,Somerset,E05014357,E14001247,E06000066,E06000066
+2024,2024,West Purbeck,Mid Dorset and North Poole,Dorset,Dorset,E05012728,E14001363,E06000059,E06000059
+2024,2024,West Purbeck,South Dorset,Dorset,Dorset,E05012728,E14001485,E06000059,E06000059
+2024,2024,Westham,South Dorset,Dorset,Dorset,E05012729,E14001485,E06000059,E06000059
+2024,2024,Wimborne Minster,Mid Dorset and North Poole,Dorset,Dorset,E05012730,E14001363,E06000059,E06000059
+2024,2024,Winterborne & Broadmayne,West Dorset,Dorset,Dorset,E05012731,E14001575,E06000059,E06000059
+2024,2024,Winterborne North,North Dorset,Dorset,Dorset,E05012732,E14001388,E06000059,E06000059
+2024,2024,Yetminster,West Dorset,Dorset,Dorset,E05012733,E14001575,E06000059,E06000059
+2024,2024,Bridport,West Dorset,Dorset,Dorset,E05015779,E14001575,E06000059,E06000059
+2024,2024,Chesil Bank,West Dorset,Dorset,Dorset,E05015780,E14001575,E06000059,E06000059
+2024,2024,Eggardon,West Dorset,Dorset,Dorset,E05015781,E14001575,E06000059,E06000059
+2024,2024,Marshwood Vale,West Dorset,Dorset,Dorset,E05015782,E14001575,E06000059,E06000059
+2024,2024,Abbey,Wycombe,Buckinghamshire,Buckinghamshire,E05013120,E14001600,E06000060,E06000060
+2024,2024,Amersham and Chesham Bois,Chesham and Amersham,Buckinghamshire,Buckinghamshire,E05013121,E14001162,E06000060,E06000060
+2024,2024,Aston Clinton and Bierton,Aylesbury,Buckinghamshire,Buckinghamshire,E05013122,E14001071,E06000060,E06000060
+2024,2024,Aylesbury East,Aylesbury,Buckinghamshire,Buckinghamshire,E05013123,E14001071,E06000060,E06000060
+2024,2024,Aylesbury North,Aylesbury,Buckinghamshire,Buckinghamshire,E05013124,E14001071,E06000060,E06000060
+2024,2024,Aylesbury North West,Aylesbury,Buckinghamshire,Buckinghamshire,E05013125,E14001071,E06000060,E06000060
+2024,2024,Aylesbury South East,Aylesbury,Buckinghamshire,Buckinghamshire,E05013126,E14001071,E06000060,E06000060
+2024,2024,Aylesbury South West,Aylesbury,Buckinghamshire,Buckinghamshire,E05013127,E14001071,E06000060,E06000060
+2024,2024,Aylesbury West,Aylesbury,Buckinghamshire,Buckinghamshire,E05013128,E14001071,E06000060,E06000060
+2024,2024,Beaconsfield,Beaconsfield,Buckinghamshire,Buckinghamshire,E05013129,E14001082,E06000060,E06000060
+2024,2024,Bernwood,Mid Buckinghamshire,Buckinghamshire,Buckinghamshire,E05013130,E14001360,E06000060,E06000060
+2024,2024,"Booker, Cressex and Castlefield",Wycombe,Buckinghamshire,Buckinghamshire,E05013131,E14001600,E06000060,E06000060
+2024,2024,Buckingham East,Buckingham and Bletchley,Buckinghamshire,Buckinghamshire,E05013132,E14001141,E06000060,E06000060
+2024,2024,Buckingham West,Buckingham and Bletchley,Buckinghamshire,Buckinghamshire,E05013133,E14001141,E06000060,E06000060
+2024,2024,Chalfont St Giles,Chesham and Amersham,Buckinghamshire,Buckinghamshire,E05013134,E14001162,E06000060,E06000060
+2024,2024,Huntingdon North,Huntingdon,Huntingdonshire,Cambridgeshire,E05011266,E14001298,E07000011,E10000003
+2024,2024,Kimbolton,Huntingdon,Huntingdonshire,Cambridgeshire,E05011267,E14001298,E07000011,E10000003
+2024,2024,Ramsey,North West Cambridgeshire,Huntingdonshire,Cambridgeshire,E05011268,E14001401,E07000011,E10000003
+2024,2024,St Ives East,Huntingdon,Huntingdonshire,Cambridgeshire,E05011269,E14001298,E07000011,E10000003
+2024,2024,St Ives South,Huntingdon,Huntingdonshire,Cambridgeshire,E05011270,E14001298,E07000011,E10000003
+2024,2024,St Ives West,Huntingdon,Huntingdonshire,Cambridgeshire,E05011271,E14001298,E07000011,E10000003
+2024,2024,St Neots East,St Neots and Mid Cambridgeshire,Huntingdonshire,Cambridgeshire,E05011272,E14001512,E07000011,E10000003
+2024,2024,St Neots Eatons,St Neots and Mid Cambridgeshire,Huntingdonshire,Cambridgeshire,E05011273,E14001512,E07000011,E10000003
+2024,2024,St Neots Eynesbury,St Neots and Mid Cambridgeshire,Huntingdonshire,Cambridgeshire,E05011274,E14001512,E07000011,E10000003
+2024,2024,St Neots Priory Park & Little Paxton,St Neots and Mid Cambridgeshire,Huntingdonshire,Cambridgeshire,E05011275,E14001512,E07000011,E10000003
+2024,2024,Sawtry,Huntingdon,Huntingdonshire,Cambridgeshire,E05011276,E14001298,E07000011,E10000003
+2024,2024,Somersham,Huntingdon,Huntingdonshire,Cambridgeshire,E05011277,E14001298,E07000011,E10000003
+2024,2024,"Stilton, Folksworth & Washingley",North West Cambridgeshire,Huntingdonshire,Cambridgeshire,E05011278,E14001401,E07000011,E10000003
+2024,2024,The Stukeleys,Huntingdon,Huntingdonshire,Cambridgeshire,E05011279,E14001298,E07000011,E10000003
+2024,2024,Warboys,Huntingdon,Huntingdonshire,Cambridgeshire,E05011280,E14001298,E07000011,E10000003
+2024,2024,Yaxley,North West Cambridgeshire,Huntingdonshire,Cambridgeshire,E05011281,E14001401,E07000011,E10000003
+2024,2024,Balsham,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011282,E14001481,E07000012,E10000003
+2024,2024,Bar Hill,St Neots and Mid Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011283,E14001512,E07000012,E10000003
+2024,2024,Barrington,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011284,E14001481,E07000012,E10000003
+2024,2024,Bassingbourn,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011285,E14001481,E07000012,E10000003
+2024,2024,Caldecote,St Neots and Mid Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011286,E14001512,E07000012,E10000003
+2024,2024,Cottenham,Ely and East Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011289,E14001224,E07000012,E10000003
+2024,2024,Fen Ditton & Fulbourn,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011291,E14001481,E07000012,E10000003
+2024,2024,Foxton,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011292,E14001481,E07000012,E10000003
+2024,2024,Gamlingay,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011293,E14001481,E07000012,E10000003
+2024,2024,Girton,St Neots and Mid Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011294,E14001512,E07000012,E10000003
+2024,2024,Hardwick,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011295,E14001481,E07000012,E10000003
+2024,2024,Harston & Comberton,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011296,E14001481,E07000012,E10000003
+2024,2024,Histon & Impington,St Neots and Mid Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011297,E14001512,E07000012,E10000003
+2024,2024,Linton,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011298,E14001481,E07000012,E10000003
+2024,2024,Melbourn,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011300,E14001481,E07000012,E10000003
+2024,2024,Milton & Waterbeach,Ely and East Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011301,E14001224,E07000012,E10000003
+2024,2024,Shelford,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011304,E14001481,E07000012,E10000003
+2024,2024,Swavesey,St Neots and Mid Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011305,E14001512,E07000012,E10000003
+2024,2024,The Mordens,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011306,E14001481,E07000012,E10000003
+2024,2024,Whittlesford,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05011307,E14001481,E07000012,E10000003
+2024,2024,Longstanton,St Neots and Mid Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05013880,E14001512,E07000012,E10000003
+2024,2024,Over & Willingham,St Neots and Mid Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05013881,E14001512,E07000012,E10000003
+2024,2024,Cambourne,St Neots and Mid Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05014031,E14001512,E07000012,E10000003
+2024,2024,Caxton & Papworth,St Neots and Mid Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05014032,E14001512,E07000012,E10000003
+2024,2024,Duxford,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05014169,E14001481,E07000012,E10000003
+2024,2024,Sawston,South Cambridgeshire,South Cambridgeshire,Cambridgeshire,E05014170,E14001481,E07000012,E10000003
+2024,2024,Alfreton,Amber Valley,Amber Valley,Derbyshire,E05014690,E14001066,E07000032,E10000007
+2024,2024,Alport & South West Parishes,Derbyshire Dales,Amber Valley,Derbyshire,E05014691,E14001195,E07000032,E10000007
+2024,2024,Alport & South West Parishes,Mid Derbyshire,Amber Valley,Derbyshire,E05014691,E14001362,E07000032,E10000007
+2024,2024,Belper East,Mid Derbyshire,Amber Valley,Derbyshire,E05014692,E14001362,E07000032,E10000007
+2024,2024,Belper North,Mid Derbyshire,Amber Valley,Derbyshire,E05014693,E14001362,E07000032,E10000007
+2024,2024,Belper South,Mid Derbyshire,Amber Valley,Derbyshire,E05014694,E14001362,E07000032,E10000007
+2024,2024,"Codnor, Langley Mill & Aldercar",Amber Valley,Amber Valley,Derbyshire,E05014695,E14001066,E07000032,E10000007
+2024,2024,Crich & South Wingfield,Amber Valley,Amber Valley,Derbyshire,E05014696,E14001066,E07000032,E10000007
+2024,2024,Bonsall & Winster,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014592,E14001195,E07000035,E10000007
+2024,2024,Dulverton & Exmoor,Tiverton and Minehead,Somerset,Somerset,E05014358,E14001548,E06000066,E06000066
+2024,2024,Stenson,South Derbyshire,South Derbyshire,Derbyshire,E05008820,E14001483,E07000039,E10000007
+2024,2024,King's Hedges,Cambridge,Cambridge,Cambridgeshire,E05013056,E14001149,E07000008,E10000003
+2024,2024,Canonsleigh,Tiverton and Minehead,Mid Devon,Devon,E05014798,E14001548,E07000042,E10000008
+2024,2024,Hope Valley,High Peak,High Peak,Derbyshire,E05010636,E14001287,E07000037,E10000007
+2024,2024,Crich & South Wingfield,Derbyshire Dales,Amber Valley,Derbyshire,E05014696,E14001195,E07000032,E10000007
+2024,2024,Howard Town,High Peak,High Peak,Derbyshire,E05010637,E14001287,E07000037,E10000007
+2024,2024,Duffield & Quarndon,Mid Derbyshire,Amber Valley,Derbyshire,E05014697,E14001362,E07000032,E10000007
+2024,2024,Limestone Peak,High Peak,High Peak,Derbyshire,E05010638,E14001287,E07000037,E10000007
+2024,2024,Heage & Ambergate,Amber Valley,Amber Valley,Derbyshire,E05014698,E14001066,E07000032,E10000007
+2024,2024,New Mills East,High Peak,High Peak,Derbyshire,E05010639,E14001287,E07000037,E10000007
+2024,2024,Clare & Shuttern,Tiverton and Minehead,Mid Devon,Devon,E05014799,E14001548,E07000042,E10000008
+2024,2024,Market,Cambridge,Cambridge,Cambridgeshire,E05013057,E14001149,E07000008,E10000003
+2024,2024,Heanor East,Amber Valley,Amber Valley,Derbyshire,E05014699,E14001066,E07000032,E10000007
+2024,2024,Dunster,Tiverton and Minehead,Somerset,Somerset,E05014359,E14001548,E06000066,E06000066
+2024,2024,New Mills West,High Peak,High Peak,Derbyshire,E05010640,E14001287,E07000037,E10000007
+2024,2024,Swadlincote,South Derbyshire,South Derbyshire,Derbyshire,E05008821,E14001483,E07000039,E10000007
+2024,2024,Crediton Boniface,Central Devon,Mid Devon,Devon,E05014800,E14001155,E07000042,E10000008
+2024,2024,Bradwell,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014593,E14001195,E07000035,E10000007
+2024,2024,Newnham,Cambridge,Cambridge,Cambridgeshire,E05013058,E14001149,E07000008,E10000003
+2024,2024,Heanor West & Loscoe,Amber Valley,Amber Valley,Derbyshire,E05014700,E14001066,E07000032,E10000007
+2024,2024,Frome East,Frome and East Somerset,Somerset,Somerset,E05014360,E14001241,E06000066,E06000066
+2024,2024,Old Glossop,High Peak,High Peak,Derbyshire,E05010641,E14001287,E07000037,E10000007
+2024,2024,Willington and Findern,South Derbyshire,South Derbyshire,Derbyshire,E05008822,E14001483,E07000039,E10000007
+2024,2024,Crediton Lawrence,Central Devon,Mid Devon,Devon,E05014801,E14001155,E07000042,E10000008
+2024,2024,Brailsford,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014594,E14001195,E07000035,E10000007
+2024,2024,Petersfield,Cambridge,Cambridge,Cambridgeshire,E05013059,E14001149,E07000008,E10000003
+2024,2024,Ironville & Riddings,Amber Valley,Amber Valley,Derbyshire,E05014701,E14001066,E07000032,E10000007
+2024,2024,Frome North,Frome and East Somerset,Somerset,Somerset,E05014361,E14001241,E06000066,E06000066
+2024,2024,Padfield,High Peak,High Peak,Derbyshire,E05010642,E14001287,E07000037,E10000007
+2024,2024,Woodville,South Derbyshire,South Derbyshire,Derbyshire,E05008823,E14001483,E07000039,E10000007
+2024,2024,Cullompton Padbrook,Honiton and Sidmouth,Mid Devon,Devon,E05014802,E14001291,E07000042,E10000008
+2024,2024,Calver & Longstone,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014595,E14001195,E07000035,E10000007
+2024,2024,Queen Edith's,South Cambridgeshire,Cambridge,Cambridgeshire,E05013060,E14001481,E07000008,E10000003
+2024,2024,Romsey,Cambridge,Cambridge,Cambridgeshire,E05013061,E14001149,E07000008,E10000003
+2024,2024,Trumpington,Cambridge,Cambridge,Cambridgeshire,E05013062,E14001149,E07000008,E10000003
+2024,2024,West Chesterton,Cambridge,Cambridge,Cambridgeshire,E05013063,E14001149,E07000008,E10000003
+2024,2024,Burwell,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05011561,E14001224,E07000009,E10000003
+2024,2024,Downham Villages,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05011562,E14001224,E07000009,E10000003
+2024,2024,Ely East,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05011563,E14001224,E07000009,E10000003
+2024,2024,Ely North,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05011564,E14001224,E07000009,E10000003
+2024,2024,Ely West,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05011565,E14001224,E07000009,E10000003
+2024,2024,Fordham & Isleham,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05011566,E14001224,E07000009,E10000003
+2024,2024,Haddenham,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05011567,E14001224,E07000009,E10000003
+2024,2024,Littleport,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05011568,E14001224,E07000009,E10000003
+2024,2024,Soham North,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05011569,E14001224,E07000009,E10000003
+2024,2024,Soham South,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05011570,E14001224,E07000009,E10000003
+2024,2024,Stretham,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05011571,E14001224,E07000009,E10000003
+2024,2024,Sutton,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05011572,E14001224,E07000009,E10000003
+2024,2024,Bottisham,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05015488,E14001224,E07000009,E10000003
+2024,2024,Woodditton,Ely and East Cambridgeshire,East Cambridgeshire,Cambridgeshire,E05015489,E14001224,E07000009,E10000003
+2024,2024,Chatteris North & Manea,North East Cambridgeshire,Fenland,Cambridgeshire,E05015421,E14001390,E07000010,E10000003
+2024,2024,Chatteris South,North East Cambridgeshire,Fenland,Cambridgeshire,E05015422,E14001390,E07000010,E10000003
+2024,2024,Doddington & Wimblington,North East Cambridgeshire,Fenland,Cambridgeshire,E05015423,E14001390,E07000010,E10000003
+2024,2024,Elm & Christchurch,North East Cambridgeshire,Fenland,Cambridgeshire,E05015424,E14001390,E07000010,E10000003
+2024,2024,Leverington & Wisbech Rural,North East Cambridgeshire,Fenland,Cambridgeshire,E05015425,E14001390,E07000010,E10000003
+2024,2024,March East,North East Cambridgeshire,Fenland,Cambridgeshire,E05015426,E14001390,E07000010,E10000003
+2024,2024,March North,North East Cambridgeshire,Fenland,Cambridgeshire,E05015427,E14001390,E07000010,E10000003
+2024,2024,March South,North East Cambridgeshire,Fenland,Cambridgeshire,E05015428,E14001390,E07000010,E10000003
+2024,2024,March West & Benwick,North East Cambridgeshire,Fenland,Cambridgeshire,E05015429,E14001390,E07000010,E10000003
+2024,2024,Parson Drove & Wisbech St Mary,North East Cambridgeshire,Fenland,Cambridgeshire,E05015430,E14001390,E07000010,E10000003
+2024,2024,Whittlesey East & Villages,North East Cambridgeshire,Fenland,Cambridgeshire,E05015431,E14001390,E07000010,E10000003
+2024,2024,Whittlesey Lattersey,North East Cambridgeshire,Fenland,Cambridgeshire,E05015432,E14001390,E07000010,E10000003
+2024,2024,Whittlesey North West,North East Cambridgeshire,Fenland,Cambridgeshire,E05015433,E14001390,E07000010,E10000003
+2024,2024,Whittlesey South,North East Cambridgeshire,Fenland,Cambridgeshire,E05015434,E14001390,E07000010,E10000003
+2024,2024,Wisbech North,North East Cambridgeshire,Fenland,Cambridgeshire,E05015435,E14001390,E07000010,E10000003
+2024,2024,Wisbech Riverside,North East Cambridgeshire,Fenland,Cambridgeshire,E05015436,E14001390,E07000010,E10000003
+2024,2024,Wisbech South,North East Cambridgeshire,Fenland,Cambridgeshire,E05015437,E14001390,E07000010,E10000003
+2024,2024,Wisbech Walsoken & Waterlees,North East Cambridgeshire,Fenland,Cambridgeshire,E05015438,E14001390,E07000010,E10000003
+2024,2024,Alconbury,Huntingdon,Huntingdonshire,Cambridgeshire,E05011256,E14001298,E07000011,E10000003
+2024,2024,Brampton,Huntingdon,Huntingdonshire,Cambridgeshire,E05011257,E14001298,E07000011,E10000003
+2024,2024,Buckden,Huntingdon,Huntingdonshire,Cambridgeshire,E05011258,E14001298,E07000011,E10000003
+2024,2024,Fenstanton,St Neots and Mid Cambridgeshire,Huntingdonshire,Cambridgeshire,E05011259,E14001512,E07000011,E10000003
+2024,2024,Godmanchester & Hemingford Abbots,Huntingdon,Huntingdonshire,Cambridgeshire,E05011260,E14001298,E07000011,E10000003
+2024,2024,Great Paxton,St Neots and Mid Cambridgeshire,Huntingdonshire,Cambridgeshire,E05011261,E14001512,E07000011,E10000003
+2024,2024,Great Staughton,Huntingdon,Huntingdonshire,Cambridgeshire,E05011262,E14001298,E07000011,E10000003
+2024,2024,Hemingford Grey & Houghton,Huntingdon,Huntingdonshire,Cambridgeshire,E05011263,E14001298,E07000011,E10000003
+2024,2024,Holywell-cum-Needingworth,Huntingdon,Huntingdonshire,Cambridgeshire,E05011264,E14001298,E07000011,E10000003
+2024,2024,Huntingdon East,Huntingdon,Huntingdonshire,Cambridgeshire,E05011265,E14001298,E07000011,E10000003
+2024,2024,Chatsworth,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014596,E14001195,E07000035,E10000007
+2024,2024,Axminster,Honiton and Sidmouth,East Devon,Devon,E05011782,E14001291,E07000040,E10000008
+2024,2024,St John's,High Peak,High Peak,Derbyshire,E05010643,E14001287,E07000037,E10000007
+2024,2024,Sett,High Peak,High Peak,Derbyshire,E05010644,E14001287,E07000037,E10000007
+2024,2024,Simmondley,High Peak,High Peak,Derbyshire,E05010645,E14001287,E07000037,E10000007
+2024,2024,Cromford & Matlock Bath,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014597,E14001195,E07000035,E10000007
+2024,2024,Beer & Branscombe,Honiton and Sidmouth,East Devon,Devon,E05011783,E14001291,E07000040,E10000008
+2024,2024,"Kilburn, Denby, Holbrook & Horsley",Amber Valley,Amber Valley,Derbyshire,E05014702,E14001066,E07000032,E10000007
+2024,2024,Frome West,Frome and East Somerset,Somerset,Somerset,E05014362,E14001241,E06000066,E06000066
+2024,2024,Cullompton St Andrews,Honiton and Sidmouth,Mid Devon,Devon,E05014803,E14001291,E07000042,E10000008
+2024,2024,Broadclyst,Exmouth and Exeter East,East Devon,Devon,E05011784,E14001232,E07000040,E10000008
+2024,2024,Cullompton Vale,Honiton and Sidmouth,Mid Devon,Devon,E05014804,E14001291,E07000042,E10000008
+2024,2024,Halberton,Honiton and Sidmouth,Mid Devon,Devon,E05014805,E14001291,E07000042,E10000008
+2024,2024,Budleigh & Raleigh,Exmouth and Exeter East,East Devon,Devon,E05011785,E14001232,E07000040,E10000008
+2024,2024,Stone Bench,High Peak,High Peak,Derbyshire,E05010646,E14001287,E07000037,E10000007
+2024,2024,Halberton,Tiverton and Minehead,Mid Devon,Devon,E05014805,E14001548,E07000042,E10000008
+2024,2024,Glastonbury,Glastonbury and Somerton,Somerset,Somerset,E05014363,E14001247,E06000066,E06000066
+2024,2024,Ripley,Amber Valley,Amber Valley,Derbyshire,E05014703,E14001066,E07000032,E10000007
+2024,2024,Clyst Valley,Exmouth and Exeter East,East Devon,Devon,E05011786,E14001232,E07000040,E10000008
+2024,2024,Darley Dale,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014598,E14001195,E07000035,E10000007
+2024,2024,Temple,High Peak,High Peak,Derbyshire,E05010647,E14001287,E07000037,E10000007
+2024,2024,Lower Culm,Honiton and Sidmouth,Mid Devon,Devon,E05014806,E14001291,E07000042,E10000008
+2024,2024,Highbridge & Burnham South,Bridgwater,Somerset,Somerset,E05014364,E14001126,E06000066,E06000066
+2024,2024,Ripley & Marehay,Amber Valley,Amber Valley,Derbyshire,E05014704,E14001066,E07000032,E10000007
+2024,2024,Coly Valley,Honiton and Sidmouth,East Devon,Devon,E05011787,E14001291,E07000040,E10000008
+2024,2024,Tintwistle,High Peak,High Peak,Derbyshire,E05010648,E14001287,E07000037,E10000007
+2024,2024,"Dovedale, Parwich & Brassington",Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014599,E14001195,E07000035,E10000007
+2024,2024,Whaley Bridge,High Peak,High Peak,Derbyshire,E05010649,E14001287,E07000037,E10000007
+2024,2024,Doveridge & Sudbury,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014600,E14001195,E07000035,E10000007
+2024,2024,Whitfield,High Peak,High Peak,Derbyshire,E05010650,E14001287,E07000037,E10000007
+2024,2024,Hartington & Taddington,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014601,E14001195,E07000035,E10000007
+2024,2024,Ashover,North East Derbyshire,North East Derbyshire,Derbyshire,E05012040,E14001391,E07000038,E10000007
+2024,2024,Hathersage,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014602,E14001195,E07000035,E10000007
+2024,2024,Barlow & Holmesfield,North East Derbyshire,North East Derbyshire,Derbyshire,E05012041,E14001391,E07000038,E10000007
+2024,2024,Hulland,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014603,E14001195,E07000035,E10000007
+2024,2024,"Smalley, Shipley & Horsley Woodhouse",Amber Valley,Amber Valley,Derbyshire,E05014705,E14001066,E07000032,E10000007
+2024,2024,Huntspill,Bridgwater,Somerset,Somerset,E05014365,E14001126,E06000066,E06000066
+2024,2024,Brampton & Walton,North East Derbyshire,North East Derbyshire,Derbyshire,E05012042,E14001391,E07000038,E10000007
+2024,2024,Somercotes,Amber Valley,Amber Valley,Derbyshire,E05014706,E14001066,E07000032,E10000007
+2024,2024,Matlock East & Tansley,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014604,E14001195,E07000035,E10000007
+2024,2024,Cranbrook,Exmouth and Exeter East,East Devon,Devon,E05011788,E14001232,E07000040,E10000008
+2024,2024,Lower Culm,Tiverton and Minehead,Mid Devon,Devon,E05014806,E14001548,E07000042,E10000008
+2024,2024,Dunkeswell & Otterhead,Honiton and Sidmouth,East Devon,Devon,E05011789,E14001291,E07000040,E10000008
+2024,2024,Sandford & Creedy,Central Devon,Mid Devon,Devon,E05014807,E14001155,E07000042,E10000008
+2024,2024,Exe Valley,Exmouth and Exeter East,East Devon,Devon,E05011790,E14001232,E07000040,E10000008
+2024,2024,Silverton,Central Devon,Mid Devon,Devon,E05014808,E14001155,E07000042,E10000008
+2024,2024,Exmouth Brixington,Exmouth and Exeter East,East Devon,Devon,E05011791,E14001232,E07000040,E10000008
+2024,2024,Taw Vale,Central Devon,Mid Devon,Devon,E05014809,E14001155,E07000042,E10000008
+2024,2024,Exmouth Halsdon,Exmouth and Exeter East,East Devon,Devon,E05011792,E14001232,E07000040,E10000008
+2024,2024,Tiverton Castle,Tiverton and Minehead,Mid Devon,Devon,E05014810,E14001548,E07000042,E10000008
+2024,2024,Exmouth Littleham,Exmouth and Exeter East,East Devon,Devon,E05011793,E14001232,E07000040,E10000008
+2024,2024,Tiverton Cranmore,Tiverton and Minehead,Mid Devon,Devon,E05014811,E14001548,E07000042,E10000008
+2024,2024,Exmouth Town,Exmouth and Exeter East,East Devon,Devon,E05011794,E14001232,E07000040,E10000008
+2024,2024,Tiverton Lowman,Tiverton and Minehead,Mid Devon,Devon,E05014812,E14001548,E07000042,E10000008
+2024,2024,Exmouth Withycombe Raleigh,Exmouth and Exeter East,East Devon,Devon,E05011795,E14001232,E07000040,E10000008
+2024,2024,Tiverton Westexe,Tiverton and Minehead,Mid Devon,Devon,E05014813,E14001548,E07000042,E10000008
+2024,2024,Feniton,Honiton and Sidmouth,East Devon,Devon,E05011796,E14001291,E07000040,E10000008
+2024,2024,Upper Culm,Tiverton and Minehead,Mid Devon,Devon,E05014814,E14001548,E07000042,E10000008
+2024,2024,Honiton St Michael's,Honiton and Sidmouth,East Devon,Devon,E05011797,E14001291,E07000040,E10000008
+2024,2024,Upper Yeo & Taw,Central Devon,Mid Devon,Devon,E05014815,E14001155,E07000042,E10000008
+2024,2024,Way,Central Devon,Mid Devon,Devon,E05014816,E14001155,E07000042,E10000008
+2024,2024,Yeo,Central Devon,Mid Devon,Devon,E05014817,E14001155,E07000042,E10000008
+2024,2024,Barnstaple Central,North Devon,North Devon,Devon,E05012412,E14001387,E07000043,E10000008
+2024,2024,Barnstaple with Pilton,North Devon,North Devon,Devon,E05012413,E14001387,E07000043,E10000008
+2024,2024,Barnstaple with Westacott,North Devon,North Devon,Devon,E05012414,E14001387,E07000043,E10000008
+2024,2024,Bickington,North Devon,North Devon,Devon,E05012415,E14001387,E07000043,E10000008
+2024,2024,Bishop's Nympton,North Devon,North Devon,Devon,E05012416,E14001387,E07000043,E10000008
+2024,2024,Bratton Fleming,North Devon,North Devon,Devon,E05012417,E14001387,E07000043,E10000008
+2024,2024,Braunton East,North Devon,North Devon,Devon,E05012418,E14001387,E07000043,E10000008
+2024,2024,Braunton West & Georgeham,North Devon,North Devon,Devon,E05012419,E14001387,E07000043,E10000008
+2024,2024,Chittlehampton,North Devon,North Devon,Devon,E05012420,E14001387,E07000043,E10000008
+2024,2024,Chulmleigh,North Devon,North Devon,Devon,E05012421,E14001387,E07000043,E10000008
+2024,2024,Combe Martin,North Devon,North Devon,Devon,E05012422,E14001387,E07000043,E10000008
+2024,2024,Fremington,North Devon,North Devon,Devon,E05012423,E14001387,E07000043,E10000008
+2024,2024,Heanton Punchardon,North Devon,North Devon,Devon,E05012424,E14001387,E07000043,E10000008
+2024,2024,Ilfracombe East,North Devon,North Devon,Devon,E05012425,E14001387,E07000043,E10000008
+2024,2024,Ilfracombe West,North Devon,North Devon,Devon,E05012426,E14001387,E07000043,E10000008
+2024,2024,Instow,North Devon,North Devon,Devon,E05012427,E14001387,E07000043,E10000008
+2024,2024,Landkey,North Devon,North Devon,Devon,E05012428,E14001387,E07000043,E10000008
+2024,2024,Lynton & Lynmouth,North Devon,North Devon,Devon,E05012429,E14001387,E07000043,E10000008
+2024,2024,Marwood,North Devon,North Devon,Devon,E05012430,E14001387,E07000043,E10000008
+2024,2024,Mortehoe,North Devon,North Devon,Devon,E05012431,E14001387,E07000043,E10000008
+2024,2024,Newport,North Devon,North Devon,Devon,E05012432,E14001387,E07000043,E10000008
+2024,2024,North Molton,North Devon,North Devon,Devon,E05012433,E14001387,E07000043,E10000008
+2024,2024,Roundswell,North Devon,North Devon,Devon,E05012434,E14001387,E07000043,E10000008
+2024,2024,South Molton,North Devon,North Devon,Devon,E05012435,E14001387,E07000043,E10000008
+2024,2024,Witheridge,North Devon,North Devon,Devon,E05012436,E14001387,E07000043,E10000008
+2024,2024,Allington & Strete,South Devon,South Hams,Devon,E05010128,E14001484,E07000044,E10000008
+2024,2024,Bickleigh & Cornwood,South West Devon,South Hams,Devon,E05010129,E14001495,E07000044,E10000008
+2024,2024,Blackawton & Stoke Fleming,South Devon,South Hams,Devon,E05010130,E14001484,E07000044,E10000008
+2024,2024,Clay Cross North,North East Derbyshire,North East Derbyshire,Derbyshire,E05012043,E14001391,E07000038,E10000007
+2024,2024,Huntspill,Wells and Mendip Hills,Somerset,Somerset,E05014365,E14001572,E06000066,E06000066
+2024,2024,Swanwick,Amber Valley,Amber Valley,Derbyshire,E05014707,E14001066,E07000032,E10000007
+2024,2024,Matlock West,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014605,E14001195,E07000035,E10000007
+2024,2024,Clay Cross South,North East Derbyshire,North East Derbyshire,Derbyshire,E05012044,E14001391,E07000038,E10000007
+2024,2024,Coal Aston,North East Derbyshire,North East Derbyshire,Derbyshire,E05012045,E14001391,E07000038,E10000007
+2024,2024,Dronfield North,North East Derbyshire,North East Derbyshire,Derbyshire,E05012046,E14001391,E07000038,E10000007
+2024,2024,Dronfield South,North East Derbyshire,North East Derbyshire,Derbyshire,E05012047,E14001391,E07000038,E10000007
+2024,2024,Dronfield Woodhouse,North East Derbyshire,North East Derbyshire,Derbyshire,E05012048,E14001391,E07000038,E10000007
+2024,2024,Eckington North,North East Derbyshire,North East Derbyshire,Derbyshire,E05012049,E14001391,E07000038,E10000007
+2024,2024,Ilminster,Yeovil,Somerset,Somerset,E05014366,E14001603,E06000066,E06000066
+2024,2024,Eckington South & Renishaw,North East Derbyshire,North East Derbyshire,Derbyshire,E05012050,E14001391,E07000038,E10000007
+2024,2024,King Alfred,Bridgwater,Somerset,Somerset,E05014367,E14001126,E06000066,E06000066
+2024,2024,Gosforth Valley,North East Derbyshire,North East Derbyshire,Derbyshire,E05012051,E14001391,E07000038,E10000007
+2024,2024,Ault Hucknall,Bolsover,Bolsover,Derbyshire,E05011983,E14001109,E07000033,E10000007
+2024,2024,Barlborough,Bolsover,Bolsover,Derbyshire,E05011984,E14001109,E07000033,E10000007
+2024,2024,Blackwell,Bolsover,Bolsover,Derbyshire,E05011985,E14001109,E07000033,E10000007
+2024,2024,Bolsover East,Bolsover,Bolsover,Derbyshire,E05011986,E14001109,E07000033,E10000007
+2024,2024,Bolsover North & Shuttlewood,Bolsover,Bolsover,Derbyshire,E05011987,E14001109,E07000033,E10000007
+2024,2024,Bolsover South,Bolsover,Bolsover,Derbyshire,E05011988,E14001109,E07000033,E10000007
+2024,2024,Clowne East,Bolsover,Bolsover,Derbyshire,E05011989,E14001109,E07000033,E10000007
+2024,2024,Clowne West,Bolsover,Bolsover,Derbyshire,E05011990,E14001109,E07000033,E10000007
+2024,2024,Elmton-with-Creswell,Bolsover,Bolsover,Derbyshire,E05011991,E14001109,E07000033,E10000007
+2024,2024,Langwith,Bolsover,Bolsover,Derbyshire,E05011992,E14001109,E07000033,E10000007
+2024,2024,Pinxton,Bolsover,Bolsover,Derbyshire,E05011993,E14001109,E07000033,E10000007
+2024,2024,Shirebrook North,Bolsover,Bolsover,Derbyshire,E05011994,E14001109,E07000033,E10000007
+2024,2024,Shirebrook South,Bolsover,Bolsover,Derbyshire,E05011995,E14001109,E07000033,E10000007
+2024,2024,South Normanton East,Bolsover,Bolsover,Derbyshire,E05011996,E14001109,E07000033,E10000007
+2024,2024,South Normanton West,Bolsover,Bolsover,Derbyshire,E05011997,E14001109,E07000033,E10000007
+2024,2024,Honiton St Paul's,Honiton and Sidmouth,East Devon,Devon,E05011798,E14001291,E07000040,E10000008
+2024,2024,Tibshelf,Bolsover,Bolsover,Derbyshire,E05011998,E14001109,E07000033,E10000007
+2024,2024,Newbridges,Honiton and Sidmouth,East Devon,Devon,E05011799,E14001291,E07000040,E10000008
+2024,2024,Whitwell,Bolsover,Bolsover,Derbyshire,E05011999,E14001109,E07000033,E10000007
+2024,2024,Newton Poppleford & Harpford,Honiton and Sidmouth,East Devon,Devon,E05011800,E14001291,E07000040,E10000008
+2024,2024,Brampton East & Boythorpe,Chesterfield,Chesterfield,Derbyshire,E05015170,E14001165,E07000034,E10000007
+2024,2024,Ottery St Mary,Honiton and Sidmouth,East Devon,Devon,E05011801,E14001291,E07000040,E10000008
+2024,2024,Brampton West & Loundsley Green,Chesterfield,Chesterfield,Derbyshire,E05015171,E14001165,E07000034,E10000007
+2024,2024,Seaton,Honiton and Sidmouth,East Devon,Devon,E05011802,E14001291,E07000040,E10000008
+2024,2024,Brimington North,Chesterfield,Chesterfield,Derbyshire,E05015172,E14001165,E07000034,E10000007
+2024,2024,Sidmouth Rural,Honiton and Sidmouth,East Devon,Devon,E05011803,E14001291,E07000040,E10000008
+2024,2024,Brimington South,Chesterfield,Chesterfield,Derbyshire,E05015173,E14001165,E07000034,E10000007
+2024,2024,Sidmouth Sidford,Honiton and Sidmouth,East Devon,Devon,E05011804,E14001291,E07000040,E10000008
+2024,2024,Brockwell,Chesterfield,Chesterfield,Derbyshire,E05015174,E14001165,E07000034,E10000007
+2024,2024,Sidmouth Town,Honiton and Sidmouth,East Devon,Devon,E05011805,E14001291,E07000040,E10000008
+2024,2024,Dunston,Chesterfield,Chesterfield,Derbyshire,E05015175,E14001165,E07000034,E10000007
+2024,2024,Tale Vale,Honiton and Sidmouth,East Devon,Devon,E05011806,E14001291,E07000040,E10000008
+2024,2024,Hasland,Chesterfield,Chesterfield,Derbyshire,E05015176,E14001165,E07000034,E10000007
+2024,2024,Trinity,Honiton and Sidmouth,East Devon,Devon,E05011807,E14001291,E07000040,E10000008
+2024,2024,Linacre,Chesterfield,Chesterfield,Derbyshire,E05015177,E14001165,E07000034,E10000007
+2024,2024,West Hill & Aylesbeare,Honiton and Sidmouth,East Devon,Devon,E05011808,E14001291,E07000040,E10000008
+2024,2024,Whimple & Rockbeare,Exmouth and Exeter East,East Devon,Devon,E05011809,E14001232,E07000040,E10000008
+2024,2024,Woodbury & Lympstone,Exmouth and Exeter East,East Devon,Devon,E05011810,E14001232,E07000040,E10000008
+2024,2024,Yarty,Honiton and Sidmouth,East Devon,Devon,E05011811,E14001291,E07000040,E10000008
+2024,2024,Alphington,Exeter,Exeter,Devon,E05011011,E14001231,E07000041,E10000008
+2024,2024,Duryard and St James,Exeter,Exeter,Devon,E05011012,E14001231,E07000041,E10000008
+2024,2024,Exwick,Exeter,Exeter,Devon,E05011013,E14001231,E07000041,E10000008
+2024,2024,Heavitree,Exeter,Exeter,Devon,E05011014,E14001231,E07000041,E10000008
+2024,2024,Mincinglake and Whipton,Exeter,Exeter,Devon,E05011015,E14001231,E07000041,E10000008
+2024,2024,Newtown and St Leonard's,Exeter,Exeter,Devon,E05011016,E14001231,E07000041,E10000008
+2024,2024,Norbury,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014606,E14001195,E07000035,E10000007
+2024,2024,Pennsylvania,Exeter,Exeter,Devon,E05011017,E14001231,E07000041,E10000008
+2024,2024,Pinhoe,Exmouth and Exeter East,Exeter,Devon,E05011018,E14001232,E07000041,E10000008
+2024,2024,Priory,Exeter,Exeter,Devon,E05011019,E14001231,E07000041,E10000008
+2024,2024,St David's,Exeter,Exeter,Devon,E05011020,E14001231,E07000041,E10000008
+2024,2024,St Loyes,Exmouth and Exeter East,Exeter,Devon,E05011021,E14001232,E07000041,E10000008
+2024,2024,St Thomas,Exeter,Exeter,Devon,E05011022,E14001231,E07000041,E10000008
+2024,2024,Topsham,Exmouth and Exeter East,Exeter,Devon,E05011023,E14001232,E07000041,E10000008
+2024,2024,Bradninch,Central Devon,Mid Devon,Devon,E05014796,E14001155,E07000042,E10000008
+2024,2024,Bradninch,Honiton and Sidmouth,Mid Devon,Devon,E05014796,E14001291,E07000042,E10000008
+2024,2024,Cadbury,Central Devon,Mid Devon,Devon,E05014797,E14001155,E07000042,E10000008
+2024,2024,King Alfred,Wells and Mendip Hills,Somerset,Somerset,E05014367,E14001572,E06000066,E06000066
+2024,2024,Grassmoor,North East Derbyshire,North East Derbyshire,Derbyshire,E05012052,E14001391,E07000038,E10000007
+2024,2024,Lydeard,Taunton and Wellington,Somerset,Somerset,E05014368,E14001540,E06000066,E06000066
+2024,2024,Lydeard,Tiverton and Minehead,Somerset,Somerset,E05014368,E14001548,E06000066,E06000066
+2024,2024,Martock,Glastonbury and Somerton,Somerset,Somerset,E05014369,E14001247,E06000066,E06000066
+2024,2024,Mendip Central and East,Frome and East Somerset,Somerset,Somerset,E05014370,E14001241,E06000066,E06000066
+2024,2024,Mendip Hills,Frome and East Somerset,Somerset,Somerset,E05014371,E14001241,E06000066,E06000066
+2024,2024,Mendip Hills,Wells and Mendip Hills,Somerset,Somerset,E05014371,E14001572,E06000066,E06000066
+2024,2024,Mendip South,Frome and East Somerset,Somerset,Somerset,E05014372,E14001241,E06000066,E06000066
+2024,2024,Mendip South,Glastonbury and Somerton,Somerset,Somerset,E05014372,E14001247,E06000066,E06000066
+2024,2024,Mendip South,Wells and Mendip Hills,Somerset,Somerset,E05014372,E14001572,E06000066,E06000066
+2024,2024,Mendip West,Wells and Mendip Hills,Somerset,Somerset,E05014373,E14001572,E06000066,E06000066
+2024,2024,Minehead,Tiverton and Minehead,Somerset,Somerset,E05014374,E14001548,E06000066,E06000066
+2024,2024,Monkton & North Curry,Taunton and Wellington,Somerset,Somerset,E05014375,E14001540,E06000066,E06000066
+2024,2024,North Petherton,Bridgwater,Somerset,Somerset,E05014376,E14001126,E06000066,E06000066
+2024,2024,Rowbarton & Staplegrove,Taunton and Wellington,Somerset,Somerset,E05014377,E14001540,E06000066,E06000066
+2024,2024,Shepton Mallet,Wells and Mendip Hills,Somerset,Somerset,E05014378,E14001572,E06000066,E06000066
+2024,2024,Somerton,Glastonbury and Somerton,Somerset,Somerset,E05014379,E14001247,E06000066,E06000066
+2024,2024,South Petherton & Islemoor,Glastonbury and Somerton,Somerset,Somerset,E05014380,E14001247,E06000066,E06000066
+2024,2024,Holmewood & Heath,Bolsover,North East Derbyshire,Derbyshire,E05012053,E14001109,E07000038,E10000007
+2024,2024,Killamarsh East,North East Derbyshire,North East Derbyshire,Derbyshire,E05012054,E14001391,E07000038,E10000007
+2024,2024,Killamarsh West,North East Derbyshire,North East Derbyshire,Derbyshire,E05012055,E14001391,E07000038,E10000007
+2024,2024,Rother,Chesterfield,Chesterfield,Derbyshire,E05015178,E14001165,E07000034,E10000007
+2024,2024,North Wingfield Central,North East Derbyshire,North East Derbyshire,Derbyshire,E05012056,E14001391,E07000038,E10000007
+2024,2024,Spire,Chesterfield,Chesterfield,Derbyshire,E05015179,E14001165,E07000034,E10000007
+2024,2024,Pilsley & Morton,Bolsover,North East Derbyshire,Derbyshire,E05012057,E14001109,E07000038,E10000007
+2024,2024,Tideswell,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014607,E14001195,E07000035,E10000007
+2024,2024,Staveley Central,Chesterfield,Chesterfield,Derbyshire,E05015180,E14001165,E07000034,E10000007
+2024,2024,Ridgeway & Marsh Lane,North East Derbyshire,North East Derbyshire,Derbyshire,E05012058,E14001391,E07000038,E10000007
+2024,2024,Wirksworth,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014608,E14001195,E07000035,E10000007
+2024,2024,Staveley Central,North East Derbyshire,Chesterfield,Derbyshire,E05015180,E14001391,E07000034,E10000007
+2024,2024,South Petherton & Islemoor,Yeovil,Somerset,Somerset,E05014380,E14001603,E06000066,E06000066
+2024,2024,Shirland,Bolsover,North East Derbyshire,Derbyshire,E05012059,E14001109,E07000038,E10000007
+2024,2024,Youlgrave,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014609,E14001195,E07000035,E10000007
+2024,2024,Staveley North,North East Derbyshire,Chesterfield,Derbyshire,E05015181,E14001391,E07000034,E10000007
+2024,2024,Street,Glastonbury and Somerton,Somerset,Somerset,E05014381,E14001247,E06000066,E06000066
+2024,2024,Sutton,Bolsover,North East Derbyshire,Derbyshire,E05012060,E14001109,E07000038,E10000007
+2024,2024,Awsworth Road,Erewash,Erewash,Derbyshire,E05010604,E14001228,E07000036,E10000007
+2024,2024,Staveley South,Chesterfield,Chesterfield,Derbyshire,E05015182,E14001165,E07000034,E10000007
+2024,2024,Taunton East,Taunton and Wellington,Somerset,Somerset,E05014382,E14001540,E06000066,E06000066
+2024,2024,Tupton,North East Derbyshire,North East Derbyshire,Derbyshire,E05012061,E14001391,E07000038,E10000007
+2024,2024,Breaston,Erewash,Erewash,Derbyshire,E05010605,E14001228,E07000036,E10000007
+2024,2024,Walton,Chesterfield,Chesterfield,Derbyshire,E05015183,E14001165,E07000034,E10000007
+2024,2024,Taunton North,Taunton and Wellington,Somerset,Somerset,E05014383,E14001540,E06000066,E06000066
+2024,2024,Unstone,North East Derbyshire,North East Derbyshire,Derbyshire,E05012062,E14001391,E07000038,E10000007
+2024,2024,Cotmanhay,Erewash,Erewash,Derbyshire,E05010606,E14001228,E07000036,E10000007
+2024,2024,Whittington,Chesterfield,Chesterfield,Derbyshire,E05015184,E14001165,E07000034,E10000007
+2024,2024,Taunton South,Taunton and Wellington,Somerset,Somerset,E05014384,E14001540,E06000066,E06000066
+2024,2024,Wingerworth,North East Derbyshire,North East Derbyshire,Derbyshire,E05012063,E14001391,E07000038,E10000007
+2024,2024,Derby Road East,Erewash,Erewash,Derbyshire,E05010607,E14001228,E07000036,E10000007
+2024,2024,Whittington,North East Derbyshire,Chesterfield,Derbyshire,E05015184,E14001391,E07000034,E10000007
+2024,2024,Upper Tone,Taunton and Wellington,Somerset,Somerset,E05014385,E14001540,E06000066,E06000066
+2024,2024,Aston,South Derbyshire,South Derbyshire,Derbyshire,E05008809,E14001483,E07000039,E10000007
+2024,2024,Derby Road West,Erewash,Erewash,Derbyshire,E05010608,E14001228,E07000036,E10000007
+2024,2024,Whittington Moor,Chesterfield,Chesterfield,Derbyshire,E05015185,E14001165,E07000034,E10000007
+2024,2024,Upper Tone,Tiverton and Minehead,Somerset,Somerset,E05014385,E14001548,E06000066,E06000066
+2024,2024,Church Gresley,South Derbyshire,South Derbyshire,Derbyshire,E05008810,E14001483,E07000039,E10000007
+2024,2024,Draycott & Risley,Erewash,Erewash,Derbyshire,E05010609,E14001228,E07000036,E10000007
+2024,2024,Ashbourne North,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014589,E14001195,E07000035,E10000007
+2024,2024,Watchet & Stogursey,Tiverton and Minehead,Somerset,Somerset,E05014386,E14001548,E06000066,E06000066
+2024,2024,Etwall,South Derbyshire,South Derbyshire,Derbyshire,E05008811,E14001483,E07000039,E10000007
+2024,2024,Wellington,Taunton and Wellington,Somerset,Somerset,E05014387,E14001540,E06000066,E06000066
+2024,2024,Ashbourne South,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014590,E14001195,E07000035,E10000007
+2024,2024,Hatton,Derbyshire Dales,South Derbyshire,Derbyshire,E05008812,E14001195,E07000039,E10000007
+2024,2024,Wells,Wells and Mendip Hills,Somerset,Somerset,E05014388,E14001572,E06000066,E06000066
+2024,2024,Bakewell,Derbyshire Dales,Derbyshire Dales,Derbyshire,E05014591,E14001195,E07000035,E10000007
+2024,2024,Hallam Fields,Erewash,Erewash,Derbyshire,E05010610,E14001228,E07000036,E10000007
+2024,2024,Hilton,Derbyshire Dales,South Derbyshire,Derbyshire,E05008813,E14001195,E07000039,E10000007
+2024,2024,Wincanton & Bruton,Glastonbury and Somerton,Somerset,Somerset,E05014389,E14001247,E06000066,E06000066
+2024,2024,Kirk Hallam & Stanton-by-Dale,Erewash,Erewash,Derbyshire,E05010611,E14001228,E07000036,E10000007
+2024,2024,Linton,South Derbyshire,South Derbyshire,Derbyshire,E05008814,E14001483,E07000039,E10000007
+2024,2024,Yeovil Central,Yeovil,Somerset,Somerset,E05014390,E14001603,E06000066,E06000066
+2024,2024,Larklands,Erewash,Erewash,Derbyshire,E05010612,E14001228,E07000036,E10000007
+2024,2024,Melbourne,South Derbyshire,South Derbyshire,Derbyshire,E05008815,E14001483,E07000039,E10000007
+2024,2024,Yeovil East,Yeovil,Somerset,Somerset,E05014391,E14001603,E06000066,E06000066
+2024,2024,Little Eaton & Stanley,Mid Derbyshire,Erewash,Derbyshire,E05010613,E14001362,E07000036,E10000007
+2024,2024,Midway,South Derbyshire,South Derbyshire,Derbyshire,E05008816,E14001483,E07000039,E10000007
+2024,2024,Yeovil South,Yeovil,Somerset,Somerset,E05014392,E14001603,E06000066,E06000066
+2024,2024,Little Hallam,Erewash,Erewash,Derbyshire,E05010614,E14001228,E07000036,E10000007
+2024,2024,Newhall and Stanton,South Derbyshire,South Derbyshire,Derbyshire,E05008817,E14001483,E07000039,E10000007
+2024,2024,Yeovil West,Yeovil,Somerset,Somerset,E05014393,E14001603,E06000066,E06000066
+2024,2024,Long Eaton Central,Erewash,Erewash,Derbyshire,E05010615,E14001228,E07000036,E10000007
+2024,2024,Repton,South Derbyshire,South Derbyshire,Derbyshire,E05008818,E14001483,E07000039,E10000007
+2024,2024,Abbey,Cambridge,Cambridge,Cambridgeshire,E05013050,E14001149,E07000008,E10000003
+2024,2024,Nottingham Road,Erewash,Erewash,Derbyshire,E05010616,E14001228,E07000036,E10000007
+2024,2024,Seales,South Derbyshire,South Derbyshire,Derbyshire,E05008819,E14001483,E07000039,E10000007
+2024,2024,Arbury,Cambridge,Cambridge,Cambridgeshire,E05013051,E14001149,E07000008,E10000003
+2024,2024,Ockbrook & Borrowash,Mid Derbyshire,Erewash,Derbyshire,E05010617,E14001362,E07000036,E10000007
+2024,2024,Castle,Cambridge,Cambridge,Cambridgeshire,E05013052,E14001149,E07000008,E10000003
+2024,2024,Sandiacre,Erewash,Erewash,Derbyshire,E05010618,E14001228,E07000036,E10000007
+2024,2024,Cherry Hinton,South Cambridgeshire,Cambridge,Cambridgeshire,E05013053,E14001481,E07000008,E10000003
+2024,2024,Sawley,Erewash,Erewash,Derbyshire,E05010619,E14001228,E07000036,E10000007
+2024,2024,Shipley View,Erewash,Erewash,Derbyshire,E05010620,E14001228,E07000036,E10000007
+2024,2024,West Hallam & Dale Abbey,Mid Derbyshire,Erewash,Derbyshire,E05010621,E14001362,E07000036,E10000007
+2024,2024,Wilsthorpe,Erewash,Erewash,Derbyshire,E05010622,E14001228,E07000036,E10000007
+2024,2024,Barms,High Peak,High Peak,Derbyshire,E05010623,E14001287,E07000037,E10000007
+2024,2024,Blackbrook,High Peak,High Peak,Derbyshire,E05010624,E14001287,E07000037,E10000007
+2024,2024,Burbage,High Peak,High Peak,Derbyshire,E05010625,E14001287,E07000037,E10000007
+2024,2024,Buxton Central,High Peak,High Peak,Derbyshire,E05010626,E14001287,E07000037,E10000007
+2024,2024,Chapel East,High Peak,High Peak,Derbyshire,E05010627,E14001287,E07000037,E10000007
+2024,2024,Chapel West,High Peak,High Peak,Derbyshire,E05010628,E14001287,E07000037,E10000007
+2024,2024,Corbar,High Peak,High Peak,Derbyshire,E05010629,E14001287,E07000037,E10000007
+2024,2024,Cote Heath,High Peak,High Peak,Derbyshire,E05010630,E14001287,E07000037,E10000007
+2024,2024,Dinting,High Peak,High Peak,Derbyshire,E05010631,E14001287,E07000037,E10000007
+2024,2024,Gamesley,High Peak,High Peak,Derbyshire,E05010632,E14001287,E07000037,E10000007
+2024,2024,Hadfield North,High Peak,High Peak,Derbyshire,E05010633,E14001287,E07000037,E10000007
+2024,2024,Hadfield South,High Peak,High Peak,Derbyshire,E05010634,E14001287,E07000037,E10000007
+2024,2024,Hayfield,High Peak,High Peak,Derbyshire,E05010635,E14001287,E07000037,E10000007
+2024,2024,Coleridge,Cambridge,Cambridge,Cambridgeshire,E05013054,E14001149,E07000008,E10000003
+2024,2024,East Chesterton,Cambridge,Cambridge,Cambridgeshire,E05013055,E14001149,E07000008,E10000003
+2024,2024,Charterlands,South Devon,South Hams,Devon,E05010131,E14001484,E07000044,E10000008
+2024,2024,Dartington & Staverton,South Devon,South Hams,Devon,E05010132,E14001484,E07000044,E10000008
+2024,2024,Dartmouth & East Dart,South Devon,South Hams,Devon,E05010133,E14001484,E07000044,E10000008
+2024,2024,Ermington & Ugborough,South West Devon,South Hams,Devon,E05010134,E14001495,E07000044,E10000008
+2024,2024,Ivybridge East,South West Devon,South Hams,Devon,E05010135,E14001495,E07000044,E10000008
+2024,2024,Ivybridge West,South West Devon,South Hams,Devon,E05010136,E14001495,E07000044,E10000008
+2024,2024,Kingsbridge,South Devon,South Hams,Devon,E05010137,E14001484,E07000044,E10000008
+2024,2024,Loddiswell & Aveton Gifford,South Devon,South Hams,Devon,E05010138,E14001484,E07000044,E10000008
+2024,2024,Marldon & Littlehempston,South Devon,South Hams,Devon,E05010139,E14001484,E07000044,E10000008
+2024,2024,Newton & Yealmpton,South West Devon,South Hams,Devon,E05010140,E14001495,E07000044,E10000008
+2024,2024,Salcombe & Thurlestone,South Devon,South Hams,Devon,E05010141,E14001484,E07000044,E10000008
+2024,2024,South Brent,South Devon,South Hams,Devon,E05010142,E14001484,E07000044,E10000008
+2024,2024,Stokenham,South Devon,South Hams,Devon,E05010143,E14001484,E07000044,E10000008
+2024,2024,Totnes,South Devon,South Hams,Devon,E05010144,E14001484,E07000044,E10000008
+2024,2024,Wembury & Brixton,South West Devon,South Hams,Devon,E05010145,E14001495,E07000044,E10000008
+2024,2024,West Dart,South Devon,South Hams,Devon,E05010146,E14001484,E07000044,E10000008
+2024,2024,Woolwell,South West Devon,South Hams,Devon,E05010147,E14001495,E07000044,E10000008
+2024,2024,Ambrook,Newton Abbot,Teignbridge,Devon,E05011892,E14001381,E07000045,E10000008
+2024,2024,Ashburton & Buckfastleigh,Central Devon,Teignbridge,Devon,E05011893,E14001155,E07000045,E10000008
+2024,2024,Bishopsteignton,Newton Abbot,Teignbridge,Devon,E05011894,E14001381,E07000045,E10000008
+2024,2024,Bovey,Central Devon,Teignbridge,Devon,E05011895,E14001155,E07000045,E10000008
+2024,2024,Bradley,Newton Abbot,Teignbridge,Devon,E05011896,E14001381,E07000045,E10000008
+2024,2024,Buckland & Milber,Newton Abbot,Teignbridge,Devon,E05011897,E14001381,E07000045,E10000008
+2024,2024,Bushell,Newton Abbot,Teignbridge,Devon,E05011898,E14001381,E07000045,E10000008
+2024,2024,Chudleigh,Central Devon,Teignbridge,Devon,E05011899,E14001155,E07000045,E10000008
+2024,2024,College,Newton Abbot,Teignbridge,Devon,E05011900,E14001381,E07000045,E10000008
+2024,2024,Dawlish North East,Newton Abbot,Teignbridge,Devon,E05011901,E14001381,E07000045,E10000008
+2024,2024,Dawlish South West,Newton Abbot,Teignbridge,Devon,E05011902,E14001381,E07000045,E10000008
+2024,2024,Haytor,Central Devon,Teignbridge,Devon,E05011903,E14001155,E07000045,E10000008
+2024,2024,Ipplepen,Newton Abbot,Teignbridge,Devon,E05011904,E14001381,E07000045,E10000008
+2024,2024,Kenn Valley,Central Devon,Teignbridge,Devon,E05011905,E14001155,E07000045,E10000008
+2024,2024,Kenton & Starcross,Newton Abbot,Teignbridge,Devon,E05011906,E14001381,E07000045,E10000008
+2024,2024,Kerswell-with-Combe,Newton Abbot,Teignbridge,Devon,E05011907,E14001381,E07000045,E10000008
+2024,2024,Kingsteignton East,Newton Abbot,Teignbridge,Devon,E05011908,E14001381,E07000045,E10000008
+2024,2024,Kingsteignton West,Newton Abbot,Teignbridge,Devon,E05011909,E14001381,E07000045,E10000008
+2024,2024,Moretonhampstead,Central Devon,Teignbridge,Devon,E05011910,E14001155,E07000045,E10000008
+2024,2024,Shaldon & Stokeinteignhead,Newton Abbot,Teignbridge,Devon,E05011911,E14001381,E07000045,E10000008
+2024,2024,Teign Valley,Central Devon,Teignbridge,Devon,E05011912,E14001155,E07000045,E10000008
+2024,2024,Teignmouth Central,Newton Abbot,Teignbridge,Devon,E05011913,E14001381,E07000045,E10000008
+2024,2024,Teignmouth East,Newton Abbot,Teignbridge,Devon,E05011914,E14001381,E07000045,E10000008
+2024,2024,Teignmouth West,Newton Abbot,Teignbridge,Devon,E05011915,E14001381,E07000045,E10000008
+2024,2024,Appledore,Torridge and Tavistock,Torridge,Devon,E05011916,E14001552,E07000046,E10000008
+2024,2024,Bideford East,Torridge and Tavistock,Torridge,Devon,E05011917,E14001552,E07000046,E10000008
+2024,2024,Bideford North,Torridge and Tavistock,Torridge,Devon,E05011918,E14001552,E07000046,E10000008
+2024,2024,Bideford South,Torridge and Tavistock,Torridge,Devon,E05011919,E14001552,E07000046,E10000008
+2024,2024,Bideford West,Torridge and Tavistock,Torridge,Devon,E05011920,E14001552,E07000046,E10000008
+2024,2024,Broadheath,Torridge and Tavistock,Torridge,Devon,E05011921,E14001552,E07000046,E10000008
+2024,2024,Great Torrington,Torridge and Tavistock,Torridge,Devon,E05011922,E14001552,E07000046,E10000008
+2024,2024,Hartland,Torridge and Tavistock,Torridge,Devon,E05011923,E14001552,E07000046,E10000008
+2024,2024,Holsworthy,Torridge and Tavistock,Torridge,Devon,E05011924,E14001552,E07000046,E10000008
+2024,2024,Epping West & Rural,Epping Forest,Epping Forest,Essex,E05015728,E14001226,E07000072,E10000012
+2024,2024,Tarpots,Castle Point,Castle Point,Essex,E05015701,E14001154,E07000069,E10000012
+2024,2024,Hawkwell West,Rayleigh and Wickford,Rochford,Essex,E05010847,E14001437,E07000075,E10000012
+2024,2024,Crowborough St Johns,Sussex Weald,Wealden,East Sussex,E05011633,E14001533,E07000065,E10000011
+2024,2024,Milton & Tamarside,Torridge and Tavistock,Torridge,Devon,E05011925,E14001552,E07000046,E10000008
+2024,2024,"Chailey, Barcombe & Hamsey",East Grinstead and Uckfield,Lewes,East Sussex,E05011583,E14001212,E07000063,E10000011
+2024,2024,Wickford Park,Rayleigh and Wickford,Basildon,Essex,E05015650,E14001437,E07000066,E10000012
+2024,2024,Danehill & Fletching,East Grinstead and Uckfield,Wealden,East Sussex,E05011634,E14001212,E07000065,E10000011
+2024,2024,Forest Row,East Grinstead and Uckfield,Wealden,East Sussex,E05011635,E14001212,E07000065,E10000011
+2024,2024,Framfield & Cross-in-Hand,Sussex Weald,Wealden,East Sussex,E05011636,E14001533,E07000065,E10000011
+2024,2024,Frant & Wadhurst,Sussex Weald,Wealden,East Sussex,E05011637,E14001533,E07000065,E10000011
+2024,2024,Hadlow Down & Rotherfield,Sussex Weald,Wealden,East Sussex,E05011638,E14001533,E07000065,E10000011
+2024,2024,Hailsham Central,Sussex Weald,Wealden,East Sussex,E05011639,E14001533,E07000065,E10000011
+2024,2024,Hailsham East,Sussex Weald,Wealden,East Sussex,E05011640,E14001533,E07000065,E10000011
+2024,2024,Hailsham North,Sussex Weald,Wealden,East Sussex,E05011641,E14001533,E07000065,E10000011
+2024,2024,Hailsham North West,Sussex Weald,Wealden,East Sussex,E05011642,E14001533,E07000065,E10000011
+2024,2024,Hailsham South,Sussex Weald,Wealden,East Sussex,E05011643,E14001533,E07000065,E10000011
+2024,2024,Hailsham West,Sussex Weald,Wealden,East Sussex,E05011644,E14001533,E07000065,E10000011
+2024,2024,Hartfield,Sussex Weald,Wealden,East Sussex,E05011645,E14001533,E07000065,E10000011
+2024,2024,Heathfield North,Sussex Weald,Wealden,East Sussex,E05011646,E14001533,E07000065,E10000011
+2024,2024,Heathfield South,Sussex Weald,Wealden,East Sussex,E05011647,E14001533,E07000065,E10000011
+2024,2024,Hellingly,Sussex Weald,Wealden,East Sussex,E05011648,E14001533,E07000065,E10000011
+2024,2024,Herstmonceux & Pevensey Levels,Bexhill and Battle,Wealden,East Sussex,E05011649,E14001088,E07000065,E10000011
+2024,2024,Horam & Punnetts Town,Sussex Weald,Wealden,East Sussex,E05011650,E14001533,E07000065,E10000011
+2024,2024,Lower Willingdon,Lewes,Wealden,East Sussex,E05011651,E14001330,E07000065,E10000011
+2024,2024,Maresfield,East Grinstead and Uckfield,Wealden,East Sussex,E05011652,E14001212,E07000065,E10000011
+2024,2024,Mayfield & Five Ashes,Sussex Weald,Wealden,East Sussex,E05011653,E14001533,E07000065,E10000011
+2024,2024,Pevensey Bay,Bexhill and Battle,Wealden,East Sussex,E05011654,E14001088,E07000065,E10000011
+2024,2024,Polegate Central,Lewes,Wealden,East Sussex,E05011655,E14001330,E07000065,E10000011
+2024,2024,Polegate North,Lewes,Wealden,East Sussex,E05011656,E14001330,E07000065,E10000011
+2024,2024,Polegate South & Willingdon Watermill,Lewes,Wealden,East Sussex,E05011657,E14001330,E07000065,E10000011
+2024,2024,South Downs,Lewes,Wealden,East Sussex,E05011658,E14001330,E07000065,E10000011
+2024,2024,Stone Cross,Lewes,Wealden,East Sussex,E05011659,E14001330,E07000065,E10000011
+2024,2024,Uckfield East,East Grinstead and Uckfield,Wealden,East Sussex,E05011660,E14001212,E07000065,E10000011
+2024,2024,Uckfield New Town,East Grinstead and Uckfield,Wealden,East Sussex,E05011661,E14001212,E07000065,E10000011
+2024,2024,Uckfield North,East Grinstead and Uckfield,Wealden,East Sussex,E05011662,E14001212,E07000065,E10000011
+2024,2024,Uckfield Ridgewood & Little Horsted,East Grinstead and Uckfield,Wealden,East Sussex,E05011663,E14001212,E07000065,E10000011
+2024,2024,Upper Willingdon,Lewes,Wealden,East Sussex,E05011664,E14001330,E07000065,E10000011
+2024,2024,Withyham,Sussex Weald,Wealden,East Sussex,E05011665,E14001533,E07000065,E10000011
+2024,2024,Billericay East,Basildon and Billericay,Basildon,Essex,E05015637,E14001077,E07000066,E10000012
+2024,2024,Billericay West,Basildon and Billericay,Basildon,Essex,E05015638,E14001077,E07000066,E10000012
+2024,2024,Burstead,Basildon and Billericay,Basildon,Essex,E05015639,E14001077,E07000066,E10000012
+2024,2024,Castledon & Crouch,Basildon and Billericay,Basildon,Essex,E05015640,E14001077,E07000066,E10000012
+2024,2024,Castledon & Crouch,Rayleigh and Wickford,Basildon,Essex,E05015640,E14001437,E07000066,E10000012
+2024,2024,Fryerns,Basildon and Billericay,Basildon,Essex,E05015641,E14001077,E07000066,E10000012
+2024,2024,Laindon Park,Basildon and Billericay,Basildon,Essex,E05015642,E14001077,E07000066,E10000012
+2024,2024,Langdon Hills,South Basildon and East Thurrock,Basildon,Essex,E05015643,E14001480,E07000066,E10000012
+2024,2024,Lee Chapel North,Basildon and Billericay,Basildon,Essex,E05015644,E14001077,E07000066,E10000012
+2024,2024,Monkleigh & Putford,Torridge and Tavistock,Torridge,Devon,E05011926,E14001552,E07000046,E10000008
+2024,2024,Grange Hill,Epping Forest,Epping Forest,Essex,E05015729,E14001226,E07000072,E10000012
+2024,2024,Thundersley North,Castle Point,Castle Point,Essex,E05015702,E14001154,E07000069,E10000012
+2024,2024,Hockley,Rayleigh and Wickford,Rochford,Essex,E05010848,E14001437,E07000075,E10000012
+2024,2024,Ditchling & Westmeston,Lewes,Lewes,East Sussex,E05011584,E14001330,E07000063,E10000011
+2024,2024,Bocking Blackwater,Braintree,Braintree,Essex,E05010365,E14001121,E07000067,E10000012
+2024,2024,Nethermayne,Basildon and Billericay,Basildon,Essex,E05015645,E14001077,E07000066,E10000012
+2024,2024,Nethermayne,South Basildon and East Thurrock,Basildon,Essex,E05015645,E14001480,E07000066,E10000012
+2024,2024,Pitsea North West,South Basildon and East Thurrock,Basildon,Essex,E05015646,E14001480,E07000066,E10000012
+2024,2024,Pitsea South East,Basildon and Billericay,Basildon,Essex,E05015647,E14001077,E07000066,E10000012
+2024,2024,Pitsea South East,Castle Point,Basildon,Essex,E05015647,E14001154,E07000066,E10000012
+2024,2024,Pitsea South East,South Basildon and East Thurrock,Basildon,Essex,E05015647,E14001480,E07000066,E10000012
+2024,2024,St Martin's,Basildon and Billericay,Basildon,Essex,E05015648,E14001077,E07000066,E10000012
+2024,2024,Wickford North,Rayleigh and Wickford,Basildon,Essex,E05015649,E14001437,E07000066,E10000012
+2024,2024,Bocking North,Braintree,Braintree,Essex,E05010366,E14001121,E07000067,E10000012
+2024,2024,Bocking South,Braintree,Braintree,Essex,E05010367,E14001121,E07000067,E10000012
+2024,2024,Braintree Central & Beckers Green,Braintree,Braintree,Essex,E05010368,E14001121,E07000067,E10000012
+2024,2024,Braintree South,Braintree,Braintree,Essex,E05010369,E14001121,E07000067,E10000012
+2024,2024,Braintree West,Braintree,Braintree,Essex,E05010370,E14001121,E07000067,E10000012
+2024,2024,Bumpstead,Braintree,Braintree,Essex,E05010371,E14001121,E07000067,E10000012
+2024,2024,Coggeshall,Witham,Braintree,Essex,E05010372,E14001590,E07000067,E10000012
+2024,2024,Great Notley & Black Notley,Braintree,Braintree,Essex,E05010374,E14001121,E07000067,E10000012
+2024,2024,Hedingham,Braintree,Braintree,Essex,E05010378,E14001121,E07000067,E10000012
+2024,2024,Kelvedon & Feering,Witham,Braintree,Essex,E05010379,E14001590,E07000067,E10000012
+2024,2024,Rayne,Braintree,Braintree,Essex,E05010380,E14001121,E07000067,E10000012
+2024,2024,Stour Valley North,Braintree,Braintree,Essex,E05010382,E14001121,E07000067,E10000012
+2024,2024,Stour Valley South,Braintree,Braintree,Essex,E05010383,E14001121,E07000067,E10000012
+2024,2024,The Colnes,Witham,Braintree,Essex,E05010384,E14001590,E07000067,E10000012
+2024,2024,Three Fields,Braintree,Braintree,Essex,E05010385,E14001121,E07000067,E10000012
+2024,2024,Witham South,Witham,Braintree,Essex,E05010388,E14001590,E07000067,E10000012
+2024,2024,Witham West,Witham,Braintree,Essex,E05010389,E14001590,E07000067,E10000012
+2024,2024,Yeldham,Braintree,Braintree,Essex,E05010390,E14001121,E07000067,E10000012
+2024,2024,Gosfield & Greenstead Green,Braintree,Braintree,Essex,E05012961,E14001121,E07000067,E10000012
+2024,2024,Loughton Fairmead,Epping Forest,Epping Forest,Essex,E05015730,E14001226,E07000072,E10000012
+2024,2024,Halstead St Andrew's,Braintree,Braintree,Essex,E05012962,E14001121,E07000067,E10000012
+2024,2024,East Saltdean & Telscombe Cliffs,Brighton Kemptown and Peacehaven,Lewes,East Sussex,E05011585,E14001129,E07000063,E10000011
+2024,2024,Thundersley South,Castle Point,Castle Point,Essex,E05015703,E14001154,E07000069,E10000012
+2024,2024,Northam,Torridge and Tavistock,Torridge,Devon,E05011927,E14001552,E07000046,E10000008
+2024,2024,Loughton Forest,Epping Forest,Epping Forest,Essex,E05015731,E14001226,E07000072,E10000012
+2024,2024,Hockley and Ashingdon,Rayleigh and Wickford,Rochford,Essex,E05010849,E14001437,E07000075,E10000012
+2024,2024,Halstead Trinity,Braintree,Braintree,Essex,E05012963,E14001121,E07000067,E10000012
+2024,2024,Kingston,Lewes,Lewes,East Sussex,E05011586,E14001330,E07000063,E10000011
+2024,2024,Bicknacre and East and West Hanningfield,Maldon,Chelmsford,Essex,E05004096,E14001351,E07000070,E10000012
+2024,2024,Shebbear & Langtree,Torridge and Tavistock,Torridge,Devon,E05011928,E14001552,E07000046,E10000008
+2024,2024,Loughton Roding,Epping Forest,Epping Forest,Essex,E05015732,E14001226,E07000072,E10000012
+2024,2024,Hullbridge,Rayleigh and Wickford,Rochford,Essex,E05010850,E14001437,E07000075,E10000012
+2024,2024,Boreham and The Leighs,North West Essex,Chelmsford,Essex,E05004097,E14001402,E07000070,E10000012
+2024,2024,Two Rivers & Three Moors,Torridge and Tavistock,Torridge,Devon,E05011929,E14001552,E07000046,E10000008
+2024,2024,Lodge,Rayleigh and Wickford,Rochford,Essex,E05010851,E14001437,E07000075,E10000012
+2024,2024,Loughton St John's,Epping Forest,Epping Forest,Essex,E05015733,E14001226,E07000072,E10000012
+2024,2024,Lewes Bridge,Lewes,Lewes,East Sussex,E05011587,E14001330,E07000063,E10000011
+2024,2024,Hatfield Peverel & Terling,Witham,Braintree,Essex,E05012964,E14001590,E07000067,E10000012
+2024,2024,Silver End & Cressing,Witham,Braintree,Essex,E05012965,E14001590,E07000067,E10000012
+2024,2024,Witham Central,Witham,Braintree,Essex,E05012966,E14001590,E07000067,E10000012
+2024,2024,North Weald Bassett,Brentwood and Ongar,Epping Forest,Essex,E05015734,E14001125,E07000072,E10000012
+2024,2024,Witham North,Witham,Braintree,Essex,E05012967,E14001590,E07000067,E10000012
+2024,2024,Lewes Castle,Lewes,Lewes,East Sussex,E05011588,E14001330,E07000063,E10000011
+2024,2024,North Weald Bassett,Epping Forest,Epping Forest,Essex,E05015734,E14001226,E07000072,E10000012
+2024,2024,Blackmore & Doddinghurst,Brentwood and Ongar,Brentwood,Essex,E05015651,E14001125,E07000068,E10000012
+2024,2024,Roche North and Rural,Southend East and Rochford,Rochford,Essex,E05010852,E14001501,E07000075,E10000012
+2024,2024,Lewes Priory,Lewes,Lewes,East Sussex,E05011589,E14001330,E07000063,E10000011
+2024,2024,Westward Ho!,Torridge and Tavistock,Torridge,Devon,E05011930,E14001552,E07000046,E10000008
+2024,2024,Broomfield and The Walthams,North West Essex,Chelmsford,Essex,E05004098,E14001402,E07000070,E10000012
+2024,2024,North Weald Bassett,Harlow,Epping Forest,Essex,E05015734,E14001267,E07000072,E10000012
+2024,2024,Brentwood North,Brentwood and Ongar,Brentwood,Essex,E05015652,E14001125,E07000068,E10000012
+2024,2024,Roche South,Southend East and Rochford,Rochford,Essex,E05010853,E14001501,E07000075,E10000012
+2024,2024,Newhaven North,Lewes,Lewes,East Sussex,E05011590,E14001330,E07000063,E10000011
+2024,2024,Winkleigh,Torridge and Tavistock,Torridge,Devon,E05011931,E14001552,E07000046,E10000008
+2024,2024,Chelmer Village and Beaulieu Park,Chelmsford,Chelmsford,Essex,E05004099,E14001159,E07000070,E10000012
+2024,2024,Ongar,Brentwood and Ongar,Epping Forest,Essex,E05015735,E14001125,E07000072,E10000012
+2024,2024,Brentwood South,Brentwood and Ongar,Brentwood,Essex,E05015653,E14001125,E07000068,E10000012
+2024,2024,Sweyne Park and Grange,Rayleigh and Wickford,Rochford,Essex,E05010854,E14001437,E07000075,E10000012
+2024,2024,Newhaven South,Lewes,Lewes,East Sussex,E05011591,E14001330,E07000063,E10000011
+2024,2024,Bere Ferrers,Torridge and Tavistock,West Devon,Devon,E05010550,E14001552,E07000047,E10000008
+2024,2024,Chelmsford Rural West,North West Essex,Chelmsford,Essex,E05004100,E14001402,E07000070,E10000012
+2024,2024,Roydon & Lower Nazeing,Epping Forest,Epping Forest,Essex,E05015736,E14001226,E07000072,E10000012
+2024,2024,Brentwood West,Brentwood and Ongar,Brentwood,Essex,E05015654,E14001125,E07000068,E10000012
+2024,2024,Trinity,Rayleigh and Wickford,Rochford,Essex,E05010855,E14001437,E07000075,E10000012
+2024,2024,Newick,East Grinstead and Uckfield,Lewes,East Sussex,E05011592,E14001212,E07000063,E10000011
+2024,2024,Bridestowe,Torridge and Tavistock,West Devon,Devon,E05010551,E14001552,E07000047,E10000008
+2024,2024,Galleywood,Maldon,Chelmsford,Essex,E05004101,E14001351,E07000070,E10000012
+2024,2024,"Little Baddow, Danbury and Sandon",Maldon,Chelmsford,Essex,E05004105,E14001351,E07000070,E10000012
+2024,2024,Marconi,Chelmsford,Chelmsford,Essex,E05004106,E14001159,E07000070,E10000012
+2024,2024,Moulsham Lodge,Chelmsford,Chelmsford,Essex,E05004108,E14001159,E07000070,E10000012
+2024,2024,Patching Hall,Chelmsford,Chelmsford,Essex,E05004109,E14001159,E07000070,E10000012
+2024,2024,Rettendon and Runwell,Maldon,Chelmsford,Essex,E05004110,E14001351,E07000070,E10000012
+2024,2024,St Andrews,Chelmsford,Chelmsford,Essex,E05004111,E14001159,E07000070,E10000012
+2024,2024,"South Hanningfield, Stock and Margaretting",Maldon,Chelmsford,Essex,E05004112,E14001351,E07000070,E10000012
+2024,2024,South Woodham-Chetwood and Collingwood,Maldon,Chelmsford,Essex,E05004113,E14001351,E07000070,E10000012
+2024,2024,South Woodham-Elmwood and Woodville,Maldon,Chelmsford,Essex,E05004114,E14001351,E07000070,E10000012
+2024,2024,Springfield North,Chelmsford,Chelmsford,Essex,E05004115,E14001159,E07000070,E10000012
+2024,2024,The Lawns,Chelmsford,Chelmsford,Essex,E05004116,E14001159,E07000070,E10000012
+2024,2024,Trinity,Chelmsford,Chelmsford,Essex,E05004117,E14001159,E07000070,E10000012
+2024,2024,Waterhouse Farm,Chelmsford,Chelmsford,Essex,E05004118,E14001159,E07000070,E10000012
+2024,2024,Writtle,North West Essex,Chelmsford,Essex,E05004119,E14001402,E07000070,E10000012
+2024,2024,Goat Hall,Chelmsford,Chelmsford,Essex,E05015470,E14001159,E07000070,E10000012
+2024,2024,Great Baddow East,Chelmsford,Chelmsford,Essex,E05015471,E14001159,E07000070,E10000012
+2024,2024,Great Baddow West,Chelmsford,Chelmsford,Essex,E05015472,E14001159,E07000070,E10000012
+2024,2024,Moulsham and Central,Chelmsford,Chelmsford,Essex,E05015473,E14001159,E07000070,E10000012
+2024,2024,Berechurch,Colchester,Colchester,Essex,E05010827,E14001176,E07000071,E10000012
+2024,2024,Castle,Colchester,Colchester,Essex,E05010828,E14001176,E07000071,E10000012
+2024,2024,Greenstead,Colchester,Colchester,Essex,E05010829,E14001176,E07000071,E10000012
+2024,2024,Highwoods,Colchester,Colchester,Essex,E05010830,E14001176,E07000071,E10000012
+2024,2024,Lexden and Braiswick,Colchester,Colchester,Essex,E05010831,E14001176,E07000071,E10000012
+2024,2024,Lexden and Braiswick,Harwich and North Essex,Colchester,Essex,E05010831,E14001273,E07000071,E10000012
+2024,2024,Marks Tey and Layer,Witham,Colchester,Essex,E05010832,E14001590,E07000071,E10000012
+2024,2024,Mersea and Pyefleet,Harwich and North Essex,Colchester,Essex,E05010833,E14001273,E07000071,E10000012
+2024,2024,Mile End,Colchester,Colchester,Essex,E05010834,E14001176,E07000071,E10000012
+2024,2024,New Town and Christ Church,Colchester,Colchester,Essex,E05010835,E14001176,E07000071,E10000012
+2024,2024,Old Heath and The Hythe,Harwich and North Essex,Colchester,Essex,E05010836,E14001273,E07000071,E10000012
+2024,2024,Prettygate,Colchester,Colchester,Essex,E05010837,E14001176,E07000071,E10000012
+2024,2024,Rural North,Harwich and North Essex,Colchester,Essex,E05010838,E14001273,E07000071,E10000012
+2024,2024,St Anne's and St John's,Colchester,Colchester,Essex,E05010839,E14001176,E07000071,E10000012
+2024,2024,Shrub End,Colchester,Colchester,Essex,E05010840,E14001176,E07000071,E10000012
+2024,2024,Stanway,Witham,Colchester,Essex,E05010841,E14001590,E07000071,E10000012
+2024,2024,Tiptree,Witham,Colchester,Essex,E05010842,E14001590,E07000071,E10000012
+2024,2024,Wivenhoe,Harwich and North Essex,Colchester,Essex,E05010843,E14001273,E07000071,E10000012
+2024,2024,Buckhurst Hill East & Whitebridge,Epping Forest,Epping Forest,Essex,E05015724,E14001226,E07000072,E10000012
+2024,2024,Buckhurst Hill West,Epping Forest,Epping Forest,Essex,E05015725,E14001226,E07000072,E10000012
+2024,2024,Chigwell with Lambourne,Brentwood and Ongar,Epping Forest,Essex,E05015726,E14001125,E07000072,E10000012
+2024,2024,Chigwell with Lambourne,Epping Forest,Epping Forest,Essex,E05015726,E14001226,E07000072,E10000012
+2024,2024,Epping East,Epping Forest,Epping Forest,Essex,E05015727,E14001226,E07000072,E10000012
+2024,2024,Buckland Monachorum,South West Devon,West Devon,Devon,E05010552,E14001495,E07000047,E10000008
+2024,2024,Burrator,South West Devon,West Devon,Devon,E05010553,E14001495,E07000047,E10000008
+2024,2024,Chagford,Central Devon,West Devon,Devon,E05010554,E14001155,E07000047,E10000008
+2024,2024,Dartmoor,Torridge and Tavistock,West Devon,Devon,E05010555,E14001552,E07000047,E10000008
+2024,2024,Drewsteignton,Central Devon,West Devon,Devon,E05010556,E14001155,E07000047,E10000008
+2024,2024,Exbourne,Central Devon,West Devon,Devon,E05010557,E14001155,E07000047,E10000008
+2024,2024,Hatherleigh,Central Devon,West Devon,Devon,E05010558,E14001155,E07000047,E10000008
+2024,2024,Mary Tavy,Torridge and Tavistock,West Devon,Devon,E05010559,E14001552,E07000047,E10000008
+2024,2024,Milton Ford,Torridge and Tavistock,West Devon,Devon,E05010560,E14001552,E07000047,E10000008
+2024,2024,Okehampton North,Central Devon,West Devon,Devon,E05010561,E14001155,E07000047,E10000008
+2024,2024,Roydon & Lower Nazeing,Harlow,Epping Forest,Essex,E05015736,E14001267,E07000072,E10000012
+2024,2024,Okehampton South,Central Devon,West Devon,Devon,E05010562,E14001155,E07000047,E10000008
+2024,2024,Rural East,Brentwood and Ongar,Epping Forest,Essex,E05015737,E14001125,E07000072,E10000012
+2024,2024,South Tawton,Central Devon,West Devon,Devon,E05010563,E14001155,E07000047,E10000008
+2024,2024,Rural East,Harlow,Epping Forest,Essex,E05015737,E14001267,E07000072,E10000012
+2024,2024,Tamarside,Torridge and Tavistock,West Devon,Devon,E05010564,E14001552,E07000047,E10000008
+2024,2024,Theydon Bois with Passingford,Brentwood and Ongar,Epping Forest,Essex,E05015738,E14001125,E07000072,E10000012
+2024,2024,Tavistock North,Torridge and Tavistock,West Devon,Devon,E05010565,E14001552,E07000047,E10000008
+2024,2024,Theydon Bois with Passingford,Epping Forest,Epping Forest,Essex,E05015738,E14001226,E07000072,E10000012
+2024,2024,Tavistock South East,Torridge and Tavistock,West Devon,Devon,E05010566,E14001552,E07000047,E10000008
+2024,2024,Waltham Abbey North,Epping Forest,Epping Forest,Essex,E05015739,E14001226,E07000072,E10000012
+2024,2024,Tavistock South West,Torridge and Tavistock,West Devon,Devon,E05010567,E14001552,E07000047,E10000008
+2024,2024,Waltham Abbey South & Rural,Epping Forest,Epping Forest,Essex,E05015740,E14001226,E07000072,E10000012
+2024,2024,Devonshire,Eastbourne,Eastbourne,East Sussex,E05011574,E14001219,E07000061,E10000011
+2024,2024,Waltham Abbey West,Epping Forest,Epping Forest,Essex,E05015741,E14001226,E07000072,E10000012
+2024,2024,Hampden Park,Eastbourne,Eastbourne,East Sussex,E05011575,E14001219,E07000061,E10000011
+2024,2024,Bush Fair,Harlow,Harlow,Essex,E05015680,E14001267,E07000073,E10000012
+2024,2024,Langney,Eastbourne,Eastbourne,East Sussex,E05011576,E14001219,E07000061,E10000011
+2024,2024,Church Langley North & Newhall,Harlow,Harlow,Essex,E05015681,E14001267,E07000073,E10000012
+2024,2024,Meads,Eastbourne,Eastbourne,East Sussex,E05011577,E14001219,E07000061,E10000011
+2024,2024,Church Langley South & Potter Street,Harlow,Harlow,Essex,E05015682,E14001267,E07000073,E10000012
+2024,2024,Old Town,Eastbourne,Eastbourne,East Sussex,E05011578,E14001219,E07000061,E10000011
+2024,2024,Great Parndon,Harlow,Harlow,Essex,E05015683,E14001267,E07000073,E10000012
+2024,2024,Ratton,Eastbourne,Eastbourne,East Sussex,E05011579,E14001219,E07000061,E10000011
+2024,2024,St Anthony's,Eastbourne,Eastbourne,East Sussex,E05011580,E14001219,E07000061,E10000011
+2024,2024,Latton Bush & Stewards,Harlow,Harlow,Essex,E05015684,E14001267,E07000073,E10000012
+2024,2024,Wheatley,Rayleigh and Wickford,Rochford,Essex,E05010856,E14001437,E07000075,E10000012
+2024,2024,Alresford & Elmstead,Harwich and North Essex,Tendring,Essex,E05011932,E14001273,E07000076,E10000012
+2024,2024,Ardleigh & Little Bromley,Harwich and North Essex,Tendring,Essex,E05011933,E14001273,E07000076,E10000012
+2024,2024,Little Parndon & Town Centre,Harlow,Harlow,Essex,E05015685,E14001267,E07000073,E10000012
+2024,2024,Sovereign,Eastbourne,Eastbourne,East Sussex,E05011581,E14001219,E07000061,E10000011
+2024,2024,"Brizes, Stondon Massey & South Weald",Brentwood and Ongar,Brentwood,Essex,E05015655,E14001125,E07000068,E10000012
+2024,2024,Mark Hall,Harlow,Harlow,Essex,E05015686,E14001267,E07000073,E10000012
+2024,2024,Upperton,Eastbourne,Eastbourne,East Sussex,E05011582,E14001219,E07000061,E10000011
+2024,2024,Bluehouse,Clacton,Tendring,Essex,E05011934,E14001174,E07000076,E10000012
+2024,2024,Ouse Valley & Ringmer,Lewes,Lewes,East Sussex,E05011593,E14001330,E07000063,E10000011
+2024,2024,Brightlingsea,Harwich and North Essex,Tendring,Essex,E05011935,E14001273,E07000076,E10000012
+2024,2024,Burrsville,Clacton,Tendring,Essex,E05011936,E14001174,E07000076,E10000012
+2024,2024,Peacehaven East,Brighton Kemptown and Peacehaven,Lewes,East Sussex,E05011594,E14001129,E07000063,E10000011
+2024,2024,Ashdown,Hastings and Rye,Hastings,East Sussex,E05011201,E14001274,E07000062,E10000011
+2024,2024,Cann Hall,Clacton,Tendring,Essex,E05011937,E14001174,E07000076,E10000012
+2024,2024,Netteswell,Harlow,Harlow,Essex,E05015687,E14001267,E07000073,E10000012
+2024,2024,Peacehaven North,Brighton Kemptown and Peacehaven,Lewes,East Sussex,E05011595,E14001129,E07000063,E10000011
+2024,2024,Baird,Hastings and Rye,Hastings,East Sussex,E05011202,E14001274,E07000062,E10000011
+2024,2024,"Herongate, Ingrave & West Horndon",Brentwood and Ongar,Brentwood,Essex,E05015656,E14001125,E07000068,E10000012
+2024,2024,Coppins,Clacton,Tendring,Essex,E05011938,E14001174,E07000076,E10000012
+2024,2024,Old Harlow,Harlow,Harlow,Essex,E05015688,E14001267,E07000073,E10000012
+2024,2024,Peacehaven West,Brighton Kemptown and Peacehaven,Lewes,East Sussex,E05011596,E14001129,E07000063,E10000011
+2024,2024,Braybrooke,Hastings and Rye,Hastings,East Sussex,E05011203,E14001274,E07000062,E10000011
+2024,2024,Hutton East,Brentwood and Ongar,Brentwood,Essex,E05015657,E14001125,E07000068,E10000012
+2024,2024,Dovercourt All Saints,Harwich and North Essex,Tendring,Essex,E05011939,E14001273,E07000076,E10000012
+2024,2024,Passmores,Harlow,Harlow,Essex,E05015689,E14001267,E07000073,E10000012
+2024,2024,"Plumpton, Streat, East Chiltington & St John",Lewes,Lewes,East Sussex,E05011597,E14001330,E07000063,E10000011
+2024,2024,Castle,Hastings and Rye,Hastings,East Sussex,E05011204,E14001274,E07000062,E10000011
+2024,2024,Hutton North,Brentwood and Ongar,Brentwood,Essex,E05015658,E14001125,E07000068,E10000012
+2024,2024,Dovercourt Bay,Harwich and North Essex,Tendring,Essex,E05011940,E14001273,E07000076,E10000012
+2024,2024,Sumners & Kingsmoor,Harlow,Harlow,Essex,E05015690,E14001267,E07000073,E10000012
+2024,2024,Seaford Central,Lewes,Lewes,East Sussex,E05011598,E14001330,E07000063,E10000011
+2024,2024,Central St Leonards,Hastings and Rye,Hastings,East Sussex,E05011205,E14001274,E07000062,E10000011
+2024,2024,Hutton South,Brentwood and Ongar,Brentwood,Essex,E05015659,E14001125,E07000068,E10000012
+2024,2024,Dovercourt Tollgate,Harwich and North Essex,Tendring,Essex,E05011941,E14001273,E07000076,E10000012
+2024,2024,Althorne,Maldon,Maldon,Essex,E05004190,E14001351,E07000074,E10000012
+2024,2024,Seaford East,Lewes,Lewes,East Sussex,E05011599,E14001330,E07000063,E10000011
+2024,2024,Conquest,Hastings and Rye,Hastings,East Sussex,E05011206,E14001274,E07000062,E10000011
+2024,2024,"Ingatestone, Fryerning & Mountnessing",Brentwood and Ongar,Brentwood,Essex,E05015660,E14001125,E07000068,E10000012
+2024,2024,Pilgrims Hatch,Brentwood and Ongar,Brentwood,Essex,E05015661,E14001125,E07000068,E10000012
+2024,2024,Shenfield,Brentwood and Ongar,Brentwood,Essex,E05015662,E14001125,E07000068,E10000012
+2024,2024,Warley,Brentwood and Ongar,Brentwood,Essex,E05015663,E14001125,E07000068,E10000012
+2024,2024,Appleton,Castle Point,Castle Point,Essex,E05015691,E14001154,E07000069,E10000012
+2024,2024,Canvey Island Central,Castle Point,Castle Point,Essex,E05015692,E14001154,E07000069,E10000012
+2024,2024,Canvey Island East,Castle Point,Castle Point,Essex,E05015693,E14001154,E07000069,E10000012
+2024,2024,Canvey Island North,Castle Point,Castle Point,Essex,E05015694,E14001154,E07000069,E10000012
+2024,2024,Canvey Island South,Castle Point,Castle Point,Essex,E05015695,E14001154,E07000069,E10000012
+2024,2024,Canvey Island Winter Gardens,Castle Point,Castle Point,Essex,E05015696,E14001154,E07000069,E10000012
+2024,2024,Hadleigh St James,Castle Point,Castle Point,Essex,E05015697,E14001154,E07000069,E10000012
+2024,2024,St George's,Castle Point,Castle Point,Essex,E05015698,E14001154,E07000069,E10000012
+2024,2024,St Mary's,Castle Point,Castle Point,Essex,E05015699,E14001154,E07000069,E10000012
+2024,2024,St Michael's,Castle Point,Castle Point,Essex,E05015700,E14001154,E07000069,E10000012
+2024,2024,Burnham-on-Crouch North,Maldon,Maldon,Essex,E05004191,E14001351,E07000074,E10000012
+2024,2024,Burnham-on-Crouch South,Maldon,Maldon,Essex,E05004192,E14001351,E07000074,E10000012
+2024,2024,Great Totham,Witham,Maldon,Essex,E05004193,E14001590,E07000074,E10000012
+2024,2024,Heybridge East,Maldon,Maldon,Essex,E05004194,E14001351,E07000074,E10000012
+2024,2024,Heybridge West,Maldon,Maldon,Essex,E05004195,E14001351,E07000074,E10000012
+2024,2024,Maldon East,Maldon,Maldon,Essex,E05004196,E14001351,E07000074,E10000012
+2024,2024,Maldon North,Maldon,Maldon,Essex,E05004197,E14001351,E07000074,E10000012
+2024,2024,Maldon South,Maldon,Maldon,Essex,E05004198,E14001351,E07000074,E10000012
+2024,2024,Maldon West,Maldon,Maldon,Essex,E05004199,E14001351,E07000074,E10000012
+2024,2024,Mayland,Maldon,Maldon,Essex,E05004200,E14001351,E07000074,E10000012
+2024,2024,Purleigh,Maldon,Maldon,Essex,E05004201,E14001351,E07000074,E10000012
+2024,2024,Southminster,Maldon,Maldon,Essex,E05004202,E14001351,E07000074,E10000012
+2024,2024,Tillingham,Maldon,Maldon,Essex,E05004203,E14001351,E07000074,E10000012
+2024,2024,Tollesbury,Witham,Maldon,Essex,E05004204,E14001590,E07000074,E10000012
+2024,2024,Tolleshunt D'arcy,Witham,Maldon,Essex,E05004205,E14001590,E07000074,E10000012
+2024,2024,Wickham Bishops and Woodham,Witham,Maldon,Essex,E05004206,E14001590,E07000074,E10000012
+2024,2024,Downhall and Rawreth,Rayleigh and Wickford,Rochford,Essex,E05010844,E14001437,E07000075,E10000012
+2024,2024,Foulness and The Wakerings,Southend East and Rochford,Rochford,Essex,E05010845,E14001501,E07000075,E10000012
+2024,2024,Hawkwell East,Rayleigh and Wickford,Rochford,Essex,E05010846,E14001437,E07000075,E10000012
+2024,2024,Dovercourt Vines & Parkeston,Harwich and North Essex,Tendring,Essex,E05011942,E14001273,E07000076,E10000012
+2024,2024,Eastcliff,Clacton,Tendring,Essex,E05011943,E14001174,E07000076,E10000012
+2024,2024,Frinton,Clacton,Tendring,Essex,E05011944,E14001174,E07000076,E10000012
+2024,2024,Harwich & Kingsway,Harwich and North Essex,Tendring,Essex,E05011945,E14001273,E07000076,E10000012
+2024,2024,Homelands,Clacton,Tendring,Essex,E05011946,E14001174,E07000076,E10000012
+2024,2024,Kirby Cross,Clacton,Tendring,Essex,E05011947,E14001174,E07000076,E10000012
+2024,2024,Kirby-le-Soken & Hamford,Clacton,Tendring,Essex,E05011948,E14001174,E07000076,E10000012
+2024,2024,"Lawford, Manningtree & Mistley",Harwich and North Essex,Tendring,Essex,E05011949,E14001273,E07000076,E10000012
+2024,2024,Little Clacton,Clacton,Tendring,Essex,E05011950,E14001174,E07000076,E10000012
+2024,2024,Pier,Clacton,Tendring,Essex,E05011951,E14001174,E07000076,E10000012
+2024,2024,St Bartholomew's,Clacton,Tendring,Essex,E05011952,E14001174,E07000076,E10000012
+2024,2024,St James,Clacton,Tendring,Essex,E05011953,E14001174,E07000076,E10000012
+2024,2024,St John's,Clacton,Tendring,Essex,E05011954,E14001174,E07000076,E10000012
+2024,2024,St Osyth,Clacton,Tendring,Essex,E05011955,E14001174,E07000076,E10000012
+2024,2024,St Paul's,Clacton,Tendring,Essex,E05011956,E14001174,E07000076,E10000012
+2024,2024,Stour Valley,Harwich and North Essex,Tendring,Essex,E05011957,E14001273,E07000076,E10000012
+2024,2024,The Bentleys & Frating,Clacton,Tendring,Essex,E05011958,E14001174,E07000076,E10000012
+2024,2024,The Oakleys & Wix,Clacton,Tendring,Essex,E05011959,E14001174,E07000076,E10000012
+2024,2024,"Thorpe, Beaumont & Great Holland",Clacton,Tendring,Essex,E05011960,E14001174,E07000076,E10000012
+2024,2024,Walton,Clacton,Tendring,Essex,E05011961,E14001174,E07000076,E10000012
+2024,2024,Weeley & Tendring,Clacton,Tendring,Essex,E05011962,E14001174,E07000076,E10000012
+2024,2024,West Clacton & Jaywick Sands,Clacton,Tendring,Essex,E05011963,E14001174,E07000076,E10000012
+2024,2024,Ashdon,North West Essex,Uttlesford,Essex,E05009910,E14001402,E07000077,E10000012
+2024,2024,Broad Oak & the Hallingburys,Harlow,Uttlesford,Essex,E05009911,E14001267,E07000077,E10000012
+2024,2024,Clavering,North West Essex,Uttlesford,Essex,E05009912,E14001402,E07000077,E10000012
+2024,2024,Debden & Wimbish,North West Essex,Uttlesford,Essex,E05009913,E14001402,E07000077,E10000012
+2024,2024,Elsenham & Henham,North West Essex,Uttlesford,Essex,E05009914,E14001402,E07000077,E10000012
+2024,2024,Felsted & Stebbing,Braintree,Uttlesford,Essex,E05009915,E14001121,E07000077,E10000012
+2024,2024,Flitch Green & Little Dunmow,North West Essex,Uttlesford,Essex,E05009916,E14001402,E07000077,E10000012
+2024,2024,Great Dunmow South & Barnston,North West Essex,Uttlesford,Essex,E05009918,E14001402,E07000077,E10000012
+2024,2024,Gensing,Hastings and Rye,Hastings,East Sussex,E05011207,E14001274,E07000062,E10000011
+2024,2024,Seaford North,Lewes,Lewes,East Sussex,E05011600,E14001330,E07000063,E10000011
+2024,2024,Hollington,Hastings and Rye,Hastings,East Sussex,E05011208,E14001274,E07000062,E10000011
+2024,2024,Maze Hill,Hastings and Rye,Hastings,East Sussex,E05011209,E14001274,E07000062,E10000011
+2024,2024,Old Hastings,Hastings and Rye,Hastings,East Sussex,E05011210,E14001274,E07000062,E10000011
+2024,2024,Ore,Hastings and Rye,Hastings,East Sussex,E05011211,E14001274,E07000062,E10000011
+2024,2024,St Helens,Hastings and Rye,Hastings,East Sussex,E05011212,E14001274,E07000062,E10000011
+2024,2024,Silverhill,Hastings and Rye,Hastings,East Sussex,E05011213,E14001274,E07000062,E10000011
+2024,2024,Tressell,Hastings and Rye,Hastings,East Sussex,E05011214,E14001274,E07000062,E10000011
+2024,2024,West St Leonards,Hastings and Rye,Hastings,East Sussex,E05011215,E14001274,E07000062,E10000011
+2024,2024,Wishing Tree,Hastings and Rye,Hastings,East Sussex,E05011216,E14001274,E07000062,E10000011
+2024,2024,Seaford South,Lewes,Lewes,East Sussex,E05011601,E14001330,E07000063,E10000011
+2024,2024,Seaford West,Lewes,Lewes,East Sussex,E05011602,E14001330,E07000063,E10000011
+2024,2024,Wivelsfield,East Grinstead and Uckfield,Lewes,East Sussex,E05011603,E14001212,E07000063,E10000011
+2024,2024,Bexhill Central,Bexhill and Battle,Rother,East Sussex,E05011604,E14001088,E07000064,E10000011
+2024,2024,Bexhill Collington,Bexhill and Battle,Rother,East Sussex,E05011605,E14001088,E07000064,E10000011
+2024,2024,Bexhill Kewhurst,Bexhill and Battle,Rother,East Sussex,E05011606,E14001088,E07000064,E10000011
+2024,2024,Bexhill Old Town & Worsham,Bexhill and Battle,Rother,East Sussex,E05011607,E14001088,E07000064,E10000011
+2024,2024,Bexhill Pebsham & St Michaels,Bexhill and Battle,Rother,East Sussex,E05011608,E14001088,E07000064,E10000011
+2024,2024,Bexhill Sackville,Bexhill and Battle,Rother,East Sussex,E05011609,E14001088,E07000064,E10000011
+2024,2024,Bexhill Sidley,Bexhill and Battle,Rother,East Sussex,E05011610,E14001088,E07000064,E10000011
+2024,2024,Bexhill St Marks,Bexhill and Battle,Rother,East Sussex,E05011611,E14001088,E07000064,E10000011
+2024,2024,Bexhill St Stephens,Bexhill and Battle,Rother,East Sussex,E05011612,E14001088,E07000064,E10000011
+2024,2024,Brede & Udimore,Bexhill and Battle,Rother,East Sussex,E05011613,E14001088,E07000064,E10000011
+2024,2024,Burwash & the Weald,Bexhill and Battle,Rother,East Sussex,E05011614,E14001088,E07000064,E10000011
+2024,2024,Catsfield & Crowhurst,Bexhill and Battle,Rother,East Sussex,E05011615,E14001088,E07000064,E10000011
+2024,2024,Eastern Rother,Hastings and Rye,Rother,East Sussex,E05011616,E14001274,E07000064,E10000011
+2024,2024,Hurst Green & Ticehurst,Bexhill and Battle,Rother,East Sussex,E05011617,E14001088,E07000064,E10000011
+2024,2024,"North Battle, Netherfield & Whatlington",Bexhill and Battle,Rother,East Sussex,E05011618,E14001088,E07000064,E10000011
+2024,2024,Northern Rother,Bexhill and Battle,Rother,East Sussex,E05011619,E14001088,E07000064,E10000011
+2024,2024,Robertsbridge,Bexhill and Battle,Rother,East Sussex,E05011620,E14001088,E07000064,E10000011
+2024,2024,Rye & Winchelsea,Hastings and Rye,Rother,East Sussex,E05011621,E14001274,E07000064,E10000011
+2024,2024,Sedlescombe & Westfield,Bexhill and Battle,Rother,East Sussex,E05011622,E14001088,E07000064,E10000011
+2024,2024,South Battle & Telham,Bexhill and Battle,Rother,East Sussex,E05011623,E14001088,E07000064,E10000011
+2024,2024,Southern Rother,Hastings and Rye,Rother,East Sussex,E05011624,E14001274,E07000064,E10000011
+2024,2024,Arlington,Lewes,Wealden,East Sussex,E05011625,E14001330,E07000065,E10000011
+2024,2024,Buxted,East Grinstead and Uckfield,Wealden,East Sussex,E05011626,E14001212,E07000065,E10000011
+2024,2024,"Chiddingly, East Hoathly & Waldron",Sussex Weald,Wealden,East Sussex,E05011627,E14001533,E07000065,E10000011
+2024,2024,Crowborough Central,Sussex Weald,Wealden,East Sussex,E05011628,E14001533,E07000065,E10000011
+2024,2024,Crowborough Jarvis Brook,Sussex Weald,Wealden,East Sussex,E05011629,E14001533,E07000065,E10000011
+2024,2024,Crowborough North,Sussex Weald,Wealden,East Sussex,E05011630,E14001533,E07000065,E10000011
+2024,2024,Crowborough South East,Sussex Weald,Wealden,East Sussex,E05011631,E14001533,E07000065,E10000011
+2024,2024,Crowborough South West,Sussex Weald,Wealden,East Sussex,E05011632,E14001533,E07000065,E10000011
+2024,2024,Petersfield Bell Hill,East Hampshire,East Hampshire,Hampshire,E05012312,E14001214,E07000085,E10000014
+2024,2024,Petersfield Causeway,East Hampshire,East Hampshire,Hampshire,E05012313,E14001214,E07000085,E10000014
+2024,2024,Petersfield Heath,East Hampshire,East Hampshire,Hampshire,E05012314,E14001214,E07000085,E10000014
+2024,2024,Petersfield St Peter's,East Hampshire,East Hampshire,Hampshire,E05012315,E14001214,E07000085,E10000014
+2024,2024,"Ropley, Hawkley & Hangers",East Hampshire,East Hampshire,Hampshire,E05012316,E14001214,E07000085,E10000014
+2024,2024,Rowlands Castle,East Hampshire,East Hampshire,Hampshire,E05012317,E14001214,E07000085,E10000014
+2024,2024,Whitehill Chase,Farnham and Bordon,East Hampshire,Hampshire,E05012318,E14001234,E07000085,E10000014
+2024,2024,Whitehill Hogmoor & Greatham,Farnham and Bordon,East Hampshire,Hampshire,E05012319,E14001234,E07000085,E10000014
+2024,2024,Whitehill Pinewood,Farnham and Bordon,East Hampshire,Hampshire,E05012320,E14001234,E07000085,E10000014
+2024,2024,Bishopstoke,Eastleigh,Eastleigh,Hampshire,E05011187,E14001220,E07000086,E10000014
+2024,2024,Botley,Hamble Valley,Eastleigh,Hampshire,E05011188,E14001263,E07000086,E10000014
+2024,2024,Bursledon & Hound North,Hamble Valley,Eastleigh,Hampshire,E05011189,E14001263,E07000086,E10000014
+2024,2024,Chandler's Ford,Eastleigh,Eastleigh,Hampshire,E05011190,E14001220,E07000086,E10000014
+2024,2024,Eastleigh Central,Eastleigh,Eastleigh,Hampshire,E05011191,E14001220,E07000086,E10000014
+2024,2024,Eastleigh North,Eastleigh,Eastleigh,Hampshire,E05011192,E14001220,E07000086,E10000014
+2024,2024,Eastleigh South,Eastleigh,Eastleigh,Hampshire,E05011193,E14001220,E07000086,E10000014
+2024,2024,Fair Oak & Horton Heath,Eastleigh,Eastleigh,Hampshire,E05011194,E14001220,E07000086,E10000014
+2024,2024,Hamble & Netley,Hamble Valley,Eastleigh,Hampshire,E05011195,E14001263,E07000086,E10000014
+2024,2024,Hedge End North,Hamble Valley,Eastleigh,Hampshire,E05011196,E14001263,E07000086,E10000014
+2024,2024,Hedge End South,Hamble Valley,Eastleigh,Hampshire,E05011197,E14001263,E07000086,E10000014
+2024,2024,Hiltingbury,Eastleigh,Eastleigh,Hampshire,E05011198,E14001220,E07000086,E10000014
+2024,2024,West End North,Eastleigh,Eastleigh,Hampshire,E05011199,E14001220,E07000086,E10000014
+2024,2024,West End South,Eastleigh,Eastleigh,Hampshire,E05011200,E14001220,E07000086,E10000014
+2024,2024,Avenue,Fareham and Waterlooville,Fareham,Hampshire,E05015664,E14001233,E07000087,E10000014
+2024,2024,Avenue,Hamble Valley,Fareham,Hampshire,E05015664,E14001263,E07000087,E10000014
+2024,2024,Fareham Park,Fareham and Waterlooville,Fareham,Hampshire,E05015665,E14001233,E07000087,E10000014
+2024,2024,Fareham Town,Fareham and Waterlooville,Fareham,Hampshire,E05015666,E14001233,E07000087,E10000014
+2024,2024,Fort Fareham,Fareham and Waterlooville,Fareham,Hampshire,E05015667,E14001233,E07000087,E10000014
+2024,2024,Hill Head,Gosport,Fareham,Hampshire,E05015668,E14001252,E07000087,E10000014
+2024,2024,Hook-with-Warsash,Hamble Valley,Fareham,Hampshire,E05015669,E14001263,E07000087,E10000014
+2024,2024,Locks Heath,Hamble Valley,Fareham,Hampshire,E05015670,E14001263,E07000087,E10000014
+2024,2024,Park Gate,Hamble Valley,Fareham,Hampshire,E05015671,E14001263,E07000087,E10000014
+2024,2024,Portchester Castle,Fareham and Waterlooville,Fareham,Hampshire,E05015672,E14001233,E07000087,E10000014
+2024,2024,Portchester Wicor,Fareham and Waterlooville,Fareham,Hampshire,E05015673,E14001233,E07000087,E10000014
+2024,2024,Sarisbury & Whiteley,Hamble Valley,Fareham,Hampshire,E05015674,E14001263,E07000087,E10000014
+2024,2024,Stubbington,Gosport,Fareham,Hampshire,E05015675,E14001252,E07000087,E10000014
+2024,2024,Stubbington,Hamble Valley,Fareham,Hampshire,E05015675,E14001263,E07000087,E10000014
+2024,2024,Titchfield,Fareham and Waterlooville,Fareham,Hampshire,E05015676,E14001233,E07000087,E10000014
+2024,2024,Titchfield,Hamble Valley,Fareham,Hampshire,E05015676,E14001263,E07000087,E10000014
+2024,2024,Titchfield Common,Hamble Valley,Fareham,Hampshire,E05015677,E14001263,E07000087,E10000014
+2024,2024,Uplands & Funtley,Fareham and Waterlooville,Fareham,Hampshire,E05015678,E14001233,E07000087,E10000014
+2024,2024,Wallington & Downend,Fareham and Waterlooville,Fareham,Hampshire,E05015679,E14001233,E07000087,E10000014
+2024,2024,Alverstoke,Gosport,Gosport,Hampshire,E05014138,E14001252,E07000088,E10000014
+2024,2024,Anglesey,Gosport,Gosport,Hampshire,E05014139,E14001252,E07000088,E10000014
+2024,2024,Bridgemary,Gosport,Gosport,Hampshire,E05014140,E14001252,E07000088,E10000014
+2024,2024,Brockhurst & Privett,Gosport,Gosport,Hampshire,E05014141,E14001252,E07000088,E10000014
+2024,2024,Elson,Gosport,Gosport,Hampshire,E05014142,E14001252,E07000088,E10000014
+2024,2024,Forton,Gosport,Gosport,Hampshire,E05014143,E14001252,E07000088,E10000014
+2024,2024,Grange & Alver Valley,Gosport,Gosport,Hampshire,E05014144,E14001252,E07000088,E10000014
+2024,2024,Harbourside & Town,Gosport,Gosport,Hampshire,E05014145,E14001252,E07000088,E10000014
+2024,2024,Hatfield Heath,Harlow,Uttlesford,Essex,E05009919,E14001267,E07000077,E10000012
+2024,2024,Kingsway,Gloucester,Gloucester,Gloucestershire,E05010959,E14001248,E07000081,E10000013
+2024,2024,The Worthys,Winchester,Winchester,Hampshire,E05011007,E14001587,E07000094,E10000014
+2024,2024,Moreton East,North Cotswolds,Cotswold,Gloucestershire,E05010711,E14001386,E07000079,E10000013
+2024,2024,Moreton West,North Cotswolds,Cotswold,Gloucestershire,E05010712,E14001386,E07000079,E10000013
+2024,2024,New Mills,South Cotswolds,Cotswold,Gloucestershire,E05010713,E14001482,E07000079,E10000013
+2024,2024,Northleach,North Cotswolds,Cotswold,Gloucestershire,E05010714,E14001386,E07000079,E10000013
+2024,2024,St Michael's,South Cotswolds,Cotswold,Gloucestershire,E05010715,E14001482,E07000079,E10000013
+2024,2024,Siddington & Cerney Rural,South Cotswolds,Cotswold,Gloucestershire,E05010717,E14001482,E07000079,E10000013
+2024,2024,South Cerney Village,South Cotswolds,Cotswold,Gloucestershire,E05010718,E14001482,E07000079,E10000013
+2024,2024,Stow,North Cotswolds,Cotswold,Gloucestershire,E05010719,E14001386,E07000079,E10000013
+2024,2024,Tetbury East & Rural,South Cotswolds,Cotswold,Gloucestershire,E05010721,E14001482,E07000079,E10000013
+2024,2024,Tetbury Town,South Cotswolds,Cotswold,Gloucestershire,E05010722,E14001482,E07000079,E10000013
+2024,2024,Tetbury with Upton,South Cotswolds,Cotswold,Gloucestershire,E05010723,E14001482,E07000079,E10000013
+2024,2024,The Ampneys & Hampton,South Cotswolds,Cotswold,Gloucestershire,E05010724,E14001482,E07000079,E10000013
+2024,2024,The Beeches,South Cotswolds,Cotswold,Gloucestershire,E05010725,E14001482,E07000079,E10000013
+2024,2024,The Rissingtons,North Cotswolds,Cotswold,Gloucestershire,E05010726,E14001386,E07000079,E10000013
+2024,2024,Watermoor,South Cotswolds,Cotswold,Gloucestershire,E05010727,E14001482,E07000079,E10000013
+2024,2024,Chedworth & Churn Valley,North Cotswolds,Cotswold,Gloucestershire,E05015554,E14001386,E07000079,E10000013
+2024,2024,Ermin,North Cotswolds,Cotswold,Gloucestershire,E05015555,E14001386,E07000079,E10000013
+2024,2024,Sandywell,North Cotswolds,Cotswold,Gloucestershire,E05015556,E14001386,E07000079,E10000013
+2024,2024,Stratton,North Cotswolds,Cotswold,Gloucestershire,E05015557,E14001386,E07000079,E10000013
+2024,2024,Stratton,South Cotswolds,Cotswold,Gloucestershire,E05015557,E14001482,E07000079,E10000013
+2024,2024,Ringwood South,New Forest West,New Forest,Hampshire,E05014791,E14001374,E07000091,E10000014
+2024,2024,Berry Hill,Forest of Dean,Forest of Dean,Gloucestershire,E05012156,E14001240,E07000080,E10000013
+2024,2024,Bream,Forest of Dean,Forest of Dean,Gloucestershire,E05012157,E14001240,E07000080,E10000013
+2024,2024,Cinderford East,Forest of Dean,Forest of Dean,Gloucestershire,E05012158,E14001240,E07000080,E10000013
+2024,2024,Sway,New Forest East,New Forest,Hampshire,E05014792,E14001373,E07000091,E10000014
+2024,2024,Cinderford West,Forest of Dean,Forest of Dean,Gloucestershire,E05012159,E14001240,E07000080,E10000013
+2024,2024,Totton Central,New Forest East,New Forest,Hampshire,E05014793,E14001373,E07000091,E10000014
+2024,2024,Coleford,Forest of Dean,Forest of Dean,Gloucestershire,E05012160,E14001240,E07000080,E10000013
+2024,2024,Totton North,New Forest East,New Forest,Hampshire,E05014794,E14001373,E07000091,E10000014
+2024,2024,Totton South,New Forest East,New Forest,Hampshire,E05014795,E14001373,E07000091,E10000014
+2024,2024,Aldershot Park,Aldershot,Rushmoor,Hampshire,E05008989,E14001063,E07000092,E10000014
+2024,2024,Cherrywood,Aldershot,Rushmoor,Hampshire,E05008990,E14001063,E07000092,E10000014
+2024,2024,Cove and Southwood,Aldershot,Rushmoor,Hampshire,E05008991,E14001063,E07000092,E10000014
+2024,2024,Empress,Aldershot,Rushmoor,Hampshire,E05008992,E14001063,E07000092,E10000014
+2024,2024,Fernhill,Aldershot,Rushmoor,Hampshire,E05008993,E14001063,E07000092,E10000014
+2024,2024,Knellwood,Aldershot,Rushmoor,Hampshire,E05008994,E14001063,E07000092,E10000014
+2024,2024,Manor Park,Aldershot,Rushmoor,Hampshire,E05008995,E14001063,E07000092,E10000014
+2024,2024,North Town,Aldershot,Rushmoor,Hampshire,E05008996,E14001063,E07000092,E10000014
+2024,2024,Rowhill,Aldershot,Rushmoor,Hampshire,E05008997,E14001063,E07000092,E10000014
+2024,2024,St John's,Aldershot,Rushmoor,Hampshire,E05008998,E14001063,E07000092,E10000014
+2024,2024,St Mark's,Aldershot,Rushmoor,Hampshire,E05008999,E14001063,E07000092,E10000014
+2024,2024,Wellington,Aldershot,Rushmoor,Hampshire,E05009000,E14001063,E07000092,E10000014
+2024,2024,West Heath,Aldershot,Rushmoor,Hampshire,E05009001,E14001063,E07000092,E10000014
+2024,2024,Andover Downlands,North West Hampshire,Test Valley,Hampshire,E05012085,E14001403,E07000093,E10000014
+2024,2024,Andover Romans,North West Hampshire,Test Valley,Hampshire,E05012088,E14001403,E07000093,E10000014
+2024,2024,Blackwater,Romsey and Southampton North,Test Valley,Hampshire,E05012093,E14001449,E07000093,E10000014
+2024,2024,Harewood,Romsey and Southampton North,Test Valley,Hampshire,E05012097,E14001449,E07000093,E10000014
+2024,2024,Mid Test,Romsey and Southampton North,Test Valley,Hampshire,E05012098,E14001449,E07000093,E10000014
+2024,2024,Romsey Abbey,Romsey and Southampton North,Test Valley,Hampshire,E05012100,E14001449,E07000093,E10000014
+2024,2024,Romsey Tadburn,Romsey and Southampton North,Test Valley,Hampshire,E05012102,E14001449,E07000093,E10000014
+2024,2024,Ampfield & Braishfield,Romsey and Southampton North,Test Valley,Hampshire,E05012927,E14001449,E07000093,E10000014
+2024,2024,Andover Harroway,North West Hampshire,Test Valley,Hampshire,E05012928,E14001403,E07000093,E10000014
+2024,2024,Andover Millway,North West Hampshire,Test Valley,Hampshire,E05012929,E14001403,E07000093,E10000014
+2024,2024,Andover St Mary's,North West Hampshire,Test Valley,Hampshire,E05012930,E14001403,E07000093,E10000014
+2024,2024,Andover Winton,North West Hampshire,Test Valley,Hampshire,E05012931,E14001403,E07000093,E10000014
+2024,2024,Anna,Romsey and Southampton North,Test Valley,Hampshire,E05012932,E14001449,E07000093,E10000014
+2024,2024,Bellinger,Romsey and Southampton North,Test Valley,Hampshire,E05012933,E14001449,E07000093,E10000014
+2024,2024,Bourne Valley,North West Hampshire,Test Valley,Hampshire,E05012934,E14001403,E07000093,E10000014
+2024,2024,Charlton & the Pentons,Romsey and Southampton North,Test Valley,Hampshire,E05012935,E14001449,E07000093,E10000014
+2024,2024,"Chilworth, Nursling & Rownhams",Romsey and Southampton North,Test Valley,Hampshire,E05012936,E14001449,E07000093,E10000014
+2024,2024,North Baddesley,Romsey and Southampton North,Test Valley,Hampshire,E05012937,E14001449,E07000093,E10000014
+2024,2024,Romsey Cupernham,Romsey and Southampton North,Test Valley,Hampshire,E05012938,E14001449,E07000093,E10000014
+2024,2024,Valley Park,Eastleigh,Test Valley,Hampshire,E05012939,E14001220,E07000093,E10000014
+2024,2024,Alresford and Itchen Valley,Winchester,Winchester,Hampshire,E05010995,E14001587,E07000094,E10000014
+2024,2024,Churchdown Brookfield with Hucclecote,North Cotswolds,Tewkesbury,Gloucestershire,E05015481,E14001386,E07000083,E10000013
+2024,2024,High Easter & the Rodings,North West Essex,Uttlesford,Essex,E05009920,E14001402,E07000077,E10000012
+2024,2024,Badger Farm and Oliver's Battery,Winchester,Winchester,Hampshire,E05010996,E14001587,E07000094,E10000014
+2024,2024,Bishop's Waltham,Winchester,Winchester,Hampshire,E05010997,E14001587,E07000094,E10000014
+2024,2024,Central Meon Valley,Winchester,Winchester,Hampshire,E05010998,E14001587,E07000094,E10000014
+2024,2024,Colden Common and Twyford,Winchester,Winchester,Hampshire,E05010999,E14001587,E07000094,E10000014
+2024,2024,Denmead,Fareham and Waterlooville,Winchester,Hampshire,E05011000,E14001233,E07000094,E10000014
+2024,2024,St Barnabas,Winchester,Winchester,Hampshire,E05011001,E14001587,E07000094,E10000014
+2024,2024,St Bartholomew,Winchester,Winchester,Hampshire,E05011002,E14001587,E07000094,E10000014
+2024,2024,St Luke,Winchester,Winchester,Hampshire,E05011003,E14001587,E07000094,E10000014
+2024,2024,St Michael,Winchester,Winchester,Hampshire,E05011004,E14001587,E07000094,E10000014
+2024,2024,St Paul,Winchester,Winchester,Hampshire,E05011005,E14001587,E07000094,E10000014
+2024,2024,Southwick and Wickham,Fareham and Waterlooville,Winchester,Hampshire,E05011006,E14001233,E07000094,E10000014
+2024,2024,Upper Meon Valley,Winchester,Winchester,Hampshire,E05011008,E14001587,E07000094,E10000014
+2024,2024,Longlevens,Tewkesbury,Gloucester,Gloucestershire,E05010960,E14001542,E07000081,E10000013
+2024,2024,Whiteley and Shedfield,Hamble Valley,Winchester,Hampshire,E05011009,E14001263,E07000094,E10000014
+2024,2024,Wonston and Micheldever,Winchester,Winchester,Hampshire,E05011010,E14001587,E07000094,E10000014
+2024,2024,Broxbourne and Hoddesdon South,Broxbourne,Broxbourne,Hertfordshire,E05009002,E14001139,E07000095,E10000015
+2024,2024,Cheshunt North,Broxbourne,Broxbourne,Hertfordshire,E05009003,E14001139,E07000095,E10000015
+2024,2024,Cheshunt South and Theobalds,Broxbourne,Broxbourne,Hertfordshire,E05009004,E14001139,E07000095,E10000015
+2024,2024,Flamstead End,Broxbourne,Broxbourne,Hertfordshire,E05009005,E14001139,E07000095,E10000015
+2024,2024,Goffs Oak,Broxbourne,Broxbourne,Hertfordshire,E05009006,E14001139,E07000095,E10000015
+2024,2024,Hoddesdon North,Broxbourne,Broxbourne,Hertfordshire,E05009007,E14001139,E07000095,E10000015
+2024,2024,Hoddesdon Town and Rye Park,Broxbourne,Broxbourne,Hertfordshire,E05009008,E14001139,E07000095,E10000015
+2024,2024,Rosedale and Bury Green,Broxbourne,Broxbourne,Hertfordshire,E05009009,E14001139,E07000095,E10000015
+2024,2024,Waltham Cross,Broxbourne,Broxbourne,Hertfordshire,E05009010,E14001139,E07000095,E10000015
+2024,2024,Wormley and Turnford,Broxbourne,Broxbourne,Hertfordshire,E05009011,E14001139,E07000095,E10000015
+2024,2024,Adeyfield East,Hemel Hempstead,Dacorum,Hertfordshire,E05004691,E14001278,E07000096,E10000015
+2024,2024,Adeyfield West,Hemel Hempstead,Dacorum,Hertfordshire,E05004692,E14001278,E07000096,E10000015
+2024,2024,Aldbury and Wigginton,Harpenden and Berkhamsted,Dacorum,Hertfordshire,E05004693,E14001268,E07000096,E10000015
+2024,2024,Apsley and Corner Hall,Hemel Hempstead,Dacorum,Hertfordshire,E05004694,E14001278,E07000096,E10000015
+2024,2024,Ashridge,Harpenden and Berkhamsted,Dacorum,Hertfordshire,E05004695,E14001268,E07000096,E10000015
+2024,2024,Churchdown Brookfield with Hucclecote,Tewkesbury,Tewkesbury,Gloucestershire,E05015481,E14001542,E07000083,E10000013
+2024,2024,Bennetts End,Hemel Hempstead,Dacorum,Hertfordshire,E05004696,E14001278,E07000096,E10000015
+2024,2024,Berkhamsted Castle,Harpenden and Berkhamsted,Dacorum,Hertfordshire,E05004697,E14001268,E07000096,E10000015
+2024,2024,Churchdown St John's,North Cotswolds,Tewkesbury,Gloucestershire,E05015482,E14001386,E07000083,E10000013
+2024,2024,Hardway,Gosport,Gosport,Hampshire,E05014146,E14001252,E07000088,E10000014
+2024,2024,Berkhamsted East,Harpenden and Berkhamsted,Dacorum,Hertfordshire,E05004698,E14001268,E07000096,E10000015
+2024,2024,"Matson, Robinswood and White City",Gloucester,Gloucester,Gloucestershire,E05010961,E14001248,E07000081,E10000013
+2024,2024,Dymock,Forest of Dean,Forest of Dean,Gloucestershire,E05012161,E14001240,E07000080,E10000013
+2024,2024,Hartpury & Redmarley,Forest of Dean,Forest of Dean,Gloucestershire,E05012162,E14001240,E07000080,E10000013
+2024,2024,Moreland,Gloucester,Gloucester,Gloucestershire,E05010962,E14001248,E07000081,E10000013
+2024,2024,Berkhamsted West,Harpenden and Berkhamsted,Dacorum,Hertfordshire,E05004699,E14001268,E07000096,E10000015
+2024,2024,"Littlebury, Chesterford & Wenden Lofts",North West Essex,Uttlesford,Essex,E05009921,E14001402,E07000077,E10000012
+2024,2024,Churchdown St John's,Tewkesbury,Tewkesbury,Gloucestershire,E05015482,E14001542,E07000083,E10000013
+2024,2024,Lee East,Gosport,Gosport,Hampshire,E05014147,E14001252,E07000088,E10000014
+2024,2024,Lee West,Gosport,Gosport,Hampshire,E05014148,E14001252,E07000088,E10000014
+2024,2024,Leesland & Newtown,Gosport,Gosport,Hampshire,E05014149,E14001252,E07000088,E10000014
+2024,2024,Peel Common,Gosport,Gosport,Hampshire,E05014150,E14001252,E07000088,E10000014
+2024,2024,Rowner & Holbrook,Gosport,Gosport,Hampshire,E05014151,E14001252,E07000088,E10000014
+2024,2024,Blackwater and Hawley,Aldershot,Hart,Hampshire,E05009352,E14001063,E07000089,E10000014
+2024,2024,Crookham East,North East Hampshire,Hart,Hampshire,E05009353,E14001392,E07000089,E10000014
+2024,2024,Crookham West and Ewshot,North East Hampshire,Hart,Hampshire,E05009354,E14001392,E07000089,E10000014
+2024,2024,Newport,North West Essex,Uttlesford,Essex,E05009922,E14001402,E07000077,E10000012
+2024,2024,Fleet Central,North East Hampshire,Hart,Hampshire,E05009355,E14001392,E07000089,E10000014
+2024,2024,Cleeve Grange,Tewkesbury,Tewkesbury,Gloucestershire,E05015483,E14001542,E07000083,E10000013
+2024,2024,Saffron Walden Audley,North West Essex,Uttlesford,Essex,E05009923,E14001402,E07000077,E10000012
+2024,2024,"Bovingdon, Flaunden and Chipperfield",Hemel Hempstead,Dacorum,Hertfordshire,E05004700,E14001278,E07000096,E10000015
+2024,2024,Podsmead,Gloucester,Gloucester,Gloucestershire,E05010963,E14001248,E07000081,E10000013
+2024,2024,Fleet East,North East Hampshire,Hart,Hampshire,E05009356,E14001392,E07000089,E10000014
+2024,2024,Longhope & Huntley,Forest of Dean,Forest of Dean,Gloucestershire,E05012163,E14001240,E07000080,E10000013
+2024,2024,Saffron Walden Castle,North West Essex,Uttlesford,Essex,E05009924,E14001402,E07000077,E10000012
+2024,2024,Fleet West,North East Hampshire,Hart,Hampshire,E05009357,E14001392,E07000089,E10000014
+2024,2024,Lydbrook,Forest of Dean,Forest of Dean,Gloucestershire,E05012164,E14001240,E07000080,E10000013
+2024,2024,Boxmoor,Hemel Hempstead,Dacorum,Hertfordshire,E05004701,E14001278,E07000096,E10000015
+2024,2024,Quedgeley Fieldcourt,Gloucester,Gloucester,Gloucestershire,E05010964,E14001248,E07000081,E10000013
+2024,2024,Cleeve Hill,Tewkesbury,Tewkesbury,Gloucestershire,E05015484,E14001542,E07000083,E10000013
+2024,2024,Quedgeley Severn Vale,Gloucester,Gloucester,Gloucestershire,E05010965,E14001248,E07000081,E10000013
+2024,2024,Lydney East,Forest of Dean,Forest of Dean,Gloucestershire,E05012165,E14001240,E07000080,E10000013
+2024,2024,Innsworth,Tewkesbury,Tewkesbury,Gloucestershire,E05015485,E14001542,E07000083,E10000013
+2024,2024,Tuffley,Gloucester,Gloucester,Gloucestershire,E05010966,E14001248,E07000081,E10000013
+2024,2024,Hartley Wintney,North East Hampshire,Hart,Hampshire,E05009358,E14001392,E07000089,E10000014
+2024,2024,Lydney North,Forest of Dean,Forest of Dean,Gloucestershire,E05012166,E14001240,E07000080,E10000013
+2024,2024,Chaulden and Warners End,Hemel Hempstead,Dacorum,Hertfordshire,E05004702,E14001278,E07000096,E10000015
+2024,2024,Isbourne,Tewkesbury,Tewkesbury,Gloucestershire,E05015486,E14001542,E07000083,E10000013
+2024,2024,Westgate,Gloucester,Gloucester,Gloucestershire,E05010967,E14001248,E07000081,E10000013
+2024,2024,Hook,North East Hampshire,Hart,Hampshire,E05009359,E14001392,E07000089,E10000014
+2024,2024,Lydney West & Aylburton,Forest of Dean,Forest of Dean,Gloucestershire,E05012167,E14001240,E07000080,E10000013
+2024,2024,Tewkesbury East,Tewkesbury,Tewkesbury,Gloucestershire,E05015487,E14001542,E07000083,E10000013
+2024,2024,Odiham,North East Hampshire,Hart,Hampshire,E05009360,E14001392,E07000089,E10000014
+2024,2024,Basing & Upton Grey,North East Hampshire,Basingstoke and Deane,Hampshire,E05013078,E14001392,E07000084,E10000014
+2024,2024,"Mitcheldean, Ruardean & Drybrook",Forest of Dean,Forest of Dean,Gloucestershire,E05012168,E14001240,E07000080,E10000013
+2024,2024,Berkeley Vale,Stroud,Stroud,Gloucestershire,E05010969,E14001529,E07000082,E10000013
+2024,2024,Saffron Walden Shire,North West Essex,Uttlesford,Essex,E05009925,E14001402,E07000077,E10000012
+2024,2024,Gadebridge,Hemel Hempstead,Dacorum,Hertfordshire,E05004703,E14001278,E07000096,E10000015
+2024,2024,Grovehill,Hemel Hempstead,Dacorum,Hertfordshire,E05004704,E14001278,E07000096,E10000015
+2024,2024,Hemel Hempstead Town,Hemel Hempstead,Dacorum,Hertfordshire,E05004705,E14001278,E07000096,E10000015
+2024,2024,Highfield,Hemel Hempstead,Dacorum,Hertfordshire,E05004706,E14001278,E07000096,E10000015
+2024,2024,Kings Langley,South West Hertfordshire,Dacorum,Hertfordshire,E05004707,E14001496,E07000096,E10000015
+2024,2024,Leverstock Green,Hemel Hempstead,Dacorum,Hertfordshire,E05004708,E14001278,E07000096,E10000015
+2024,2024,Nash Mills,Hemel Hempstead,Dacorum,Hertfordshire,E05004709,E14001278,E07000096,E10000015
+2024,2024,Northchurch,Harpenden and Berkhamsted,Dacorum,Hertfordshire,E05004710,E14001268,E07000096,E10000015
+2024,2024,Tring Central,Harpenden and Berkhamsted,Dacorum,Hertfordshire,E05004711,E14001268,E07000096,E10000015
+2024,2024,Tring East,Harpenden and Berkhamsted,Dacorum,Hertfordshire,E05004712,E14001268,E07000096,E10000015
+2024,2024,Tring West and Rural,Harpenden and Berkhamsted,Dacorum,Hertfordshire,E05004713,E14001268,E07000096,E10000015
+2024,2024,Watling,Harpenden and Berkhamsted,Dacorum,Hertfordshire,E05004714,E14001268,E07000096,E10000015
+2024,2024,Woodhall Farm,Hemel Hempstead,Dacorum,Hertfordshire,E05004715,E14001278,E07000096,E10000015
+2024,2024,Aldenham East,Hertsmere,Hertsmere,Hertfordshire,E05012177,E14001284,E07000098,E10000015
+2024,2024,Aldenham West,Hertsmere,Hertsmere,Hertfordshire,E05012178,E14001284,E07000098,E10000015
+2024,2024,Bentley Heath & The Royds,Hertsmere,Hertsmere,Hertfordshire,E05012179,E14001284,E07000098,E10000015
+2024,2024,Borehamwood Brookmeadow,Hertsmere,Hertsmere,Hertfordshire,E05012180,E14001284,E07000098,E10000015
+2024,2024,Borehamwood Cowley Hill,Hertsmere,Hertsmere,Hertfordshire,E05012181,E14001284,E07000098,E10000015
+2024,2024,Borehamwood Hillside,Hertsmere,Hertsmere,Hertfordshire,E05012182,E14001284,E07000098,E10000015
+2024,2024,Borehamwood Kenilworth,Hertsmere,Hertsmere,Hertfordshire,E05012183,E14001284,E07000098,E10000015
+2024,2024,Bushey Heath,Hertsmere,Hertsmere,Hertfordshire,E05012184,E14001284,E07000098,E10000015
+2024,2024,Yateley East,Aldershot,Hart,Hampshire,E05009361,E14001063,E07000089,E10000014
+2024,2024,Bushey North,Watford,Hertsmere,Hertfordshire,E05012185,E14001568,E07000098,E10000015
+2024,2024,Bushey Park,Hertsmere,Hertsmere,Hertfordshire,E05012186,E14001284,E07000098,E10000015
+2024,2024,Yateley West,North East Hampshire,Hart,Hampshire,E05009362,E14001392,E07000089,E10000014
+2024,2024,Bushey St James,Hertsmere,Hertsmere,Hertfordshire,E05012187,E14001284,E07000098,E10000015
+2024,2024,Bedhampton,Havant,Havant,Hampshire,E05015581,E14001275,E07000090,E10000014
+2024,2024,Cowplain,Fareham and Waterlooville,Havant,Hampshire,E05015582,E14001233,E07000090,E10000014
+2024,2024,Bramley,North East Hampshire,Basingstoke and Deane,Hampshire,E05013079,E14001392,E07000084,E10000014
+2024,2024,Emsworth,Havant,Havant,Hampshire,E05015583,E14001275,E07000090,E10000014
+2024,2024,Hart Plain,Fareham and Waterlooville,Havant,Hampshire,E05015584,E14001233,E07000090,E10000014
+2024,2024,Havant St Faith's,Havant,Havant,Hampshire,E05015585,E14001275,E07000090,E10000014
+2024,2024,Hayling East,Havant,Havant,Hampshire,E05015586,E14001275,E07000090,E10000014
+2024,2024,Brighton Hill,Basingstoke,Basingstoke and Deane,Hampshire,E05013080,E14001078,E07000084,E10000014
+2024,2024,Newent & Taynton,Forest of Dean,Forest of Dean,Gloucestershire,E05012169,E14001240,E07000080,E10000013
+2024,2024,Hayling West,Havant,Havant,Hampshire,E05015587,E14001275,E07000090,E10000014
+2024,2024,Cam East,Stroud,Stroud,Gloucestershire,E05010972,E14001529,E07000082,E10000013
+2024,2024,Stansted North,North West Essex,Uttlesford,Essex,E05009926,E14001402,E07000077,E10000012
+2024,2024,Leigh Park Central & West Leigh,Havant,Havant,Hampshire,E05015588,E14001275,E07000090,E10000014
+2024,2024,Stansted South & Birchanger,North West Essex,Uttlesford,Essex,E05009927,E14001402,E07000077,E10000012
+2024,2024,Stort Valley,North West Essex,Uttlesford,Essex,E05009928,E14001402,E07000077,E10000012
+2024,2024,Leigh Park Hermitage,Havant,Havant,Hampshire,E05015589,E14001275,E07000090,E10000014
+2024,2024,Brookvale & Kings Furlong,Basingstoke,Basingstoke and Deane,Hampshire,E05013081,E14001078,E07000084,E10000014
+2024,2024,Takeley,North West Essex,Uttlesford,Essex,E05009929,E14001402,E07000077,E10000012
+2024,2024,Purbrook,Havant,Havant,Hampshire,E05015590,E14001275,E07000090,E10000014
+2024,2024,Cam West,Stroud,Stroud,Gloucestershire,E05010973,E14001529,E07000082,E10000013
+2024,2024,Newland & Sling,Forest of Dean,Forest of Dean,Gloucestershire,E05012170,E14001240,E07000080,E10000013
+2024,2024,Chineham,Basingstoke,Basingstoke and Deane,Hampshire,E05013082,E14001078,E07000084,E10000014
+2024,2024,The Sampfords,Braintree,Uttlesford,Essex,E05009931,E14001121,E07000077,E10000012
+2024,2024,Stakes,Havant,Havant,Hampshire,E05015591,E14001275,E07000090,E10000014
+2024,2024,Coaley and Uley,Stroud,Stroud,Gloucestershire,E05010975,E14001529,E07000082,E10000013
+2024,2024,Newnham,Forest of Dean,Forest of Dean,Gloucestershire,E05012171,E14001240,E07000080,E10000013
+2024,2024,Eastrop & Grove,Basingstoke,Basingstoke and Deane,Hampshire,E05013083,E14001078,E07000084,E10000014
+2024,2024,Great Dunmow North,North West Essex,Uttlesford,Essex,E05014489,E14001402,E07000077,E10000012
+2024,2024,Waterloo,Fareham and Waterlooville,Havant,Hampshire,E05015592,E14001233,E07000090,E10000014
+2024,2024,Dursley,Stroud,Stroud,Gloucestershire,E05010976,E14001529,E07000082,E10000013
+2024,2024,Pillowell,Forest of Dean,Forest of Dean,Gloucestershire,E05012172,E14001240,E07000080,E10000013
+2024,2024,Evingar,North West Hampshire,Basingstoke and Deane,Hampshire,E05013084,E14001403,E07000084,E10000014
+2024,2024,Thaxted & the Eastons,North West Essex,Uttlesford,Essex,E05014490,E14001402,E07000077,E10000012
+2024,2024,"Ashley, Bashley & Fernhill",New Forest West,New Forest,Hampshire,E05014770,E14001374,E07000091,E10000014
+2024,2024,Painswick and Upton,North Cotswolds,Stroud,Gloucestershire,E05010981,E14001386,E07000082,E10000013
+2024,2024,Ruspidge,Forest of Dean,Forest of Dean,Gloucestershire,E05012173,E14001240,E07000080,E10000013
+2024,2024,Hatch Warren & Beggarwood,Basingstoke,Basingstoke and Deane,Hampshire,E05013085,E14001078,E07000084,E10000014
+2024,2024,All Saints,Cheltenham,Cheltenham,Gloucestershire,E05015704,E14001161,E07000078,E10000013
+2024,2024,"Ashurst, Bramshaw, Copythorne & Netley Marsh",New Forest East,New Forest,Hampshire,E05014771,E14001373,E07000091,E10000014
+2024,2024,"Randwick, Whiteshill and Ruscombe",Stroud,Stroud,Gloucestershire,E05010982,E14001529,E07000082,E10000013
+2024,2024,St. Briavels,Forest of Dean,Forest of Dean,Gloucestershire,E05012174,E14001240,E07000080,E10000013
+2024,2024,Kempshott & Buckskin,Basingstoke,Basingstoke and Deane,Hampshire,E05013086,E14001078,E07000084,E10000014
+2024,2024,Battledown,Cheltenham,Cheltenham,Gloucestershire,E05015705,E14001161,E07000078,E10000013
+2024,2024,Ballard,New Forest West,New Forest,Hampshire,E05014772,E14001374,E07000091,E10000014
+2024,2024,Stroud Central,Stroud,Stroud,Gloucestershire,E05010986,E14001529,E07000082,E10000013
+2024,2024,Tidenham,Forest of Dean,Forest of Dean,Gloucestershire,E05012175,E14001240,E07000080,E10000013
+2024,2024,"Benhall, the Reddings & Fiddler's Green",Cheltenham,Cheltenham,Gloucestershire,E05015706,E14001161,E07000078,E10000013
+2024,2024,Barton & Becton,New Forest West,New Forest,Hampshire,E05014773,E14001374,E07000091,E10000014
+2024,2024,Westbury-on-Severn,Forest of Dean,Forest of Dean,Gloucestershire,E05012176,E14001240,E07000080,E10000013
+2024,2024,Stroud Farmhill and Paganhill,Stroud,Stroud,Gloucestershire,E05010987,E14001529,E07000082,E10000013
+2024,2024,Norden,Basingstoke,Basingstoke and Deane,Hampshire,E05013087,E14001078,E07000084,E10000014
+2024,2024,Stroud Slade,Stroud,Stroud,Gloucestershire,E05010988,E14001529,E07000082,E10000013
+2024,2024,Oakley & The Candovers,Basingstoke,Basingstoke and Deane,Hampshire,E05013088,E14001078,E07000084,E10000014
+2024,2024,Stroud Uplands,Stroud,Stroud,Gloucestershire,E05010990,E14001529,E07000082,E10000013
+2024,2024,Abbeydale,Gloucester,Gloucester,Gloucestershire,E05010950,E14001248,E07000081,E10000013
+2024,2024,Oakley & The Candovers,East Hampshire,Basingstoke and Deane,Hampshire,E05013088,E14001214,E07000084,E10000014
+2024,2024,"Bransgore, Burley, Sopley & Ringwood East",New Forest West,New Forest,Hampshire,E05014774,E14001374,E07000091,E10000014
+2024,2024,Stroud Valley,Stroud,Stroud,Gloucestershire,E05010991,E14001529,E07000082,E10000013
+2024,2024,Abbeymead,Gloucester,Gloucester,Gloucestershire,E05010951,E14001248,E07000081,E10000013
+2024,2024,Charlton Kings,Cheltenham,Cheltenham,Gloucestershire,E05015707,E14001161,E07000078,E10000013
+2024,2024,Popley,Basingstoke,Basingstoke and Deane,Hampshire,E05013089,E14001078,E07000084,E10000014
+2024,2024,Brockenhurst & Denny Lodge,New Forest East,New Forest,Hampshire,E05014775,E14001373,E07000091,E10000014
+2024,2024,The Stanleys,Stroud,Stroud,Gloucestershire,E05010992,E14001529,E07000082,E10000013
+2024,2024,Barnwood,Gloucester,Gloucester,Gloucestershire,E05010952,E14001248,E07000081,E10000013
+2024,2024,Charlton Park,Cheltenham,Cheltenham,Gloucestershire,E05015708,E14001161,E07000078,E10000013
+2024,2024,Sherborne St John & Rooksdown,North West Hampshire,Basingstoke and Deane,Hampshire,E05013090,E14001403,E07000084,E10000014
+2024,2024,Dibden & Dibden Purlieu,New Forest East,New Forest,Hampshire,E05014776,E14001373,E07000091,E10000014
+2024,2024,Amberley and Woodchester,Stroud,Stroud,Gloucestershire,E05013187,E14001529,E07000082,E10000013
+2024,2024,Barton and Tredworth,Gloucester,Gloucester,Gloucestershire,E05010953,E14001248,E07000081,E10000013
+2024,2024,College,Cheltenham,Cheltenham,Gloucestershire,E05015709,E14001161,E07000078,E10000013
+2024,2024,South Ham,Basingstoke,Basingstoke and Deane,Hampshire,E05013091,E14001078,E07000084,E10000014
+2024,2024,Downlands & Forest North,New Forest West,New Forest,Hampshire,E05014777,E14001374,E07000091,E10000014
+2024,2024,Bisley,North Cotswolds,Stroud,Gloucestershire,E05013188,E14001386,E07000082,E10000013
+2024,2024,Coney Hill,Gloucester,Gloucester,Gloucestershire,E05010954,E14001248,E07000081,E10000013
+2024,2024,Hesters Way,Cheltenham,Cheltenham,Gloucestershire,E05015710,E14001161,E07000078,E10000013
+2024,2024,Tadley & Pamber,North West Hampshire,Basingstoke and Deane,Hampshire,E05013092,E14001403,E07000084,E10000014
+2024,2024,"Fawley, Blackfield, Calshot & Langley",New Forest East,New Forest,Hampshire,E05014778,E14001373,E07000091,E10000014
+2024,2024,Chalford,Stroud,Stroud,Gloucestershire,E05013189,E14001529,E07000082,E10000013
+2024,2024,Elmbridge,Tewkesbury,Gloucester,Gloucestershire,E05010955,E14001542,E07000081,E10000013
+2024,2024,"Tadley North, Kingsclere & Baughurst",North West Hampshire,Basingstoke and Deane,Hampshire,E05013093,E14001403,E07000084,E10000014
+2024,2024,"Fordingbridge, Godshill & Hyde",New Forest West,New Forest,Hampshire,E05014779,E14001374,E07000091,E10000014
+2024,2024,Grange,Gloucester,Gloucester,Gloucestershire,E05010956,E14001248,E07000081,E10000013
+2024,2024,"Whitchurch, Overton & Laverstoke",North West Hampshire,Basingstoke and Deane,Hampshire,E05013094,E14001403,E07000084,E10000014
+2024,2024,Kingswood,South Cotswolds,Stroud,Gloucestershire,E05013191,E14001482,E07000082,E10000013
+2024,2024,Hesters Way,Tewkesbury,Cheltenham,Gloucestershire,E05015710,E14001542,E07000078,E10000013
+2024,2024,Lansdown,Cheltenham,Cheltenham,Gloucestershire,E05015711,E14001161,E07000078,E10000013
+2024,2024,Leckhampton,Cheltenham,Cheltenham,Gloucestershire,E05015712,E14001161,E07000078,E10000013
+2024,2024,Oakley,Cheltenham,Cheltenham,Gloucestershire,E05015713,E14001161,E07000078,E10000013
+2024,2024,Park,Cheltenham,Cheltenham,Gloucestershire,E05015714,E14001161,E07000078,E10000013
+2024,2024,Pittville,Cheltenham,Cheltenham,Gloucestershire,E05015715,E14001161,E07000078,E10000013
+2024,2024,Pittville,Tewkesbury,Cheltenham,Gloucestershire,E05015715,E14001542,E07000078,E10000013
+2024,2024,Prestbury,Cheltenham,Cheltenham,Gloucestershire,E05015716,E14001161,E07000078,E10000013
+2024,2024,Prestbury,Tewkesbury,Cheltenham,Gloucestershire,E05015716,E14001542,E07000078,E10000013
+2024,2024,Springbank,Tewkesbury,Cheltenham,Gloucestershire,E05015717,E14001542,E07000078,E10000013
+2024,2024,St Mark's,Cheltenham,Cheltenham,Gloucestershire,E05015718,E14001161,E07000078,E10000013
+2024,2024,St Paul's,Cheltenham,Cheltenham,Gloucestershire,E05015719,E14001161,E07000078,E10000013
+2024,2024,St Peter's,Cheltenham,Cheltenham,Gloucestershire,E05015720,E14001161,E07000078,E10000013
+2024,2024,Swindon Village,Tewkesbury,Cheltenham,Gloucestershire,E05015721,E14001542,E07000078,E10000013
+2024,2024,Up Hatherley,Cheltenham,Cheltenham,Gloucestershire,E05015722,E14001161,E07000078,E10000013
+2024,2024,Warden Hill,Cheltenham,Cheltenham,Gloucestershire,E05015723,E14001161,E07000078,E10000013
+2024,2024,Abbey,South Cotswolds,Cotswold,Gloucestershire,E05010696,E14001482,E07000079,E10000013
+2024,2024,Blockley,North Cotswolds,Cotswold,Gloucestershire,E05010697,E14001386,E07000079,E10000013
+2024,2024,Bourton Vale,North Cotswolds,Cotswold,Gloucestershire,E05010698,E14001386,E07000079,E10000013
+2024,2024,Bourton Village,North Cotswolds,Cotswold,Gloucestershire,E05010699,E14001386,E07000079,E10000013
+2024,2024,Campden & Vale,North Cotswolds,Cotswold,Gloucestershire,E05010700,E14001386,E07000079,E10000013
+2024,2024,Winklebury & Manydown,Basingstoke,Basingstoke and Deane,Hampshire,E05013095,E14001078,E07000084,E10000014
+2024,2024,Chesterton,South Cotswolds,Cotswold,Gloucestershire,E05010702,E14001482,E07000079,E10000013
+2024,2024,Coln Valley,North Cotswolds,Cotswold,Gloucestershire,E05010703,E14001386,E07000079,E10000013
+2024,2024,Alton Amery,East Hampshire,East Hampshire,Hampshire,E05012290,E14001214,E07000085,E10000014
+2024,2024,Fairford North,South Cotswolds,Cotswold,Gloucestershire,E05010705,E14001482,E07000079,E10000013
+2024,2024,Alton Ashdell,East Hampshire,East Hampshire,Hampshire,E05012291,E14001214,E07000085,E10000014
+2024,2024,Fosseridge,North Cotswolds,Cotswold,Gloucestershire,E05010706,E14001386,E07000079,E10000013
+2024,2024,Alton Eastbrooke,East Hampshire,East Hampshire,Hampshire,E05012292,E14001214,E07000085,E10000014
+2024,2024,Minchinhampton,North Cotswolds,Stroud,Gloucestershire,E05013192,E14001386,E07000082,E10000013
+2024,2024,Four Acres,South Cotswolds,Cotswold,Gloucestershire,E05010707,E14001482,E07000079,E10000013
+2024,2024,Grumbolds Ash with Avening,South Cotswolds,Cotswold,Gloucestershire,E05010708,E14001482,E07000079,E10000013
+2024,2024,Kemble,South Cotswolds,Cotswold,Gloucestershire,E05010709,E14001482,E07000079,E10000013
+2024,2024,"Lechlade, Kempsford & Fairford South",South Cotswolds,Cotswold,Gloucestershire,E05010710,E14001482,E07000079,E10000013
+2024,2024,Alton Holybourne,East Hampshire,East Hampshire,Hampshire,E05012293,E14001214,E07000085,E10000014
+2024,2024,Nailsworth,Stroud,Stroud,Gloucestershire,E05013193,E14001529,E07000082,E10000013
+2024,2024,Forest & Solent,New Forest East,New Forest,Hampshire,E05014780,E14001373,E07000091,E10000014
+2024,2024,Alton Westbrooke,East Hampshire,East Hampshire,Hampshire,E05012294,E14001214,E07000085,E10000014
+2024,2024,Rodborough,Stroud,Stroud,Gloucestershire,E05013194,E14001529,E07000082,E10000013
+2024,2024,Hucclecote,Gloucester,Gloucester,Gloucestershire,E05010957,E14001248,E07000081,E10000013
+2024,2024,Alton Whitedown,East Hampshire,East Hampshire,Hampshire,E05012295,E14001214,E07000085,E10000014
+2024,2024,Kingsholm and Wotton,Gloucester,Gloucester,Gloucestershire,E05010958,E14001248,E07000081,E10000013
+2024,2024,Stroud Trinity,Stroud,Stroud,Gloucestershire,E05013197,E14001529,E07000082,E10000013
+2024,2024,Alton Wooteys,East Hampshire,East Hampshire,Hampshire,E05012296,E14001214,E07000085,E10000014
+2024,2024,"Hardley, Holbury & North Blackfield",New Forest East,New Forest,Hampshire,E05014781,E14001373,E07000091,E10000014
+2024,2024,Thrupp,Stroud,Stroud,Gloucestershire,E05013198,E14001529,E07000082,E10000013
+2024,2024,Bentworth & Froyle,East Hampshire,East Hampshire,Hampshire,E05012297,E14001214,E07000085,E10000014
+2024,2024,Hythe Central,New Forest East,New Forest,Hampshire,E05014782,E14001373,E07000091,E10000014
+2024,2024,Wotton-under-Edge,Stroud,Stroud,Gloucestershire,E05013199,E14001529,E07000082,E10000013
+2024,2024,Cainscross,Stroud,Stroud,Gloucestershire,E05013212,E14001529,E07000082,E10000013
+2024,2024,Hardwicke,North Cotswolds,Stroud,Gloucestershire,E05015846,E14001386,E07000082,E10000013
+2024,2024,Severn,North Cotswolds,Stroud,Gloucestershire,E05015847,E14001386,E07000082,E10000013
+2024,2024,Severn,Stroud,Stroud,Gloucestershire,E05015847,E14001529,E07000082,E10000013
+2024,2024,Stonehouse,Stroud,Stroud,Gloucestershire,E05015848,E14001529,E07000082,E10000013
+2024,2024,Brockworth East,North Cotswolds,Tewkesbury,Gloucestershire,E05012065,E14001386,E07000083,E10000013
+2024,2024,Brockworth West,North Cotswolds,Tewkesbury,Gloucestershire,E05012066,E14001386,E07000083,E10000013
+2024,2024,Cleeve St Michael's,Tewkesbury,Tewkesbury,Gloucestershire,E05012071,E14001542,E07000083,E10000013
+2024,2024,Cleeve West,Tewkesbury,Tewkesbury,Gloucestershire,E05012072,E14001542,E07000083,E10000013
+2024,2024,Highnam with Haw Bridge,Forest of Dean,Tewkesbury,Gloucestershire,E05012073,E14001240,E07000083,E10000013
+2024,2024,Northway,Tewkesbury,Tewkesbury,Gloucestershire,E05012076,E14001542,E07000083,E10000013
+2024,2024,Severn Vale North,Tewkesbury,Tewkesbury,Gloucestershire,E05012077,E14001542,E07000083,E10000013
+2024,2024,Severn Vale South,Tewkesbury,Tewkesbury,Gloucestershire,E05012078,E14001542,E07000083,E10000013
+2024,2024,Shurdington,North Cotswolds,Tewkesbury,Gloucestershire,E05012079,E14001386,E07000083,E10000013
+2024,2024,Tewkesbury North & Twyning,Tewkesbury,Tewkesbury,Gloucestershire,E05012081,E14001542,E07000083,E10000013
+2024,2024,Tewkesbury South,Tewkesbury,Tewkesbury,Gloucestershire,E05012082,E14001542,E07000083,E10000013
+2024,2024,Winchcombe,Tewkesbury,Tewkesbury,Gloucestershire,E05012083,E14001542,E07000083,E10000013
+2024,2024,Badgeworth,North Cotswolds,Tewkesbury,Gloucestershire,E05015480,E14001386,E07000083,E10000013
+2024,2024,"Binsted, Bentley & Selborne",East Hampshire,East Hampshire,Hampshire,E05012298,E14001214,E07000085,E10000014
+2024,2024,Bramshott & Liphook,Farnham and Bordon,East Hampshire,Hampshire,E05012299,E14001234,E07000085,E10000014
+2024,2024,Buriton & East Meon,East Hampshire,East Hampshire,Hampshire,E05012300,E14001214,E07000085,E10000014
+2024,2024,Clanfield,East Hampshire,East Hampshire,Hampshire,E05012301,E14001214,E07000085,E10000014
+2024,2024,Four Marks & Medstead,East Hampshire,East Hampshire,Hampshire,E05012302,E14001214,E07000085,E10000014
+2024,2024,"Froxfield, Sheet & Steep",East Hampshire,East Hampshire,Hampshire,E05012303,E14001214,E07000085,E10000014
+2024,2024,Grayshott,Farnham and Bordon,East Hampshire,Hampshire,E05012304,E14001234,E07000085,E10000014
+2024,2024,Headley,Farnham and Bordon,East Hampshire,Hampshire,E05012305,E14001234,E07000085,E10000014
+2024,2024,Horndean Catherington,East Hampshire,East Hampshire,Hampshire,E05012306,E14001214,E07000085,E10000014
+2024,2024,Horndean Downs,East Hampshire,East Hampshire,Hampshire,E05012307,E14001214,E07000085,E10000014
+2024,2024,Horndean Kings & Blendworth,East Hampshire,East Hampshire,Hampshire,E05012308,E14001214,E07000085,E10000014
+2024,2024,Horndean Murray,East Hampshire,East Hampshire,Hampshire,E05012309,E14001214,E07000085,E10000014
+2024,2024,Lindford,Farnham and Bordon,East Hampshire,Hampshire,E05012310,E14001234,E07000085,E10000014
+2024,2024,Liss,East Hampshire,East Hampshire,Hampshire,E05012311,E14001214,E07000085,E10000014
+2024,2024,Hythe South,New Forest East,New Forest,Hampshire,E05014783,E14001373,E07000091,E10000014
+2024,2024,Lymington,New Forest West,New Forest,Hampshire,E05014784,E14001374,E07000091,E10000014
+2024,2024,Lyndhurst & Minstead,New Forest East,New Forest,Hampshire,E05014785,E14001373,E07000091,E10000014
+2024,2024,Marchwood & Eling,New Forest East,New Forest,Hampshire,E05014786,E14001373,E07000091,E10000014
+2024,2024,Milford & Hordle,New Forest West,New Forest,Hampshire,E05014787,E14001374,E07000091,E10000014
+2024,2024,Milton,New Forest West,New Forest,Hampshire,E05014788,E14001374,E07000091,E10000014
+2024,2024,Pennington,New Forest West,New Forest,Hampshire,E05014789,E14001374,E07000091,E10000014
+2024,2024,Ringwood North & Ellingham,New Forest West,New Forest,Hampshire,E05014790,E14001374,E07000091,E10000014
+2024,2024,Elstree,Hertsmere,Hertsmere,Hertfordshire,E05012188,E14001284,E07000098,E10000015
+2024,2024,Potters Bar Furzefield,Hertsmere,Hertsmere,Hertfordshire,E05012189,E14001284,E07000098,E10000015
+2024,2024,Potters Bar Oakmere,Hertsmere,Hertsmere,Hertfordshire,E05012190,E14001284,E07000098,E10000015
+2024,2024,Potters Bar Parkfield,Hertsmere,Hertsmere,Hertfordshire,E05012191,E14001284,E07000098,E10000015
+2024,2024,Shenley,Hertsmere,Hertsmere,Hertfordshire,E05012192,E14001284,E07000098,E10000015
+2024,2024,Arbury,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015754,E14001393,E07000099,E10000015
+2024,2024,Baldock East,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015755,E14001393,E07000099,E10000015
+2024,2024,Baldock West,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015756,E14001393,E07000099,E10000015
+2024,2024,Cadwell,Hitchin,North Hertfordshire,Hertfordshire,E05015757,E14001289,E07000099,E10000015
+2024,2024,Codicote & Kimpton,Hitchin,North Hertfordshire,Hertfordshire,E05015758,E14001289,E07000099,E10000015
+2024,2024,Larkfield,Chatham and Aylesford,Tonbridge and Malling,Kent,E05015047,E14001157,E07000115,E10000016
+2024,2024,Codicote & Kimpton,Stevenage,North Hertfordshire,Hertfordshire,E05015758,E14001516,E07000099,E10000015
+2024,2024,Ermine,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015759,E14001393,E07000099,E10000015
+2024,2024,"Graveley, St Ippolyts & Wymondley",Hitchin,North Hertfordshire,Hertfordshire,E05015760,E14001289,E07000099,E10000015
+2024,2024,Great Ashby,Hitchin,North Hertfordshire,Hertfordshire,E05015761,E14001289,E07000099,E10000015
+2024,2024,Great Ashby,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015761,E14001393,E07000099,E10000015
+2024,2024,Hitchin Bearton,Hitchin,North Hertfordshire,Hertfordshire,E05015762,E14001289,E07000099,E10000015
+2024,2024,Hitchin Highbury,Hitchin,North Hertfordshire,Hertfordshire,E05015763,E14001289,E07000099,E10000015
+2024,2024,Hitchin Oughton,Hitchin,North Hertfordshire,Hertfordshire,E05015764,E14001289,E07000099,E10000015
+2024,2024,Hitchin Priory,Hitchin,North Hertfordshire,Hertfordshire,E05015765,E14001289,E07000099,E10000015
+2024,2024,Hitchin Walsworth,Hitchin,North Hertfordshire,Hertfordshire,E05015766,E14001289,E07000099,E10000015
+2024,2024,Hitchwood,Hitchin,North Hertfordshire,Hertfordshire,E05015767,E14001289,E07000099,E10000015
+2024,2024,Knebworth,Stevenage,North Hertfordshire,Hertfordshire,E05015768,E14001516,E07000099,E10000015
+2024,2024,Letchworth Grange,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015769,E14001393,E07000099,E10000015
+2024,2024,Letchworth Norton,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015770,E14001393,E07000099,E10000015
+2024,2024,Letchworth South East,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015771,E14001393,E07000099,E10000015
+2024,2024,Letchworth South West,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015772,E14001393,E07000099,E10000015
+2024,2024,Letchworth Wilbury,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015773,E14001393,E07000099,E10000015
+2024,2024,Offa,Hitchin,North Hertfordshire,Hertfordshire,E05015774,E14001289,E07000099,E10000015
+2024,2024,Royston Heath,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015775,E14001393,E07000099,E10000015
+2024,2024,Royston Meridian,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015776,E14001393,E07000099,E10000015
+2024,2024,Royston Palace,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015777,E14001393,E07000099,E10000015
+2024,2024,Weston & Sandon,North East Hertfordshire,North Hertfordshire,Hertfordshire,E05015778,E14001393,E07000099,E10000015
+2024,2024,Abbots Langley & Bedmond,South West Hertfordshire,Three Rivers,Hertfordshire,E05009425,E14001496,E07000102,E10000015
+2024,2024,Carpenders Park,South West Hertfordshire,Three Rivers,Hertfordshire,E05009426,E14001496,E07000102,E10000015
+2024,2024,Chorleywood North & Sarratt,South West Hertfordshire,Three Rivers,Hertfordshire,E05009427,E14001496,E07000102,E10000015
+2024,2024,Chorleywood South & Maple Cross,South West Hertfordshire,Three Rivers,Hertfordshire,E05009428,E14001496,E07000102,E10000015
+2024,2024,Dickinsons,South West Hertfordshire,Three Rivers,Hertfordshire,E05009429,E14001496,E07000102,E10000015
+2024,2024,Durrants,South West Hertfordshire,Three Rivers,Hertfordshire,E05009430,E14001496,E07000102,E10000015
+2024,2024,Gade Valley,South West Hertfordshire,Three Rivers,Hertfordshire,E05009431,E14001496,E07000102,E10000015
+2024,2024,Leavesden,South West Hertfordshire,Three Rivers,Hertfordshire,E05009432,E14001496,E07000102,E10000015
+2024,2024,Moor Park & Eastbury,South West Hertfordshire,Three Rivers,Hertfordshire,E05009433,E14001496,E07000102,E10000015
+2024,2024,Oxhey Hall & Hayling,South West Hertfordshire,Three Rivers,Hertfordshire,E05009434,E14001496,E07000102,E10000015
+2024,2024,Nascot,Watford,Watford,Hertfordshire,E05011051,E14001568,E07000103,E10000015
+2024,2024,Crockenhill and Well Hill,Sevenoaks,Sevenoaks,Kent,E05005011,E14001465,E07000111,E10000016
+2024,2024,Sandwich,Herne Bay and Sandwich,Dover,Kent,E05012867,E14001282,E07000108,E10000016
+2024,2024,Penn & Mill End,South West Hertfordshire,Three Rivers,Hertfordshire,E05009435,E14001496,E07000102,E10000015
+2024,2024,Rickmansworth Town,South West Hertfordshire,Three Rivers,Hertfordshire,E05009436,E14001496,E07000102,E10000015
+2024,2024,South Oxhey,South West Hertfordshire,Three Rivers,Hertfordshire,E05009437,E14001496,E07000102,E10000015
+2024,2024,Callowland,Watford,Watford,Hertfordshire,E05011046,E14001568,E07000103,E10000015
+2024,2024,Central,Watford,Watford,Hertfordshire,E05011047,E14001568,E07000103,E10000015
+2024,2024,Holywell,Watford,Watford,Hertfordshire,E05011048,E14001568,E07000103,E10000015
+2024,2024,Leggatts,Watford,Watford,Hertfordshire,E05011049,E14001568,E07000103,E10000015
+2024,2024,Meriden,Watford,Watford,Hertfordshire,E05011050,E14001568,E07000103,E10000015
+2024,2024,Gorrell,Canterbury,Canterbury,Kent,E05010396,E14001151,E07000106,E10000016
+2024,2024,Priory,Faversham and Mid Kent,Swale,Kent,E05009556,E14001235,E07000113,E10000016
+2024,2024,Euxton,Chorley,Chorley,Lancashire,E05013077,E14001170,E07000118,E10000017
+2024,2024,Tower Hamlets,Dover and Deal,Dover,Kent,E05012868,E14001202,E07000108,E10000016
+2024,2024,Town & Castle,Dover and Deal,Dover,Kent,E05012869,E14001202,E07000108,E10000016
+2024,2024,Walmer,Dover and Deal,Dover,Kent,E05012870,E14001202,E07000108,E10000016
+2024,2024,Whitfield,Dover and Deal,Dover,Kent,E05012871,E14001202,E07000108,E10000016
+2024,2024,Chalk,Gravesham,Gravesham,Kent,E05014912,E14001254,E07000109,E10000016
+2024,2024,Coldharbour & Perry Street,Gravesham,Gravesham,Kent,E05014913,E14001254,E07000109,E10000016
+2024,2024,Denton,Gravesham,Gravesham,Kent,E05014914,E14001254,E07000109,E10000016
+2024,2024,Higham & Shorne,Gravesham,Gravesham,Kent,E05014915,E14001254,E07000109,E10000016
+2024,2024,"Istead Rise, Cobham & Luddesdown",Gravesham,Gravesham,Kent,E05014916,E14001254,E07000109,E10000016
+2024,2024,Meopham North,Gravesham,Gravesham,Kent,E05014917,E14001254,E07000109,E10000016
+2024,2024,Meopham South & Vigo,Gravesham,Gravesham,Kent,E05014918,E14001254,E07000109,E10000016
+2024,2024,Northfleet & Springhead,Gravesham,Gravesham,Kent,E05014919,E14001254,E07000109,E10000016
+2024,2024,Painters Ash,Gravesham,Gravesham,Kent,E05014920,E14001254,E07000109,E10000016
+2024,2024,Pelham,Gravesham,Gravesham,Kent,E05014921,E14001254,E07000109,E10000016
+2024,2024,Riverview Park,Gravesham,Gravesham,Kent,E05014922,E14001254,E07000109,E10000016
+2024,2024,Rosherville,Gravesham,Gravesham,Kent,E05014923,E14001254,E07000109,E10000016
+2024,2024,Singlewell,Gravesham,Gravesham,Kent,E05014924,E14001254,E07000109,E10000016
+2024,2024,Ansdell & Fairhaven,Fylde,Fylde,Lancashire,E05014538,E14001242,E07000119,E10000017
+2024,2024,Town,Gravesham,Gravesham,Kent,E05014925,E14001254,E07000109,E10000016
+2024,2024,Dunton Green and Riverhead,Sevenoaks,Sevenoaks,Kent,E05005012,E14001465,E07000111,E10000016
+2024,2024,Oxhey,Watford,Watford,Hertfordshire,E05011052,E14001568,E07000103,E10000015
+2024,2024,Ashton,Fylde,Fylde,Lancashire,E05014539,E14001242,E07000119,E10000017
+2024,2024,Westcourt,Gravesham,Gravesham,Kent,E05014926,E14001254,E07000109,E10000016
+2024,2024,Edenbridge North and East,Tonbridge,Sevenoaks,Kent,E05005013,E14001549,E07000111,E10000016
+2024,2024,Queenborough and Halfway,Sittingbourne and Sheppey,Swale,Kent,E05009557,E14001474,E07000113,E10000016
+2024,2024,Greenhill,Herne Bay and Sandwich,Canterbury,Kent,E05010397,E14001282,E07000106,E10000016
+2024,2024,Park,Watford,Watford,Hertfordshire,E05011053,E14001568,E07000103,E10000015
+2024,2024,Carnegie,Fylde,Fylde,Lancashire,E05014540,E14001242,E07000119,E10000017
+2024,2024,Pilgrims with Ightham,Tonbridge,Tonbridge and Malling,Kent,E05015048,E14001549,E07000115,E10000016
+2024,2024,Roman,Sittingbourne and Sheppey,Swale,Kent,E05009558,E14001474,E07000113,E10000016
+2024,2024,St Ann's,Faversham and Mid Kent,Swale,Kent,E05009559,E14001235,E07000113,E10000016
+2024,2024,Whitehill & Windmill Hill,Gravesham,Gravesham,Kent,E05014927,E14001254,E07000109,E10000016
+2024,2024,Snodland East & Ham Hill,Chatham and Aylesford,Tonbridge and Malling,Kent,E05015049,E14001157,E07000115,E10000016
+2024,2024,Woodlands,Gravesham,Gravesham,Kent,E05014928,E14001254,E07000109,E10000016
+2024,2024,Sheerness,Sittingbourne and Sheppey,Swale,Kent,E05009560,E14001474,E07000113,E10000016
+2024,2024,Herne & Broomfield,Herne Bay and Sandwich,Canterbury,Kent,E05010398,E14001282,E07000106,E10000016
+2024,2024,Freckleton Village,Fylde,Fylde,Lancashire,E05014541,E14001242,E07000119,E10000017
+2024,2024,Allington & Bridge,Maidstone and Malling,Maidstone,Kent,E05015593,E14001349,E07000110,E10000016
+2024,2024,Heron,Herne Bay and Sandwich,Canterbury,Kent,E05010399,E14001282,E07000106,E10000016
+2024,2024,Snodland West & Holborough Lakes,Chatham and Aylesford,Tonbridge and Malling,Kent,E05015050,E14001157,E07000115,E10000016
+2024,2024,Sheppey Central,Sittingbourne and Sheppey,Swale,Kent,E05009561,E14001474,E07000113,E10000016
+2024,2024,Stanborough,Watford,Watford,Hertfordshire,E05011054,E14001568,E07000103,E10000015
+2024,2024,Edenbridge South and West,Tonbridge,Sevenoaks,Kent,E05005014,E14001549,E07000111,E10000016
+2024,2024,"Farningham, Horton Kirby and South Darenth",Sevenoaks,Sevenoaks,Kent,E05005016,E14001465,E07000111,E10000016
+2024,2024,Sheppey East,Sittingbourne and Sheppey,Swale,Kent,E05009562,E14001474,E07000113,E10000016
+2024,2024,Fawkham and West Kingsdown,Sevenoaks,Sevenoaks,Kent,E05005017,E14001465,E07000111,E10000016
+2024,2024,Teynham and Lynsted,Faversham and Mid Kent,Swale,Kent,E05009563,E14001235,E07000113,E10000016
+2024,2024,"Halstead, Knockholt and Badgers Mount",Sevenoaks,Sevenoaks,Kent,E05005018,E14001465,E07000111,E10000016
+2024,2024,The Meads,Sittingbourne and Sheppey,Swale,Kent,E05009564,E14001474,E07000113,E10000016
+2024,2024,Kemsing,Sevenoaks,Sevenoaks,Kent,E05005021,E14001465,E07000111,E10000016
+2024,2024,Watling,Faversham and Mid Kent,Swale,Kent,E05009565,E14001235,E07000113,E10000016
+2024,2024,West Downs,Faversham and Mid Kent,Swale,Kent,E05009566,E14001235,E07000113,E10000016
+2024,2024,Woodstock,Sittingbourne and Sheppey,Swale,Kent,E05009567,E14001474,E07000113,E10000016
+2024,2024,Beacon Road,East Thanet,Thanet,Kent,E05005081,E14001216,E07000114,E10000016
+2024,2024,Birchington North,Herne Bay and Sandwich,Thanet,Kent,E05005082,E14001282,E07000114,E10000016
+2024,2024,Birchington South,Herne Bay and Sandwich,Thanet,Kent,E05005083,E14001282,E07000114,E10000016
+2024,2024,Bradstowe,East Thanet,Thanet,Kent,E05005084,E14001216,E07000114,E10000016
+2024,2024,Central Harbour,East Thanet,Thanet,Kent,E05005085,E14001216,E07000114,E10000016
+2024,2024,Cliffsend and Pegwell,East Thanet,Thanet,Kent,E05005086,E14001216,E07000114,E10000016
+2024,2024,Cliftonville East,East Thanet,Thanet,Kent,E05005087,E14001216,E07000114,E10000016
+2024,2024,Cliftonville West,East Thanet,Thanet,Kent,E05005088,E14001216,E07000114,E10000016
+2024,2024,Dane Valley,East Thanet,Thanet,Kent,E05005089,E14001216,E07000114,E10000016
+2024,2024,Eastcliff,East Thanet,Thanet,Kent,E05005090,E14001216,E07000114,E10000016
+2024,2024,Garlinge,Herne Bay and Sandwich,Thanet,Kent,E05005091,E14001282,E07000114,E10000016
+2024,2024,Kingsgate,East Thanet,Thanet,Kent,E05005092,E14001216,E07000114,E10000016
+2024,2024,Margate Central,East Thanet,Thanet,Kent,E05005093,E14001216,E07000114,E10000016
+2024,2024,Nethercourt,East Thanet,Thanet,Kent,E05005094,E14001216,E07000114,E10000016
+2024,2024,Newington,East Thanet,Thanet,Kent,E05005095,E14001216,E07000114,E10000016
+2024,2024,Northwood,East Thanet,Thanet,Kent,E05005096,E14001216,E07000114,E10000016
+2024,2024,St Peters,East Thanet,Thanet,Kent,E05005097,E14001216,E07000114,E10000016
+2024,2024,Salmestone,East Thanet,Thanet,Kent,E05005098,E14001216,E07000114,E10000016
+2024,2024,Sir Moses Montefiore,East Thanet,Thanet,Kent,E05005099,E14001216,E07000114,E10000016
+2024,2024,Thanet Villages,Herne Bay and Sandwich,Thanet,Kent,E05005100,E14001282,E07000114,E10000016
+2024,2024,Viking,East Thanet,Thanet,Kent,E05005101,E14001216,E07000114,E10000016
+2024,2024,Westbrook,Herne Bay and Sandwich,Thanet,Kent,E05005102,E14001282,E07000114,E10000016
+2024,2024,Westgate-on-Sea,Herne Bay and Sandwich,Thanet,Kent,E05005103,E14001282,E07000114,E10000016
+2024,2024,Aylesford North & North Downs,Chatham and Aylesford,Tonbridge and Malling,Kent,E05015035,E14001157,E07000115,E10000016
+2024,2024,Aylesford North & North Downs,Maidstone and Malling,Tonbridge and Malling,Kent,E05015035,E14001349,E07000115,E10000016
+2024,2024,Aylesford South & Ditton,Maidstone and Malling,Tonbridge and Malling,Kent,E05015036,E14001349,E07000115,E10000016
+2024,2024,"Birling, Leybourne & Ryarsh",Maidstone and Malling,Tonbridge and Malling,Kent,E05015037,E14001349,E07000115,E10000016
+2024,2024,"Birling, Leybourne & Ryarsh",Tonbridge,Tonbridge and Malling,Kent,E05015037,E14001549,E07000115,E10000016
+2024,2024,Borough Green & Platt,Tonbridge,Tonbridge and Malling,Kent,E05015038,E14001549,E07000115,E10000016
+2024,2024,Bourne,Tonbridge,Tonbridge and Malling,Kent,E05015039,E14001549,E07000115,E10000016
+2024,2024,Cage Green & Angel,Tonbridge,Tonbridge and Malling,Kent,E05015040,E14001549,E07000115,E10000016
+2024,2024,"East and West Peckham, Mereworth & Wateringbury",Tonbridge,Tonbridge and Malling,Kent,E05015041,E14001549,E07000115,E10000016
+2024,2024,"East Malling, West Malling & Offham",Maidstone and Malling,Tonbridge and Malling,Kent,E05015042,E14001349,E07000115,E10000016
+2024,2024,"East Malling, West Malling & Offham",Tonbridge,Tonbridge and Malling,Kent,E05015042,E14001549,E07000115,E10000016
+2024,2024,Tudor,Watford,Watford,Hertfordshire,E05011055,E14001568,E07000103,E10000015
+2024,2024,Trench,Tonbridge,Tonbridge and Malling,Kent,E05015051,E14001549,E07000115,E10000016
+2024,2024,Barming Heath & Teston,Maidstone and Malling,Maidstone,Kent,E05015594,E14001349,E07000110,E10000016
+2024,2024,Heyhouses,Fylde,Fylde,Lancashire,E05014542,E14001242,E07000119,E10000017
+2024,2024,Northgate,Canterbury,Canterbury,Kent,E05010402,E14001151,E07000106,E10000016
+2024,2024,Higham,Tonbridge,Tonbridge and Malling,Kent,E05015043,E14001549,E07000115,E10000016
+2024,2024,Hildenborough,Tonbridge,Tonbridge and Malling,Kent,E05015044,E14001549,E07000115,E10000016
+2024,2024,Judd,Tonbridge,Tonbridge and Malling,Kent,E05015045,E14001549,E07000115,E10000016
+2024,2024,Kings Hill,Maidstone and Malling,Tonbridge and Malling,Kent,E05015046,E14001349,E07000115,E10000016
+2024,2024,Bearsted & Downswood,Faversham and Mid Kent,Maidstone,Kent,E05015595,E14001235,E07000110,E10000016
+2024,2024,Boughton Monchelsea & Chart Sutton,Faversham and Mid Kent,Maidstone,Kent,E05015596,E14001235,E07000110,E10000016
+2024,2024,Boughton Monchelsea & Chart Sutton,Weald of Kent,Maidstone,Kent,E05015596,E14001570,E07000110,E10000016
+2024,2024,Boxley Downs,Faversham and Mid Kent,Maidstone,Kent,E05015597,E14001235,E07000110,E10000016
+2024,2024,Coxheath & Farleigh,Weald of Kent,Maidstone,Kent,E05015598,E14001570,E07000110,E10000016
+2024,2024,Fant & Oakwood,Maidstone and Malling,Maidstone,Kent,E05015599,E14001349,E07000110,E10000016
+2024,2024,Grove Green & Vinters Park,Faversham and Mid Kent,Maidstone,Kent,E05015600,E14001235,E07000110,E10000016
+2024,2024,Grove Green & Vinters Park,Maidstone and Malling,Maidstone,Kent,E05015600,E14001349,E07000110,E10000016
+2024,2024,"Harrietsham, Lenham & North Downs",Faversham and Mid Kent,Maidstone,Kent,E05015601,E14001235,E07000110,E10000016
+2024,2024,Headcorn & Sutton Valence,Weald of Kent,Maidstone,Kent,E05015602,E14001570,E07000110,E10000016
+2024,2024,High Street,Maidstone and Malling,Maidstone,Kent,E05015603,E14001349,E07000110,E10000016
+2024,2024,Leeds & Langley,Faversham and Mid Kent,Maidstone,Kent,E05015604,E14001235,E07000110,E10000016
+2024,2024,Leeds & Langley,Weald of Kent,Maidstone,Kent,E05015604,E14001570,E07000110,E10000016
+2024,2024,Loose & Linton,Faversham and Mid Kent,Maidstone,Kent,E05015605,E14001235,E07000110,E10000016
+2024,2024,Loose & Linton,Maidstone and Malling,Maidstone,Kent,E05015605,E14001349,E07000110,E10000016
+2024,2024,Loose & Linton,Weald of Kent,Maidstone,Kent,E05015605,E14001570,E07000110,E10000016
+2024,2024,Marden & Yalding,Weald of Kent,Maidstone,Kent,E05015606,E14001570,E07000110,E10000016
+2024,2024,Palace Wood,Maidstone and Malling,Maidstone,Kent,E05015607,E14001349,E07000110,E10000016
+2024,2024,Park Wood & Mangravet,Faversham and Mid Kent,Maidstone,Kent,E05015608,E14001235,E07000110,E10000016
+2024,2024,Penenden Heath,Maidstone and Malling,Maidstone,Kent,E05015609,E14001349,E07000110,E10000016
+2024,2024,Seasalter,Canterbury,Canterbury,Kent,E05010404,E14001151,E07000106,E10000016
+2024,2024,Ringlestone,Maidstone and Malling,Maidstone,Kent,E05015610,E14001349,E07000110,E10000016
+2024,2024,St Stephen's,Canterbury,Canterbury,Kent,E05010405,E14001151,E07000106,E10000016
+2024,2024,Senacre,Faversham and Mid Kent,Maidstone,Kent,E05015611,E14001235,E07000110,E10000016
+2024,2024,Swalecliffe,Canterbury,Canterbury,Kent,E05010407,E14001151,E07000106,E10000016
+2024,2024,Vicarage,Watford,Watford,Hertfordshire,E05011056,E14001568,E07000103,E10000015
+2024,2024,Kilgrimol,Fylde,Fylde,Lancashire,E05014543,E14001242,E07000119,E10000017
+2024,2024,Shepway,Faversham and Mid Kent,Maidstone,Kent,E05015612,E14001235,E07000110,E10000016
+2024,2024,Vauxhall,Tonbridge,Tonbridge and Malling,Kent,E05015052,E14001549,E07000115,E10000016
+2024,2024,Tankerton,Canterbury,Canterbury,Kent,E05010408,E14001151,E07000106,E10000016
+2024,2024,Woodside,Watford,Watford,Hertfordshire,E05011057,E14001568,E07000103,E10000015
+2024,2024,Sevenoaks Eastern,Sevenoaks,Sevenoaks,Kent,E05005026,E14001465,E07000111,E10000016
+2024,2024,West Bay,Herne Bay and Sandwich,Canterbury,Kent,E05010409,E14001282,E07000106,E10000016
+2024,2024,Westgate,Canterbury,Canterbury,Kent,E05010410,E14001151,E07000106,E10000016
+2024,2024,Wincheap,Canterbury,Canterbury,Kent,E05010411,E14001151,E07000106,E10000016
+2024,2024,Little Stour & Adisham,Canterbury,Canterbury,Kent,E05012953,E14001151,E07000106,E10000016
+2024,2024,Nailbourne,Canterbury,Canterbury,Kent,E05012954,E14001151,E07000106,E10000016
+2024,2024,Reculver,Herne Bay and Sandwich,Canterbury,Kent,E05012955,E14001282,E07000106,E10000016
+2024,2024,Sturry,Herne Bay and Sandwich,Canterbury,Kent,E05012956,E14001282,E07000106,E10000016
+2024,2024,Barton,Canterbury,Canterbury,Kent,E05012990,E14001151,E07000106,E10000016
+2024,2024,Chartham & Stone Street,Canterbury,Canterbury,Kent,E05012991,E14001151,E07000106,E10000016
+2024,2024,Bean & Village Park,Dartford,Dartford,Kent,E05012392,E14001191,E07000107,E10000016
+2024,2024,Brent,Dartford,Dartford,Kent,E05012393,E14001191,E07000107,E10000016
+2024,2024,Bridge,Dartford,Dartford,Kent,E05012394,E14001191,E07000107,E10000016
+2024,2024,Burnham,Dartford,Dartford,Kent,E05012395,E14001191,E07000107,E10000016
+2024,2024,Darenth,Dartford,Dartford,Kent,E05012396,E14001191,E07000107,E10000016
+2024,2024,Greenhithe & Knockhall,Dartford,Dartford,Kent,E05012398,E14001191,E07000107,E10000016
+2024,2024,Heath,Dartford,Dartford,Kent,E05012399,E14001191,E07000107,E10000016
+2024,2024,Joyden's Wood,Dartford,Dartford,Kent,E05012400,E14001191,E07000107,E10000016
+2024,2024,"Longfield, New Barn & Southfleet",Dartford,Dartford,Kent,E05012401,E14001191,E07000107,E10000016
+2024,2024,Maypole & Leyton Cross,Dartford,Dartford,Kent,E05012402,E14001191,E07000107,E10000016
+2024,2024,Newtown,Dartford,Dartford,Kent,E05012403,E14001191,E07000107,E10000016
+2024,2024,Princes,Dartford,Dartford,Kent,E05012404,E14001191,E07000107,E10000016
+2024,2024,Stone Castle,Dartford,Dartford,Kent,E05012405,E14001191,E07000107,E10000016
+2024,2024,Stone House,Dartford,Dartford,Kent,E05012406,E14001191,E07000107,E10000016
+2024,2024,Temple Hill,Dartford,Dartford,Kent,E05012408,E14001191,E07000107,E10000016
+2024,2024,Town,Dartford,Dartford,Kent,E05012409,E14001191,E07000107,E10000016
+2024,2024,West Hill,Dartford,Dartford,Kent,E05012410,E14001191,E07000107,E10000016
+2024,2024,"Wilmington, Sutton-at-Hone & Hawley",Sevenoaks,Dartford,Kent,E05012411,E14001465,E07000107,E10000016
+2024,2024,Ebbsfleet,Dartford,Dartford,Kent,E05015466,E14001191,E07000107,E10000016
+2024,2024,Swanscombe,Dartford,Dartford,Kent,E05015467,E14001191,E07000107,E10000016
+2024,2024,Alkham & Capel-le-Ferne,Dover and Deal,Dover,Kent,E05012855,E14001202,E07000108,E10000016
+2024,2024,"Aylesham, Eythorne & Shepherdswell",Dover and Deal,Dover,Kent,E05012856,E14001202,E07000108,E10000016
+2024,2024,Buckland,Dover and Deal,Dover,Kent,E05012857,E14001202,E07000108,E10000016
+2024,2024,Dover Downs & River,Dover and Deal,Dover,Kent,E05012858,E14001202,E07000108,E10000016
+2024,2024,Eastry Rural,Dover and Deal,Dover,Kent,E05012859,E14001202,E07000108,E10000016
+2024,2024,"Guston, Kingsdown & St Margaret's-at-Cliffe",Dover and Deal,Dover,Kent,E05012860,E14001202,E07000108,E10000016
+2024,2024,Little Stour & Ashstone,Herne Bay and Sandwich,Dover,Kent,E05012861,E14001282,E07000108,E10000016
+2024,2024,Maxton & Elms Vale,Dover and Deal,Dover,Kent,E05012862,E14001202,E07000108,E10000016
+2024,2024,Middle Deal,Dover and Deal,Dover,Kent,E05012863,E14001202,E07000108,E10000016
+2024,2024,Mill Hill,Dover and Deal,Dover,Kent,E05012864,E14001202,E07000108,E10000016
+2024,2024,North Deal,Dover and Deal,Dover,Kent,E05012865,E14001202,E07000108,E10000016
+2024,2024,Staplehurst,Weald of Kent,Maidstone,Kent,E05015613,E14001570,E07000110,E10000016
+2024,2024,Walderslade,Chatham and Aylesford,Tonbridge and Malling,Kent,E05015053,E14001157,E07000115,E10000016
+2024,2024,Kilnhouse,Fylde,Fylde,Lancashire,E05014544,E14001242,E07000119,E10000017
+2024,2024,St Radigunds,Dover and Deal,Dover,Kent,E05012866,E14001202,E07000108,E10000016
+2024,2024,Tovil,Maidstone and Malling,Maidstone,Kent,E05015614,E14001349,E07000110,E10000016
+2024,2024,Cowden and Hever,Tonbridge,Sevenoaks,Kent,E05005010,E14001549,E07000111,E10000016
+2024,2024,Kirkham,Fylde,Fylde,Lancashire,E05014545,E14001242,E07000119,E10000017
+2024,2024,Lytham East,Fylde,Fylde,Lancashire,E05014546,E14001242,E07000119,E10000017
+2024,2024,Lytham West,Fylde,Fylde,Lancashire,E05014547,E14001242,E07000119,E10000017
+2024,2024,Medlar-with-Wesham,Fylde,Fylde,Lancashire,E05014548,E14001242,E07000119,E10000017
+2024,2024,Park,Fylde,Fylde,Lancashire,E05014549,E14001242,E07000119,E10000017
+2024,2024,Rural East Fylde,Fylde,Fylde,Lancashire,E05014550,E14001242,E07000119,E10000017
+2024,2024,Rural North Fylde,Fylde,Fylde,Lancashire,E05014551,E14001242,E07000119,E10000017
+2024,2024,Staining,Fylde,Fylde,Lancashire,E05014552,E14001242,E07000119,E10000017
+2024,2024,Warton,Fylde,Fylde,Lancashire,E05014553,E14001242,E07000119,E10000017
+2024,2024,Wrea Green with Westby,Fylde,Fylde,Lancashire,E05014554,E14001242,E07000119,E10000017
+2024,2024,Altham,Hyndburn,Hyndburn,Lancashire,E05005206,E14001299,E07000120,E10000017
+2024,2024,Barnfield,Hyndburn,Hyndburn,Lancashire,E05005207,E14001299,E07000120,E10000017
+2024,2024,Baxenden,Hyndburn,Hyndburn,Lancashire,E05005208,E14001299,E07000120,E10000017
+2024,2024,Central,Hyndburn,Hyndburn,Lancashire,E05005209,E14001299,E07000120,E10000017
+2024,2024,Church,Hyndburn,Hyndburn,Lancashire,E05005210,E14001299,E07000120,E10000017
+2024,2024,Clayton-le-Moors,Hyndburn,Hyndburn,Lancashire,E05005211,E14001299,E07000120,E10000017
+2024,2024,Huncoat,Hyndburn,Hyndburn,Lancashire,E05005212,E14001299,E07000120,E10000017
+2024,2024,Immanuel,Hyndburn,Hyndburn,Lancashire,E05005213,E14001299,E07000120,E10000017
+2024,2024,Milnshaw,Hyndburn,Hyndburn,Lancashire,E05005214,E14001299,E07000120,E10000017
+2024,2024,Netherton,Hyndburn,Hyndburn,Lancashire,E05005215,E14001299,E07000120,E10000017
+2024,2024,Overton,Hyndburn,Hyndburn,Lancashire,E05005216,E14001299,E07000120,E10000017
+2024,2024,Peel,Hyndburn,Hyndburn,Lancashire,E05005217,E14001299,E07000120,E10000017
+2024,2024,Rishton,Hyndburn,Hyndburn,Lancashire,E05005218,E14001299,E07000120,E10000017
+2024,2024,St Andrew's,Hyndburn,Hyndburn,Lancashire,E05005219,E14001299,E07000120,E10000017
+2024,2024,St Oswald's,Hyndburn,Hyndburn,Lancashire,E05005220,E14001299,E07000120,E10000017
+2024,2024,Spring Hill,Hyndburn,Hyndburn,Lancashire,E05005221,E14001299,E07000120,E10000017
+2024,2024,Bare,Morecambe and Lunesdale,Lancaster,Lancashire,E05014885,E14001372,E07000121,E10000017
+2024,2024,Bolton & Slyne,Morecambe and Lunesdale,Lancaster,Lancashire,E05014886,E14001372,E07000121,E10000017
+2024,2024,Bowerham,Lancaster and Wyre,Lancaster,Lancashire,E05014887,E14001318,E07000121,E10000017
+2024,2024,Bulk,Lancaster and Wyre,Lancaster,Lancashire,E05014888,E14001318,E07000121,E10000017
+2024,2024,Carnforth & Millhead,Morecambe and Lunesdale,Lancaster,Lancashire,E05014889,E14001372,E07000121,E10000017
+2024,2024,Castle,Lancaster and Wyre,Lancaster,Lancashire,E05014890,E14001318,E07000121,E10000017
+2024,2024,Ellel,Lancaster and Wyre,Lancaster,Lancashire,E05014891,E14001318,E07000121,E10000017
+2024,2024,Halton-with-Aughton & Kellet,Morecambe and Lunesdale,Lancaster,Lancashire,E05014892,E14001372,E07000121,E10000017
+2024,2024,Heysham Central,Morecambe and Lunesdale,Lancaster,Lancashire,E05014893,E14001372,E07000121,E10000017
+2024,2024,Heysham North,Morecambe and Lunesdale,Lancaster,Lancashire,E05014894,E14001372,E07000121,E10000017
+2024,2024,Heysham South,Morecambe and Lunesdale,Lancaster,Lancashire,E05014895,E14001372,E07000121,E10000017
+2024,2024,John O'Gaunt,Lancaster and Wyre,Lancaster,Lancashire,E05014896,E14001318,E07000121,E10000017
+2024,2024,Lower Lune Valley,Morecambe and Lunesdale,Lancaster,Lancashire,E05014897,E14001372,E07000121,E10000017
+2024,2024,Marsh,Lancaster and Wyre,Lancaster,Lancashire,E05014898,E14001318,E07000121,E10000017
+2024,2024,Overton,Morecambe and Lunesdale,Lancaster,Lancashire,E05014899,E14001372,E07000121,E10000017
+2024,2024,Poulton,Morecambe and Lunesdale,Lancaster,Lancashire,E05014900,E14001372,E07000121,E10000017
+2024,2024,Aylesford & East Stour,Ashford,Ashford,Kent,E05011743,E14001069,E07000105,E10000016
+2024,2024,"Cranbrook, Sissinghurst & Frittenden",Weald of Kent,Tunbridge Wells,Kent,E05015803,E14001570,E07000116,E10000016
+2024,2024,Sevenoaks Kippington,Sevenoaks,Sevenoaks,Kent,E05005027,E14001465,E07000111,E10000016
+2024,2024,Sevenoaks Northern,Sevenoaks,Sevenoaks,Kent,E05005028,E14001465,E07000111,E10000016
+2024,2024,Sevenoaks Town and St John's,Sevenoaks,Sevenoaks,Kent,E05005029,E14001465,E07000111,E10000016
+2024,2024,Swanley St Mary's,Sevenoaks,Sevenoaks,Kent,E05005031,E14001465,E07000111,E10000016
+2024,2024,Swanley White Oak,Sevenoaks,Sevenoaks,Kent,E05005032,E14001465,E07000111,E10000016
+2024,2024,Ash and New Ash Green,Tonbridge,Sevenoaks,Kent,E05009956,E14001549,E07000111,E10000016
+2024,2024,Eynsford,Sevenoaks,Sevenoaks,Kent,E05009958,E14001465,E07000111,E10000016
+2024,2024,Hartley and Hodsoll Street,Tonbridge,Sevenoaks,Kent,E05009959,E14001549,E07000111,E10000016
+2024,2024,Hextable,Sevenoaks,Sevenoaks,Kent,E05009960,E14001465,E07000111,E10000016
+2024,2024,Leigh and Chiddingstone Causeway,Tonbridge,Sevenoaks,Kent,E05009961,E14001549,E07000111,E10000016
+2024,2024,Otford and Shoreham,Sevenoaks,Sevenoaks,Kent,E05009962,E14001465,E07000111,E10000016
+2024,2024,"Penshurst, Fordcombe and Chiddingstone",Tonbridge,Sevenoaks,Kent,E05009963,E14001549,E07000111,E10000016
+2024,2024,Swanley Christchurch and Swanley Village,Sevenoaks,Sevenoaks,Kent,E05009964,E14001465,E07000111,E10000016
+2024,2024,Westerham and Crockham Hill,Sevenoaks,Sevenoaks,Kent,E05009965,E14001465,E07000111,E10000016
+2024,2024,"Brasted, Chevening and Sundridge",Sevenoaks,Sevenoaks,Kent,E05011558,E14001465,E07000111,E10000016
+2024,2024,Seal and Weald,Sevenoaks,Sevenoaks,Kent,E05011559,E14001465,E07000111,E10000016
+2024,2024,Broadmead,Folkestone and Hythe,Folkestone and Hythe,Kent,E05010015,E14001239,E07000112,E10000016
+2024,2024,Cheriton,Folkestone and Hythe,Folkestone and Hythe,Kent,E05010016,E14001239,E07000112,E10000016
+2024,2024,East Folkestone,Folkestone and Hythe,Folkestone and Hythe,Kent,E05010017,E14001239,E07000112,E10000016
+2024,2024,Folkestone Central,Folkestone and Hythe,Folkestone and Hythe,Kent,E05010018,E14001239,E07000112,E10000016
+2024,2024,Folkestone Harbour,Folkestone and Hythe,Folkestone and Hythe,Kent,E05010019,E14001239,E07000112,E10000016
+2024,2024,Hythe,Folkestone and Hythe,Folkestone and Hythe,Kent,E05010020,E14001239,E07000112,E10000016
+2024,2024,Hythe Rural,Folkestone and Hythe,Folkestone and Hythe,Kent,E05010021,E14001239,E07000112,E10000016
+2024,2024,New Romney,Folkestone and Hythe,Folkestone and Hythe,Kent,E05010022,E14001239,E07000112,E10000016
+2024,2024,North Downs East,Ashford,Folkestone and Hythe,Kent,E05010023,E14001069,E07000112,E10000016
+2024,2024,North Downs West,Ashford,Folkestone and Hythe,Kent,E05010024,E14001069,E07000112,E10000016
+2024,2024,Romney Marsh,Folkestone and Hythe,Folkestone and Hythe,Kent,E05010025,E14001239,E07000112,E10000016
+2024,2024,Sandgate & West Folkestone,Folkestone and Hythe,Folkestone and Hythe,Kent,E05010026,E14001239,E07000112,E10000016
+2024,2024,Walland & Denge Marsh,Folkestone and Hythe,Folkestone and Hythe,Kent,E05010027,E14001239,E07000112,E10000016
+2024,2024,Abbey,Faversham and Mid Kent,Swale,Kent,E05009544,E14001235,E07000113,E10000016
+2024,2024,"Bobbing, Iwade and Lower Halstow",Sittingbourne and Sheppey,Swale,Kent,E05009545,E14001474,E07000113,E10000016
+2024,2024,Borden and Grove Park,Sittingbourne and Sheppey,Swale,Kent,E05009546,E14001474,E07000113,E10000016
+2024,2024,Boughton and Courtenay,Faversham and Mid Kent,Swale,Kent,E05009547,E14001235,E07000113,E10000016
+2024,2024,Chalkwell,Sittingbourne and Sheppey,Swale,Kent,E05009548,E14001474,E07000113,E10000016
+2024,2024,East Downs,Faversham and Mid Kent,Swale,Kent,E05009549,E14001235,E07000113,E10000016
+2024,2024,"Hartlip, Newington and Upchurch",Sittingbourne and Sheppey,Swale,Kent,E05009550,E14001474,E07000113,E10000016
+2024,2024,Homewood,Sittingbourne and Sheppey,Swale,Kent,E05009551,E14001474,E07000113,E10000016
+2024,2024,Kemsley,Sittingbourne and Sheppey,Swale,Kent,E05009552,E14001474,E07000113,E10000016
+2024,2024,Milton Regis,Sittingbourne and Sheppey,Swale,Kent,E05009553,E14001474,E07000113,E10000016
+2024,2024,Minster Cliffs,Sittingbourne and Sheppey,Swale,Kent,E05009554,E14001474,E07000113,E10000016
+2024,2024,Murston,Sittingbourne and Sheppey,Swale,Kent,E05009555,E14001474,E07000113,E10000016
+2024,2024,Culverden,Tunbridge Wells,Tunbridge Wells,Kent,E05015804,E14001555,E07000116,E10000016
+2024,2024,Rural Tunbridge Wells,Tunbridge Wells,Tunbridge Wells,Kent,E05015805,E14001555,E07000116,E10000016
+2024,2024,"Hawkhurst, Sandhurst & Benenden",Tunbridge Wells,Tunbridge Wells,Kent,E05015806,E14001555,E07000116,E10000016
+2024,2024,"Hawkhurst, Sandhurst & Benenden",Weald of Kent,Tunbridge Wells,Kent,E05015806,E14001570,E07000116,E10000016
+2024,2024,High Brooms,Tunbridge Wells,Tunbridge Wells,Kent,E05015807,E14001555,E07000116,E10000016
+2024,2024,Paddock Wood,Tunbridge Wells,Tunbridge Wells,Kent,E05015808,E14001555,E07000116,E10000016
+2024,2024,Pantiles,Tunbridge Wells,Tunbridge Wells,Kent,E05015809,E14001555,E07000116,E10000016
+2024,2024,Park,Tunbridge Wells,Tunbridge Wells,Kent,E05015810,E14001555,E07000116,E10000016
+2024,2024,Pembury & Capel,Tunbridge Wells,Tunbridge Wells,Kent,E05015811,E14001555,E07000116,E10000016
+2024,2024,Rusthall & Speldhurst,Tunbridge Wells,Tunbridge Wells,Kent,E05015812,E14001555,E07000116,E10000016
+2024,2024,Sherwood,Tunbridge Wells,Tunbridge Wells,Kent,E05015813,E14001555,E07000116,E10000016
+2024,2024,Southborough & Bidborough,Tunbridge Wells,Tunbridge Wells,Kent,E05015814,E14001555,E07000116,E10000016
+2024,2024,St James',Tunbridge Wells,Tunbridge Wells,Kent,E05015815,E14001555,E07000116,E10000016
+2024,2024,St John's,Tunbridge Wells,Tunbridge Wells,Kent,E05015816,E14001555,E07000116,E10000016
+2024,2024,Bank Hall,Burnley,Burnley,Lancashire,E05005150,E14001142,E07000117,E10000017
+2024,2024,Briercliffe,Burnley,Burnley,Lancashire,E05005151,E14001142,E07000117,E10000017
+2024,2024,Brunshaw,Burnley,Burnley,Lancashire,E05005152,E14001142,E07000117,E10000017
+2024,2024,Cliviger with Worsthorne,Burnley,Burnley,Lancashire,E05005153,E14001142,E07000117,E10000017
+2024,2024,Coal Clough with Deerplay,Burnley,Burnley,Lancashire,E05005154,E14001142,E07000117,E10000017
+2024,2024,Daneshouse with Stoneyholme,Burnley,Burnley,Lancashire,E05005155,E14001142,E07000117,E10000017
+2024,2024,Gannow,Burnley,Burnley,Lancashire,E05005156,E14001142,E07000117,E10000017
+2024,2024,Gawthorpe,Burnley,Burnley,Lancashire,E05005157,E14001142,E07000117,E10000017
+2024,2024,Hapton with Park,Burnley,Burnley,Lancashire,E05005158,E14001142,E07000117,E10000017
+2024,2024,Lanehead,Burnley,Burnley,Lancashire,E05005159,E14001142,E07000117,E10000017
+2024,2024,Queensgate,Burnley,Burnley,Lancashire,E05005160,E14001142,E07000117,E10000017
+2024,2024,Rosegrove with Lowerhouse,Burnley,Burnley,Lancashire,E05005161,E14001142,E07000117,E10000017
+2024,2024,Rosehill with Burnley Wood,Burnley,Burnley,Lancashire,E05005162,E14001142,E07000117,E10000017
+2024,2024,Trinity,Burnley,Burnley,Lancashire,E05005163,E14001142,E07000117,E10000017
+2024,2024,Whittlefield with Ightenhill,Burnley,Burnley,Lancashire,E05005164,E14001142,E07000117,E10000017
+2024,2024,Adlington & Anderton,Chorley,Chorley,Lancashire,E05013064,E14001170,E07000118,E10000017
+2024,2024,Buckshaw & Whittle,Chorley,Chorley,Lancashire,E05013065,E14001170,E07000118,E10000017
+2024,2024,Chorley East,Chorley,Chorley,Lancashire,E05013066,E14001170,E07000118,E10000017
+2024,2024,Chorley North East,Chorley,Chorley,Lancashire,E05013067,E14001170,E07000118,E10000017
+2024,2024,Chorley North West,Chorley,Chorley,Lancashire,E05013068,E14001170,E07000118,E10000017
+2024,2024,Chorley North & Astley,Chorley,Chorley,Lancashire,E05013069,E14001170,E07000118,E10000017
+2024,2024,Chorley South East & Heath Charnock,Chorley,Chorley,Lancashire,E05013070,E14001170,E07000118,E10000017
+2024,2024,Chorley South West,Chorley,Chorley,Lancashire,E05013071,E14001170,E07000118,E10000017
+2024,2024,"Clayton East, Brindle & Hoghton",Chorley,Chorley,Lancashire,E05013072,E14001170,E07000118,E10000017
+2024,2024,Clayton West & Cuerden,Chorley,Chorley,Lancashire,E05013073,E14001170,E07000118,E10000017
+2024,2024,Coppull,Chorley,Chorley,Lancashire,E05013074,E14001170,E07000118,E10000017
+2024,2024,"Croston, Mawdesley & Euxton South",South Ribble,Chorley,Lancashire,E05013075,E14001491,E07000118,E10000017
+2024,2024,"Eccleston, Heskin & Charnock Richard",South Ribble,Chorley,Lancashire,E05013076,E14001491,E07000118,E10000017
+2024,2024,Beaver,Ashford,Ashford,Kent,E05011744,E14001069,E07000105,E10000016
+2024,2024,Biddenden,Weald of Kent,Ashford,Kent,E05011745,E14001570,E07000105,E10000016
+2024,2024,Bircholt,Ashford,Ashford,Kent,E05011746,E14001069,E07000105,E10000016
+2024,2024,Bockhanger,Ashford,Ashford,Kent,E05011747,E14001069,E07000105,E10000016
+2024,2024,Bybrook,Ashford,Ashford,Kent,E05011748,E14001069,E07000105,E10000016
+2024,2024,Charing,Weald of Kent,Ashford,Kent,E05011749,E14001570,E07000105,E10000016
+2024,2024,Conningbrook & Little Burton Farm,Ashford,Ashford,Kent,E05011750,E14001069,E07000105,E10000016
+2024,2024,Downs North,Weald of Kent,Ashford,Kent,E05011751,E14001570,E07000105,E10000016
+2024,2024,Furley,Ashford,Ashford,Kent,E05011753,E14001069,E07000105,E10000016
+2024,2024,Godinton,Ashford,Ashford,Kent,E05011755,E14001069,E07000105,E10000016
+2024,2024,Highfield,Ashford,Ashford,Kent,E05011756,E14001069,E07000105,E10000016
+2024,2024,Isle of Oxney,Weald of Kent,Ashford,Kent,E05011757,E14001570,E07000105,E10000016
+2024,2024,Kennington,Ashford,Ashford,Kent,E05011758,E14001069,E07000105,E10000016
+2024,2024,Kingsnorth Village & Bridgefield,Weald of Kent,Ashford,Kent,E05011759,E14001570,E07000105,E10000016
+2024,2024,"Mersham, Sevington South with Finberry",Ashford,Ashford,Kent,E05011760,E14001069,E07000105,E10000016
+2024,2024,Norman,Ashford,Ashford,Kent,E05011761,E14001069,E07000105,E10000016
+2024,2024,Park Farm North,Ashford,Ashford,Kent,E05011762,E14001069,E07000105,E10000016
+2024,2024,Park Farm South,Ashford,Ashford,Kent,E05011763,E14001069,E07000105,E10000016
+2024,2024,Repton,Ashford,Ashford,Kent,E05011764,E14001069,E07000105,E10000016
+2024,2024,Rolvenden & Tenterden West,Weald of Kent,Ashford,Kent,E05011765,E14001570,E07000105,E10000016
+2024,2024,Roman,Ashford,Ashford,Kent,E05011766,E14001069,E07000105,E10000016
+2024,2024,Saxon Shore,Weald of Kent,Ashford,Kent,E05011767,E14001570,E07000105,E10000016
+2024,2024,Singleton East,Ashford,Ashford,Kent,E05011768,E14001069,E07000105,E10000016
+2024,2024,Singleton West,Ashford,Ashford,Kent,E05011769,E14001069,E07000105,E10000016
+2024,2024,Stanhope,Ashford,Ashford,Kent,E05011770,E14001069,E07000105,E10000016
+2024,2024,Tenterden North,Weald of Kent,Ashford,Kent,E05011771,E14001570,E07000105,E10000016
+2024,2024,Tenterden South,Weald of Kent,Ashford,Kent,E05011772,E14001570,E07000105,E10000016
+2024,2024,Tenterden St Michael's,Weald of Kent,Ashford,Kent,E05011773,E14001570,E07000105,E10000016
+2024,2024,Upper Weald,Weald of Kent,Ashford,Kent,E05011774,E14001570,E07000105,E10000016
+2024,2024,Victoria,Ashford,Ashford,Kent,E05011775,E14001069,E07000105,E10000016
+2024,2024,Washford,Ashford,Ashford,Kent,E05011776,E14001069,E07000105,E10000016
+2024,2024,Weald Central,Weald of Kent,Ashford,Kent,E05011777,E14001570,E07000105,E10000016
+2024,2024,Weald North,Weald of Kent,Ashford,Kent,E05011778,E14001570,E07000105,E10000016
+2024,2024,Weald South,Weald of Kent,Ashford,Kent,E05011779,E14001570,E07000105,E10000016
+2024,2024,Willesborough,Ashford,Ashford,Kent,E05011780,E14001069,E07000105,E10000016
+2024,2024,Wye with Hinxhill,Ashford,Ashford,Kent,E05011781,E14001069,E07000105,E10000016
+2024,2024,Downs West,Weald of Kent,Ashford,Kent,E05015478,E14001570,E07000105,E10000016
+2024,2024,Goat Lees,Ashford,Ashford,Kent,E05015479,E14001069,E07000105,E10000016
+2024,2024,Goat Lees,Weald of Kent,Ashford,Kent,E05015479,E14001570,E07000105,E10000016
+2024,2024,Beltinge,Herne Bay and Sandwich,Canterbury,Kent,E05010392,E14001282,E07000106,E10000016
+2024,2024,Blean Forest,Canterbury,Canterbury,Kent,E05010393,E14001151,E07000106,E10000016
+2024,2024,Chestfield,Canterbury,Canterbury,Kent,E05010395,E14001151,E07000106,E10000016
+2024,2024,Walton-le-Dale East,Ribble Valley,South Ribble,Lancashire,E05010235,E14001443,E07000126,E10000017
+2024,2024,Walton-le-Dale West,Ribble Valley,South Ribble,Lancashire,E05010236,E14001443,E07000126,E10000017
+2024,2024,Aughton & Holborn,West Lancashire,West Lancashire,Lancashire,E05014929,E14001577,E07000127,E10000017
+2024,2024,Burscough Bridge & Rufford,Southport,West Lancashire,Lancashire,E05014930,E14001504,E07000127,E10000017
+2024,2024,Burscough Bridge & Rufford,West Lancashire,West Lancashire,Lancashire,E05014930,E14001577,E07000127,E10000017
+2024,2024,Burscough Town,West Lancashire,West Lancashire,Lancashire,E05014931,E14001577,E07000127,E10000017
+2024,2024,North Meols & Hesketh Bank,Southport,West Lancashire,Lancashire,E05014932,E14001504,E07000127,E10000017
+2024,2024,Old Skelmersdale,West Lancashire,West Lancashire,Lancashire,E05014933,E14001577,E07000127,E10000017
+2024,2024,Ormskirk East,West Lancashire,West Lancashire,Lancashire,E05014934,E14001577,E07000127,E10000017
+2024,2024,Ormskirk West,West Lancashire,West Lancashire,Lancashire,E05014935,E14001577,E07000127,E10000017
+2024,2024,Rural North East,West Lancashire,West Lancashire,Lancashire,E05014936,E14001577,E07000127,E10000017
+2024,2024,Rural South,West Lancashire,West Lancashire,Lancashire,E05014937,E14001577,E07000127,E10000017
+2024,2024,Rural West,West Lancashire,West Lancashire,Lancashire,E05014938,E14001577,E07000127,E10000017
+2024,2024,Skelmersdale North,West Lancashire,West Lancashire,Lancashire,E05014939,E14001577,E07000127,E10000017
+2024,2024,Skelmersdale South,West Lancashire,West Lancashire,Lancashire,E05014940,E14001577,E07000127,E10000017
+2024,2024,Tanhouse & Skelmersdale Town Centre,West Lancashire,West Lancashire,Lancashire,E05014941,E14001577,E07000127,E10000017
+2024,2024,Tarleton Village,Southport,West Lancashire,Lancashire,E05014942,E14001504,E07000127,E10000017
+2024,2024,Up Holland,West Lancashire,West Lancashire,Lancashire,E05014943,E14001577,E07000127,E10000017
+2024,2024,Fosse Stoney Cove,South Leicestershire,Blaby,Leicestershire,E05015268,E14001488,E07000129,E10000018
+2024,2024,Market Harborough-Welland,"Harborough, Oadby and Wigston",Harborough,Leicestershire,E05011978,E14001266,E07000131,E10000018
+2024,2024,Bourne,Blackpool North and Fleetwood,Wyre,Lancashire,E05009932,E14001104,E07000128,E10000017
+2024,2024,Breck,Fylde,Wyre,Lancashire,E05009933,E14001242,E07000128,E10000017
+2024,2024,Brock with Catterall,Lancaster and Wyre,Wyre,Lancashire,E05009934,E14001318,E07000128,E10000017
+2024,2024,Calder,Lancaster and Wyre,Wyre,Lancashire,E05009935,E14001318,E07000128,E10000017
+2024,2024,Carleton,Blackpool North and Fleetwood,Wyre,Lancashire,E05009936,E14001104,E07000128,E10000017
+2024,2024,Cleveleys Park,Blackpool North and Fleetwood,Wyre,Lancashire,E05009937,E14001104,E07000128,E10000017
+2024,2024,Garstang,Lancaster and Wyre,Wyre,Lancashire,E05009938,E14001318,E07000128,E10000017
+2024,2024,Great Eccleston,Lancaster and Wyre,Wyre,Lancashire,E05009939,E14001318,E07000128,E10000017
+2024,2024,Hambleton & Stalmine,Lancaster and Wyre,Wyre,Lancashire,E05009940,E14001318,E07000128,E10000017
+2024,2024,Hardhorn with High Cross,Fylde,Wyre,Lancashire,E05009941,E14001242,E07000128,E10000017
+2024,2024,Jubilee,Blackpool North and Fleetwood,Wyre,Lancashire,E05009942,E14001104,E07000128,E10000017
+2024,2024,Marsh Mill,Blackpool North and Fleetwood,Wyre,Lancashire,E05009943,E14001104,E07000128,E10000017
+2024,2024,Mount,Blackpool North and Fleetwood,Wyre,Lancashire,E05009944,E14001104,E07000128,E10000017
+2024,2024,Park,Blackpool North and Fleetwood,Wyre,Lancashire,E05009945,E14001104,E07000128,E10000017
+2024,2024,Pharos,Blackpool North and Fleetwood,Wyre,Lancashire,E05009946,E14001104,E07000128,E10000017
+2024,2024,Pheasant's Wood,Blackpool North and Fleetwood,Wyre,Lancashire,E05009947,E14001104,E07000128,E10000017
+2024,2024,Pilling,Lancaster and Wyre,Wyre,Lancashire,E05009948,E14001318,E07000128,E10000017
+2024,2024,Preesall,Lancaster and Wyre,Wyre,Lancashire,E05009949,E14001318,E07000128,E10000017
+2024,2024,Rossall,Blackpool North and Fleetwood,Wyre,Lancashire,E05009950,E14001104,E07000128,E10000017
+2024,2024,Stanah,Blackpool North and Fleetwood,Wyre,Lancashire,E05009951,E14001104,E07000128,E10000017
+2024,2024,Tithebarn,Fylde,Wyre,Lancashire,E05009952,E14001242,E07000128,E10000017
+2024,2024,Victoria & Norcross,Blackpool North and Fleetwood,Wyre,Lancashire,E05009953,E14001104,E07000128,E10000017
+2024,2024,Warren,Blackpool North and Fleetwood,Wyre,Lancashire,E05009954,E14001104,E07000128,E10000017
+2024,2024,Wyresdale,Lancaster and Wyre,Wyre,Lancashire,E05009955,E14001318,E07000128,E10000017
+2024,2024,Blaby,South Leicestershire,Blaby,Leicestershire,E05015260,E14001488,E07000129,E10000018
+2024,2024,Braunstone Millfield,Mid Leicestershire,Blaby,Leicestershire,E05015261,E14001364,E07000129,E10000018
+2024,2024,Braunstone Ravenhurst,Mid Leicestershire,Blaby,Leicestershire,E05015262,E14001364,E07000129,E10000018
+2024,2024,Cosby & South Whetstone,South Leicestershire,Blaby,Leicestershire,E05015263,E14001488,E07000129,E10000018
+2024,2024,Countesthorpe,South Leicestershire,Blaby,Leicestershire,E05015264,E14001488,E07000129,E10000018
+2024,2024,Enderby,South Leicestershire,Blaby,Leicestershire,E05015265,E14001488,E07000129,E10000018
+2024,2024,Fosse Highcross,South Leicestershire,Blaby,Leicestershire,E05015266,E14001488,E07000129,E10000018
+2024,2024,Fosse Normanton,South Leicestershire,Blaby,Leicestershire,E05015267,E14001488,E07000129,E10000018
+2024,2024,Castle Rock,North West Leicestershire,North West Leicestershire,Leicestershire,E05010103,E14001404,E07000134,E10000018
+2024,2024,Billinghay Rural,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014427,E14001476,E07000139,E10000019
+2024,2024,Scale Hall,Lancaster and Wyre,Lancaster,Lancashire,E05014901,E14001318,E07000121,E10000017
+2024,2024,Edisford & Low Moor,Pendle and Clitheroe,Ribble Valley,Lancashire,E05012010,E14001422,E07000124,E10000017
+2024,2024,Alford,Louth and Horncastle,East Lindsey,Lincolnshire,E05009873,E14001343,E07000137,E10000019
+2024,2024,Bracebridge Heath,Lincoln,North Kesteven,Lincolnshire,E05014428,E14001336,E07000139,E10000019
+2024,2024,Branston,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014429,E14001476,E07000139,E10000019
+2024,2024,"Cranwell, Leasingham & Wilsford",Grantham and Bourne,North Kesteven,Lincolnshire,E05014430,E14001253,E07000139,E10000019
+2024,2024,"Cranwell, Leasingham & Wilsford",Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014430,E14001476,E07000139,E10000019
+2024,2024,Heckington Rural,Grantham and Bourne,North Kesteven,Lincolnshire,E05014431,E14001253,E07000139,E10000019
+2024,2024,Heighington & Washingborough,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014432,E14001476,E07000139,E10000019
+2024,2024,Helpringham & Osbournby,Grantham and Bourne,North Kesteven,Lincolnshire,E05014433,E14001253,E07000139,E10000019
+2024,2024,Hykeham Central,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014434,E14001476,E07000139,E10000019
+2024,2024,Hykeham Fosse,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014435,E14001476,E07000139,E10000019
+2024,2024,Hykeham Memorial,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014436,E14001476,E07000139,E10000019
+2024,2024,Kirkby la Thorpe & South Kyme,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014437,E14001476,E07000139,E10000019
+2024,2024,Metheringham Rural,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014438,E14001476,E07000139,E10000019
+2024,2024,Navenby & Brant Broughton,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014439,E14001476,E07000139,E10000019
+2024,2024,Ruskington,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014440,E14001476,E07000139,E10000019
+2024,2024,Skellingthorpe & Eagle,Lincoln,North Kesteven,Lincolnshire,E05014441,E14001336,E07000139,E10000019
+2024,2024,Skellingthorpe & Eagle,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014441,E14001476,E07000139,E10000019
+2024,2024,Sleaford Castle,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014442,E14001476,E07000139,E10000019
+2024,2024,Sleaford Holdingham,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014443,E14001476,E07000139,E10000019
+2024,2024,Sleaford Navigation,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014444,E14001476,E07000139,E10000019
+2024,2024,Sleaford Quarrington & Mareham,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014445,E14001476,E07000139,E10000019
+2024,2024,Sleaford Westholme,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014446,E14001476,E07000139,E10000019
+2024,2024,Waddington Rural,Lincoln,North Kesteven,Lincolnshire,E05014447,E14001336,E07000139,E10000019
+2024,2024,Waddington Rural,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014447,E14001476,E07000139,E10000019
+2024,2024,Witham St Hughs & Swinderby,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014448,E14001476,E07000139,E10000019
+2024,2024,Crowland and Deeping St Nicholas,South Holland and the Deepings,South Holland,Lincolnshire,E05005644,E14001487,E07000140,E10000019
+2024,2024,"Donington, Quadring and Gosberton",South Holland and the Deepings,South Holland,Lincolnshire,E05005645,E14001487,E07000140,E10000019
+2024,2024,Fleet,South Holland and the Deepings,South Holland,Lincolnshire,E05005646,E14001487,E07000140,E10000019
+2024,2024,Gedney,South Holland and the Deepings,South Holland,Lincolnshire,E05005647,E14001487,E07000140,E10000019
+2024,2024,Holbeach Hurn,South Holland and the Deepings,South Holland,Lincolnshire,E05005648,E14001487,E07000140,E10000019
+2024,2024,Holbeach Town,South Holland and the Deepings,South Holland,Lincolnshire,E05005649,E14001487,E07000140,E10000019
+2024,2024,Long Sutton,South Holland and the Deepings,South Holland,Lincolnshire,E05005650,E14001487,E07000140,E10000019
+2024,2024,"Moulton, Weston and Cowbit",South Holland and the Deepings,South Holland,Lincolnshire,E05005651,E14001487,E07000140,E10000019
+2024,2024,Pinchbeck and Surfleet,South Holland and the Deepings,South Holland,Lincolnshire,E05005652,E14001487,E07000140,E10000019
+2024,2024,Scotforth East,Lancaster and Wyre,Lancaster,Lancashire,E05014902,E14001318,E07000121,E10000017
+2024,2024,Misterton,South Leicestershire,Harborough,Leicestershire,E05011979,E14001488,E07000131,E10000018
+2024,2024,Glen Parva,South Leicestershire,Blaby,Leicestershire,E05015269,E14001488,E07000129,E10000018
+2024,2024,Coalville East,North West Leicestershire,North West Leicestershire,Leicestershire,E05010104,E14001404,E07000134,E10000018
+2024,2024,Gisburn & Rimington,Ribble Valley,Ribble Valley,Lancashire,E05012011,E14001443,E07000124,E10000017
+2024,2024,Binbrook,Louth and Horncastle,East Lindsey,Lincolnshire,E05009874,E14001343,E07000137,E10000019
+2024,2024,Spalding Castle,South Holland and the Deepings,South Holland,Lincolnshire,E05005653,E14001487,E07000140,E10000019
+2024,2024,Spalding Monks House,South Holland and the Deepings,South Holland,Lincolnshire,E05005654,E14001487,E07000140,E10000019
+2024,2024,Spalding St John's,South Holland and the Deepings,South Holland,Lincolnshire,E05005655,E14001487,E07000140,E10000019
+2024,2024,Spalding St Mary's,South Holland and the Deepings,South Holland,Lincolnshire,E05005656,E14001487,E07000140,E10000019
+2024,2024,Spalding St Paul's,South Holland and the Deepings,South Holland,Lincolnshire,E05005657,E14001487,E07000140,E10000019
+2024,2024,Spalding Wygate,South Holland and the Deepings,South Holland,Lincolnshire,E05005658,E14001487,E07000140,E10000019
+2024,2024,Sutton Bridge,South Holland and the Deepings,South Holland,Lincolnshire,E05005659,E14001487,E07000140,E10000019
+2024,2024,The Saints,South Holland and the Deepings,South Holland,Lincolnshire,E05005660,E14001487,E07000140,E10000019
+2024,2024,Whaplode and Holbeach St John's,South Holland and the Deepings,South Holland,Lincolnshire,E05005661,E14001487,E07000140,E10000019
+2024,2024,Aveland,Grantham and Bourne,South Kesteven,Lincolnshire,E05010148,E14001253,E07000141,E10000019
+2024,2024,Belmont,Grantham and Bourne,South Kesteven,Lincolnshire,E05010149,E14001253,E07000141,E10000019
+2024,2024,Belvoir,Grantham and Bourne,South Kesteven,Lincolnshire,E05010150,E14001253,E07000141,E10000019
+2024,2024,Bourne Austerby,Grantham and Bourne,South Kesteven,Lincolnshire,E05010151,E14001253,E07000141,E10000019
+2024,2024,Bourne East,Grantham and Bourne,South Kesteven,Lincolnshire,E05010152,E14001253,E07000141,E10000019
+2024,2024,Bourne West,Grantham and Bourne,South Kesteven,Lincolnshire,E05010153,E14001253,E07000141,E10000019
+2024,2024,Casewick,Rutland and Stamford,South Kesteven,Lincolnshire,E05010154,E14001458,E07000141,E10000019
+2024,2024,Burgh le Marsh,Boston and Skegness,East Lindsey,Lincolnshire,E05009875,E14001114,E07000137,E10000019
+2024,2024,Chapel St Leonards,Boston and Skegness,East Lindsey,Lincolnshire,E05009876,E14001114,E07000137,E10000019
+2024,2024,Coningsby & Mareham,Louth and Horncastle,East Lindsey,Lincolnshire,E05009877,E14001343,E07000137,E10000019
+2024,2024,Croft,Boston and Skegness,East Lindsey,Lincolnshire,E05009878,E14001114,E07000137,E10000019
+2024,2024,Friskney,Boston and Skegness,East Lindsey,Lincolnshire,E05009879,E14001114,E07000137,E10000019
+2024,2024,Fulstow,Louth and Horncastle,East Lindsey,Lincolnshire,E05009880,E14001343,E07000137,E10000019
+2024,2024,Grimoldby,Louth and Horncastle,East Lindsey,Lincolnshire,E05009881,E14001343,E07000137,E10000019
+2024,2024,Hagworthingham,Louth and Horncastle,East Lindsey,Lincolnshire,E05009882,E14001343,E07000137,E10000019
+2024,2024,Halton Holegate,Louth and Horncastle,East Lindsey,Lincolnshire,E05009883,E14001343,E07000137,E10000019
+2024,2024,Holton-le-Clay & North Thoresby,Louth and Horncastle,East Lindsey,Lincolnshire,E05009884,E14001343,E07000137,E10000019
+2024,2024,Horncastle,Louth and Horncastle,East Lindsey,Lincolnshire,E05009885,E14001343,E07000137,E10000019
+2024,2024,Ingoldmells,Boston and Skegness,East Lindsey,Lincolnshire,E05009886,E14001114,E07000137,E10000019
+2024,2024,Legbourne,Louth and Horncastle,East Lindsey,Lincolnshire,E05009887,E14001343,E07000137,E10000019
+2024,2024,Mablethorpe,Louth and Horncastle,East Lindsey,Lincolnshire,E05009888,E14001343,E07000137,E10000019
+2024,2024,Marshchapel & Somercotes,Louth and Horncastle,East Lindsey,Lincolnshire,E05009889,E14001343,E07000137,E10000019
+2024,2024,North Holme,Louth and Horncastle,East Lindsey,Lincolnshire,E05009890,E14001343,E07000137,E10000019
+2024,2024,Priory & St James',Louth and Horncastle,East Lindsey,Lincolnshire,E05009891,E14001343,E07000137,E10000019
+2024,2024,Roughton,Louth and Horncastle,East Lindsey,Lincolnshire,E05009892,E14001343,E07000137,E10000019
+2024,2024,St Clement's,Boston and Skegness,East Lindsey,Lincolnshire,E05009893,E14001114,E07000137,E10000019
+2024,2024,St Margaret's,Louth and Horncastle,East Lindsey,Lincolnshire,E05009894,E14001343,E07000137,E10000019
+2024,2024,St Mary's,Louth and Horncastle,East Lindsey,Lincolnshire,E05009895,E14001343,E07000137,E10000019
+2024,2024,St Michael's,Louth and Horncastle,East Lindsey,Lincolnshire,E05009896,E14001343,E07000137,E10000019
+2024,2024,Scarbrough & Seacroft,Boston and Skegness,East Lindsey,Lincolnshire,E05009897,E14001114,E07000137,E10000019
+2024,2024,Sibsey & Stickney,Boston and Skegness,East Lindsey,Lincolnshire,E05009898,E14001114,E07000137,E10000019
+2024,2024,Spilsby,Louth and Horncastle,East Lindsey,Lincolnshire,E05009899,E14001343,E07000137,E10000019
+2024,2024,Sutton on Sea,Louth and Horncastle,East Lindsey,Lincolnshire,E05009900,E14001343,E07000137,E10000019
+2024,2024,Tetford & Donington,Louth and Horncastle,East Lindsey,Lincolnshire,E05009901,E14001343,E07000137,E10000019
+2024,2024,Tetney,Louth and Horncastle,East Lindsey,Lincolnshire,E05009902,E14001343,E07000137,E10000019
+2024,2024,Trinity,Louth and Horncastle,East Lindsey,Lincolnshire,E05009903,E14001343,E07000137,E10000019
+2024,2024,Wainfleet,Boston and Skegness,East Lindsey,Lincolnshire,E05009904,E14001114,E07000137,E10000019
+2024,2024,Willoughby with Sloothby,Boston and Skegness,East Lindsey,Lincolnshire,E05009905,E14001114,E07000137,E10000019
+2024,2024,Winthorpe,Boston and Skegness,East Lindsey,Lincolnshire,E05009906,E14001114,E07000137,E10000019
+2024,2024,Withern & Theddlethorpe,Louth and Horncastle,East Lindsey,Lincolnshire,E05009907,E14001343,E07000137,E10000019
+2024,2024,Woodhall Spa,Louth and Horncastle,East Lindsey,Lincolnshire,E05009908,E14001343,E07000137,E10000019
+2024,2024,Wragby,Louth and Horncastle,East Lindsey,Lincolnshire,E05009909,E14001343,E07000137,E10000019
+2024,2024,Abbey,Lincoln,Lincoln,Lincolnshire,E05010784,E14001336,E07000138,E10000019
+2024,2024,Birchwood,Lincoln,Lincoln,Lincolnshire,E05010785,E14001336,E07000138,E10000019
+2024,2024,Boultham,Lincoln,Lincoln,Lincolnshire,E05010786,E14001336,E07000138,E10000019
+2024,2024,Carholme,Lincoln,Lincoln,Lincolnshire,E05010787,E14001336,E07000138,E10000019
+2024,2024,Castle,Lincoln,Lincoln,Lincolnshire,E05010788,E14001336,E07000138,E10000019
+2024,2024,Glebe,Lincoln,Lincoln,Lincolnshire,E05010789,E14001336,E07000138,E10000019
+2024,2024,Hartsholme,Lincoln,Lincoln,Lincolnshire,E05010790,E14001336,E07000138,E10000019
+2024,2024,Minster,Lincoln,Lincoln,Lincolnshire,E05010791,E14001336,E07000138,E10000019
+2024,2024,Moorland,Lincoln,Lincoln,Lincolnshire,E05010792,E14001336,E07000138,E10000019
+2024,2024,Park,Lincoln,Lincoln,Lincolnshire,E05010793,E14001336,E07000138,E10000019
+2024,2024,Witham,Lincoln,Lincoln,Lincolnshire,E05010794,E14001336,E07000138,E10000019
+2024,2024,"Ashby de la Launde, Digby & Scopwick",Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014425,E14001476,E07000139,E10000019
+2024,2024,Bassingham Rural,Sleaford and North Hykeham,North Kesteven,Lincolnshire,E05014426,E14001476,E07000139,E10000019
+2024,2024,Coalville West,North West Leicestershire,North West Leicestershire,Leicestershire,E05010105,E14001404,E07000134,E10000018
+2024,2024,Scotforth West,Lancaster and Wyre,Lancaster,Lancashire,E05014903,E14001318,E07000121,E10000017
+2024,2024,Hurst Green & Whitewell,Ribble Valley,Ribble Valley,Lancashire,E05012012,E14001443,E07000124,E10000017
+2024,2024,Glenfield Ellis,Mid Leicestershire,Blaby,Leicestershire,E05015270,E14001364,E07000129,E10000018
+2024,2024,Nevill,Rutland and Stamford,Harborough,Leicestershire,E05011980,E14001458,E07000131,E10000018
+2024,2024,Glenfield Faire,Mid Leicestershire,Blaby,Leicestershire,E05015271,E14001364,E07000129,E10000018
+2024,2024,Kirby Muxloe,Mid Leicestershire,Blaby,Leicestershire,E05015272,E14001364,E07000129,E10000018
+2024,2024,Leicester Forest & Lubbesthorpe,Mid Leicestershire,Blaby,Leicestershire,E05015273,E14001364,E07000129,E10000018
+2024,2024,Leicester Forest & Lubbesthorpe,South Leicestershire,Blaby,Leicestershire,E05015273,E14001488,E07000129,E10000018
+2024,2024,Narborough & Littlethorpe,South Leicestershire,Blaby,Leicestershire,E05015274,E14001488,E07000129,E10000018
+2024,2024,North Whetstone,South Leicestershire,Blaby,Leicestershire,E05015275,E14001488,E07000129,E10000018
+2024,2024,Thorpe Astley & St Mary's,Mid Leicestershire,Blaby,Leicestershire,E05015276,E14001364,E07000129,E10000018
+2024,2024,Anstey,Mid Leicestershire,Charnwood,Leicestershire,E05014666,E14001364,E07000130,E10000018
+2024,2024,Barrow upon Soar,Loughborough,Charnwood,Leicestershire,E05014667,E14001342,E07000130,E10000018
+2024,2024,Birstall East & Wanlip,Mid Leicestershire,Charnwood,Leicestershire,E05014668,E14001364,E07000130,E10000018
+2024,2024,Birstall West,Mid Leicestershire,Charnwood,Leicestershire,E05014669,E14001364,E07000130,E10000018
+2024,2024,"Dishley, Hathern & Thorpe Acre",Loughborough,Charnwood,Leicestershire,E05014670,E14001342,E07000130,E10000018
+2024,2024,Forest Bradgate,Mid Leicestershire,Charnwood,Leicestershire,E05014671,E14001364,E07000130,E10000018
+2024,2024,Loughborough Ashby,Loughborough,Charnwood,Leicestershire,E05014672,E14001342,E07000130,E10000018
+2024,2024,Loughborough East,Loughborough,Charnwood,Leicestershire,E05014673,E14001342,E07000130,E10000018
+2024,2024,Loughborough Nanpantan,Loughborough,Charnwood,Leicestershire,E05014674,E14001342,E07000130,E10000018
+2024,2024,Loughborough Outwoods & Shelthorpe,Loughborough,Charnwood,Leicestershire,E05014675,E14001342,E07000130,E10000018
+2024,2024,Loughborough Southfields,Loughborough,Charnwood,Leicestershire,E05014676,E14001342,E07000130,E10000018
+2024,2024,Loughborough Storer,Loughborough,Charnwood,Leicestershire,E05014677,E14001342,E07000130,E10000018
+2024,2024,Loughborough Woodthorpe,Loughborough,Charnwood,Leicestershire,E05014678,E14001342,E07000130,E10000018
+2024,2024,Loughborough Woodthorpe,Mid Leicestershire,Charnwood,Leicestershire,E05014678,E14001364,E07000130,E10000018
+2024,2024,Mountsorrel,Mid Leicestershire,Charnwood,Leicestershire,E05014679,E14001364,E07000130,E10000018
+2024,2024,Quorn & Mountsorrel Castle,Loughborough,Charnwood,Leicestershire,E05014680,E14001342,E07000130,E10000018
+2024,2024,Rothley Brook,Mid Leicestershire,Charnwood,Leicestershire,E05014681,E14001364,E07000130,E10000018
+2024,2024,Shepshed East,Loughborough,Charnwood,Leicestershire,E05014682,E14001342,E07000130,E10000018
+2024,2024,Shepshed West,Loughborough,Charnwood,Leicestershire,E05014683,E14001342,E07000130,E10000018
+2024,2024,Sileby & Seagrave,Loughborough,Charnwood,Leicestershire,E05014684,E14001342,E07000130,E10000018
+2024,2024,Sileby & Seagrave,Melton and Syston,Charnwood,Leicestershire,E05014684,E14001357,E07000130,E10000018
+2024,2024,South Charnwood,Melton and Syston,Charnwood,Leicestershire,E05014685,E14001357,E07000130,E10000018
+2024,2024,Syston,Melton and Syston,Charnwood,Leicestershire,E05014686,E14001357,E07000130,E10000018
+2024,2024,The Wolds,Loughborough,Charnwood,Leicestershire,E05014687,E14001342,E07000130,E10000018
+2024,2024,Thurmaston,Melton and Syston,Charnwood,Leicestershire,E05014688,E14001357,E07000130,E10000018
+2024,2024,Wreake Valley,Melton and Syston,Charnwood,Leicestershire,E05014689,E14001357,E07000130,E10000018
+2024,2024,Billesdon & Tilton,Rutland and Stamford,Harborough,Leicestershire,E05011964,E14001458,E07000131,E10000018
+2024,2024,Bosworth,South Leicestershire,Harborough,Leicestershire,E05011965,E14001488,E07000131,E10000018
+2024,2024,Broughton Astley-Primethorpe & Sutton,South Leicestershire,Harborough,Leicestershire,E05011966,E14001488,E07000131,E10000018
+2024,2024,Broughton Astley South & Leire,South Leicestershire,Harborough,Leicestershire,E05011967,E14001488,E07000131,E10000018
+2024,2024,Dunton,South Leicestershire,Harborough,Leicestershire,E05011968,E14001488,E07000131,E10000018
+2024,2024,Fleckney,South Leicestershire,Harborough,Leicestershire,E05011969,E14001488,E07000131,E10000018
+2024,2024,Glen,"Harborough, Oadby and Wigston",Harborough,Leicestershire,E05011970,E14001266,E07000131,E10000018
+2024,2024,Kibworths,"Harborough, Oadby and Wigston",Harborough,Leicestershire,E05011971,E14001266,E07000131,E10000018
+2024,2024,Lubenham,"Harborough, Oadby and Wigston",Harborough,Leicestershire,E05011972,E14001266,E07000131,E10000018
+2024,2024,Lutterworth East,South Leicestershire,Harborough,Leicestershire,E05011973,E14001488,E07000131,E10000018
+2024,2024,Lutterworth West,South Leicestershire,Harborough,Leicestershire,E05011974,E14001488,E07000131,E10000018
+2024,2024,Market Harborough-Great Bowden & Arden,"Harborough, Oadby and Wigston",Harborough,Leicestershire,E05011975,E14001266,E07000131,E10000018
+2024,2024,Market Harborough-Little Bowden,"Harborough, Oadby and Wigston",Harborough,Leicestershire,E05011976,E14001266,E07000131,E10000018
+2024,2024,Market Harborough-Logan,"Harborough, Oadby and Wigston",Harborough,Leicestershire,E05011977,E14001266,E07000131,E10000018
+2024,2024,Littlemoor,Pendle and Clitheroe,Ribble Valley,Lancashire,E05012013,E14001422,E07000124,E10000017
+2024,2024,Silverdale,Morecambe and Lunesdale,Lancaster,Lancashire,E05014904,E14001372,E07000121,E10000017
+2024,2024,Thurnby & Houghton,Rutland and Stamford,Harborough,Leicestershire,E05011981,E14001458,E07000131,E10000018
+2024,2024,Daleacre Hill,North West Leicestershire,North West Leicestershire,Leicestershire,E05010106,E14001404,E07000134,E10000018
+2024,2024,Mellor,Ribble Valley,Ribble Valley,Lancashire,E05012014,E14001443,E07000124,E10000017
+2024,2024,Primrose,Pendle and Clitheroe,Ribble Valley,Lancashire,E05012015,E14001422,E07000124,E10000017
+2024,2024,Ribchester,Ribble Valley,Ribble Valley,Lancashire,E05012016,E14001443,E07000124,E10000017
+2024,2024,Sabden,Pendle and Clitheroe,Ribble Valley,Lancashire,E05012017,E14001422,E07000124,E10000017
+2024,2024,St Mary's,Pendle and Clitheroe,Ribble Valley,Lancashire,E05012018,E14001422,E07000124,E10000017
+2024,2024,Salthill,Pendle and Clitheroe,Ribble Valley,Lancashire,E05012019,E14001422,E07000124,E10000017
+2024,2024,"Waddington, Bashall Eaves & Mitton",Ribble Valley,Ribble Valley,Lancashire,E05012020,E14001443,E07000124,E10000017
+2024,2024,West Bradford & Grindleton,Ribble Valley,Ribble Valley,Lancashire,E05012021,E14001443,E07000124,E10000017
+2024,2024,Whalley & Painter Wood,Pendle and Clitheroe,Ribble Valley,Lancashire,E05012022,E14001422,E07000124,E10000017
+2024,2024,Whalley Nethertown,Ribble Valley,Ribble Valley,Lancashire,E05012023,E14001443,E07000124,E10000017
+2024,2024,Wilpshire & Ramsgreave,Ribble Valley,Ribble Valley,Lancashire,E05012024,E14001443,E07000124,E10000017
+2024,2024,Wiswell & Barrow,Pendle and Clitheroe,Ribble Valley,Lancashire,E05012025,E14001422,E07000124,E10000017
+2024,2024,Bacup,Rossendale and Darwen,Rossendale,Lancashire,E05015817,E14001450,E07000125,E10000017
+2024,2024,Britannia & Lee Mill,Rossendale and Darwen,Rossendale,Lancashire,E05015818,E14001450,E07000125,E10000017
+2024,2024,Goodshaw & Cribden,Rossendale and Darwen,Rossendale,Lancashire,E05015819,E14001450,E07000125,E10000017
+2024,2024,Greenfield & Eden,Hyndburn,Rossendale,Lancashire,E05015820,E14001299,E07000125,E10000017
+2024,2024,Greenfield & Eden,Rossendale and Darwen,Rossendale,Lancashire,E05015820,E14001450,E07000125,E10000017
+2024,2024,Ullesthorpe,South Leicestershire,Harborough,Leicestershire,E05011982,E14001488,E07000131,E10000018
+2024,2024,Hareholme & Waterfoot,Rossendale and Darwen,Rossendale,Lancashire,E05015821,E14001450,E07000125,E10000017
+2024,2024,Ambien,Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005479,E14001288,E07000132,E10000018
+2024,2024,Haslingden,Hyndburn,Rossendale,Lancashire,E05015822,E14001299,E07000125,E10000017
+2024,2024,Ellistown & Battleflat,North West Leicestershire,North West Leicestershire,Leicestershire,E05010107,E14001404,E07000134,E10000018
+2024,2024,"Barlestone, Nailstone and Osbaston",Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005480,E14001288,E07000132,E10000018
+2024,2024,Helmshore,Hyndburn,Rossendale,Lancashire,E05015823,E14001299,E07000125,E10000017
+2024,2024,Greenhill,North West Leicestershire,North West Leicestershire,Leicestershire,E05010108,E14001404,E07000134,E10000018
+2024,2024,Skerton,Lancaster and Wyre,Lancaster,Lancashire,E05014905,E14001318,E07000121,E10000017
+2024,2024,Hermitage,North West Leicestershire,North West Leicestershire,Leicestershire,E05010109,E14001404,E07000134,E10000018
+2024,2024,Skerton,Morecambe and Lunesdale,Lancaster,Lancashire,E05014905,E14001372,E07000121,E10000017
+2024,2024,Holly Hayes,North West Leicestershire,North West Leicestershire,Leicestershire,E05010110,E14001404,E07000134,E10000018
+2024,2024,Torrisholme,Morecambe and Lunesdale,Lancaster,Lancashire,E05014906,E14001372,E07000121,E10000017
+2024,2024,Hugglescote St John's,North West Leicestershire,North West Leicestershire,Leicestershire,E05010111,E14001404,E07000134,E10000018
+2024,2024,University,Lancaster and Wyre,Lancaster,Lancashire,E05014907,E14001318,E07000121,E10000017
+2024,2024,Hugglescote St Mary's,North West Leicestershire,North West Leicestershire,Leicestershire,E05010112,E14001404,E07000134,E10000018
+2024,2024,Upper Lune Valley,Morecambe and Lunesdale,Lancaster,Lancashire,E05014908,E14001372,E07000121,E10000017
+2024,2024,Ibstock East,North West Leicestershire,North West Leicestershire,Leicestershire,E05010113,E14001404,E07000134,E10000018
+2024,2024,Warton,Morecambe and Lunesdale,Lancaster,Lancashire,E05014909,E14001372,E07000121,E10000017
+2024,2024,Ibstock West,North West Leicestershire,North West Leicestershire,Leicestershire,E05010114,E14001404,E07000134,E10000018
+2024,2024,West End,Morecambe and Lunesdale,Lancaster,Lancashire,E05014910,E14001372,E07000121,E10000017
+2024,2024,Kegworth,North West Leicestershire,North West Leicestershire,Leicestershire,E05010115,E14001404,E07000134,E10000018
+2024,2024,Westgate,Morecambe and Lunesdale,Lancaster,Lancashire,E05014911,E14001372,E07000121,E10000017
+2024,2024,Long Whatton & Diseworth,North West Leicestershire,North West Leicestershire,Leicestershire,E05010116,E14001404,E07000134,E10000018
+2024,2024,Barrowford & Pendleside,Pendle and Clitheroe,Pendle,Lancashire,E05013201,E14001422,E07000122,E10000017
+2024,2024,Measham North,North West Leicestershire,North West Leicestershire,Leicestershire,E05010117,E14001404,E07000134,E10000018
+2024,2024,Boulsworth & Foulridge,Pendle and Clitheroe,Pendle,Lancashire,E05013202,E14001422,E07000122,E10000017
+2024,2024,Measham South,North West Leicestershire,North West Leicestershire,Leicestershire,E05010118,E14001404,E07000134,E10000018
+2024,2024,Bradley,Pendle and Clitheroe,Pendle,Lancashire,E05013203,E14001422,E07000122,E10000017
+2024,2024,Helmshore,Rossendale and Darwen,Rossendale,Lancashire,E05015823,E14001450,E07000125,E10000017
+2024,2024,Oakthorpe & Donisthorpe,Hinckley and Bosworth,North West Leicestershire,Leicestershire,E05010119,E14001288,E07000134,E10000018
+2024,2024,Barwell,Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005481,E14001288,E07000132,E10000018
+2024,2024,Brierfield East & Clover Hill,Burnley,Pendle,Lancashire,E05013204,E14001142,E07000122,E10000017
+2024,2024,Longholme,Hyndburn,Rossendale,Lancashire,E05015824,E14001299,E07000125,E10000017
+2024,2024,Ravenstone & Packington,North West Leicestershire,North West Leicestershire,Leicestershire,E05010120,E14001404,E07000134,E10000018
+2024,2024,Burbage St Catherines and Lash Hill,Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005482,E14001288,E07000132,E10000018
+2024,2024,Brierfield West & Reedley,Burnley,Pendle,Lancashire,E05013205,E14001142,E07000122,E10000017
+2024,2024,Longholme,Rossendale and Darwen,Rossendale,Lancashire,E05015824,E14001450,E07000125,E10000017
+2024,2024,Sence Valley,North West Leicestershire,North West Leicestershire,Leicestershire,E05010121,E14001404,E07000134,E10000018
+2024,2024,Burbage Sketchley and Stretton,Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005483,E14001288,E07000132,E10000018
+2024,2024,Whitewell & Stacksteads,Rossendale and Darwen,Rossendale,Lancashire,E05015825,E14001450,E07000125,E10000017
+2024,2024,Snibston North,North West Leicestershire,North West Leicestershire,Leicestershire,E05010122,E14001404,E07000134,E10000018
+2024,2024,Fence & Higham,Pendle and Clitheroe,Pendle,Lancashire,E05013207,E14001422,E07000122,E10000017
+2024,2024,Snibston South,North West Leicestershire,North West Leicestershire,Leicestershire,E05010123,E14001404,E07000134,E10000018
+2024,2024,"Cadeby, Carlton and Market Bosworth with Shackerstone",Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005484,E14001288,E07000132,E10000018
+2024,2024,Marsden & Southfield,Pendle and Clitheroe,Pendle,Lancashire,E05013208,E14001422,E07000122,E10000017
+2024,2024,Whitworth,Rossendale and Darwen,Rossendale,Lancashire,E05015826,E14001450,E07000125,E10000017
+2024,2024,Thornborough,North West Leicestershire,North West Leicestershire,Leicestershire,E05010124,E14001404,E07000134,E10000018
+2024,2024,Earl Shilton,Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005485,E14001288,E07000132,E10000018
+2024,2024,Vivary Bridge,Pendle and Clitheroe,Pendle,Lancashire,E05013209,E14001422,E07000122,E10000017
+2024,2024,Bamber Bridge East,Ribble Valley,South Ribble,Lancashire,E05010214,E14001443,E07000126,E10000017
+2024,2024,Thringstone,North West Leicestershire,North West Leicestershire,Leicestershire,E05010125,E14001404,E07000134,E10000018
+2024,2024,Groby,Mid Leicestershire,Hinckley and Bosworth,Leicestershire,E05005486,E14001364,E07000132,E10000018
+2024,2024,Waterside & Horsfield,Pendle and Clitheroe,Pendle,Lancashire,E05013210,E14001422,E07000122,E10000017
+2024,2024,Bamber Bridge West,Ribble Valley,South Ribble,Lancashire,E05010215,E14001443,E07000126,E10000017
+2024,2024,Valley,North West Leicestershire,North West Leicestershire,Leicestershire,E05010126,E14001404,E07000134,E10000018
+2024,2024,Hinckley Castle,Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005487,E14001288,E07000132,E10000018
+2024,2024,Whitefield & Walverden,Pendle and Clitheroe,Pendle,Lancashire,E05013211,E14001422,E07000122,E10000017
+2024,2024,Broad Oak,South Ribble,South Ribble,Lancashire,E05010216,E14001491,E07000126,E10000017
+2024,2024,Worthington & Breedon,North West Leicestershire,North West Leicestershire,Leicestershire,E05010127,E14001404,E07000134,E10000018
+2024,2024,Hinckley Clarendon,Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005488,E14001288,E07000132,E10000018
+2024,2024,Barnoldswick,Pendle and Clitheroe,Pendle,Lancashire,E05015546,E14001422,E07000122,E10000017
+2024,2024,Broadfield,South Ribble,South Ribble,Lancashire,E05010217,E14001491,E07000126,E10000017
+2024,2024,Oadby Brocks Hill,"Harborough, Oadby and Wigston",Oadby and Wigston,Leicestershire,E05005531,E14001266,E07000135,E10000018
+2024,2024,Hinckley De Montfort,Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005489,E14001288,E07000132,E10000018
+2024,2024,Earby & Coates,Pendle and Clitheroe,Pendle,Lancashire,E05015547,E14001422,E07000122,E10000017
+2024,2024,Buckshaw & Worden,South Ribble,South Ribble,Lancashire,E05010218,E14001491,E07000126,E10000017
+2024,2024,Oadby Grange,"Harborough, Oadby and Wigston",Oadby and Wigston,Leicestershire,E05005532,E14001266,E07000135,E10000018
+2024,2024,Hinckley Trinity,Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005490,E14001288,E07000132,E10000018
+2024,2024,"Markfield, Stanton and Fieldhead",Mid Leicestershire,Hinckley and Bosworth,Leicestershire,E05005491,E14001364,E07000132,E10000018
+2024,2024,Newbold Verdon with Desford and Peckleton,Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005492,E14001288,E07000132,E10000018
+2024,2024,"Ratby, Bagworth and Thornton",Mid Leicestershire,Hinckley and Bosworth,Leicestershire,E05005493,E14001364,E07000132,E10000018
+2024,2024,Twycross and Witherley with Sheepy,Hinckley and Bosworth,Hinckley and Bosworth,Leicestershire,E05005494,E14001288,E07000132,E10000018
+2024,2024,Asfordby,Melton and Syston,Melton,Leicestershire,E05005495,E14001357,E07000133,E10000018
+2024,2024,Bottesford,Melton and Syston,Melton,Leicestershire,E05005496,E14001357,E07000133,E10000018
+2024,2024,Croxton Kerrial,Melton and Syston,Melton,Leicestershire,E05005497,E14001357,E07000133,E10000018
+2024,2024,Frisby-on-the-Wreake,Melton and Syston,Melton,Leicestershire,E05005498,E14001357,E07000133,E10000018
+2024,2024,Gaddesby,Melton and Syston,Melton,Leicestershire,E05005499,E14001357,E07000133,E10000018
+2024,2024,Long Clawson and Stathern,Melton and Syston,Melton,Leicestershire,E05005500,E14001357,E07000133,E10000018
+2024,2024,Melton Craven,Melton and Syston,Melton,Leicestershire,E05005501,E14001357,E07000133,E10000018
+2024,2024,Melton Dorian,Melton and Syston,Melton,Leicestershire,E05005502,E14001357,E07000133,E10000018
+2024,2024,Melton Egerton,Melton and Syston,Melton,Leicestershire,E05005503,E14001357,E07000133,E10000018
+2024,2024,Melton Newport,Melton and Syston,Melton,Leicestershire,E05005504,E14001357,E07000133,E10000018
+2024,2024,Melton Sysonby,Melton and Syston,Melton,Leicestershire,E05005505,E14001357,E07000133,E10000018
+2024,2024,Melton Warwick,Melton and Syston,Melton,Leicestershire,E05005506,E14001357,E07000133,E10000018
+2024,2024,Old Dalby,Melton and Syston,Melton,Leicestershire,E05005507,E14001357,E07000133,E10000018
+2024,2024,Somerby,Melton and Syston,Melton,Leicestershire,E05005508,E14001357,E07000133,E10000018
+2024,2024,Waltham-on-the-Wolds,Melton and Syston,Melton,Leicestershire,E05005509,E14001357,E07000133,E10000018
+2024,2024,Wymondham,Melton and Syston,Melton,Leicestershire,E05005510,E14001357,E07000133,E10000018
+2024,2024,Appleby,Hinckley and Bosworth,North West Leicestershire,Leicestershire,E05010090,E14001288,E07000134,E10000018
+2024,2024,Ashby Castle,North West Leicestershire,North West Leicestershire,Leicestershire,E05010091,E14001404,E07000134,E10000018
+2024,2024,Ashby Holywell,North West Leicestershire,North West Leicestershire,Leicestershire,E05010092,E14001404,E07000134,E10000018
+2024,2024,Ashby Ivanhoe,North West Leicestershire,North West Leicestershire,Leicestershire,E05010093,E14001404,E07000134,E10000018
+2024,2024,Ashby Money Hill,North West Leicestershire,North West Leicestershire,Leicestershire,E05010094,E14001404,E07000134,E10000018
+2024,2024,Ashby Willesley,North West Leicestershire,North West Leicestershire,Leicestershire,E05010095,E14001404,E07000134,E10000018
+2024,2024,Ashby Woulds,North West Leicestershire,North West Leicestershire,Leicestershire,E05010096,E14001404,E07000134,E10000018
+2024,2024,Bardon,North West Leicestershire,North West Leicestershire,Leicestershire,E05010097,E14001404,E07000134,E10000018
+2024,2024,Blackfordby,North West Leicestershire,North West Leicestershire,Leicestershire,E05010098,E14001404,E07000134,E10000018
+2024,2024,Broom Leys,North West Leicestershire,North West Leicestershire,Leicestershire,E05010099,E14001404,E07000134,E10000018
+2024,2024,Castle Donington Castle,North West Leicestershire,North West Leicestershire,Leicestershire,E05010100,E14001404,E07000134,E10000018
+2024,2024,Castle Donington Central,North West Leicestershire,North West Leicestershire,Leicestershire,E05010101,E14001404,E07000134,E10000018
+2024,2024,Castle Donington Park,North West Leicestershire,North West Leicestershire,Leicestershire,E05010102,E14001404,E07000134,E10000018
+2024,2024,Charnock,South Ribble,South Ribble,Lancashire,E05010219,E14001491,E07000126,E10000017
+2024,2024,Coupe Green & Gregson Lane,Ribble Valley,South Ribble,Lancashire,E05010220,E14001443,E07000126,E10000017
+2024,2024,Earnshaw Bridge,South Ribble,South Ribble,Lancashire,E05010221,E14001491,E07000126,E10000017
+2024,2024,Farington East,South Ribble,South Ribble,Lancashire,E05010222,E14001491,E07000126,E10000017
+2024,2024,Farington West,South Ribble,South Ribble,Lancashire,E05010223,E14001491,E07000126,E10000017
+2024,2024,Hoole,South Ribble,South Ribble,Lancashire,E05010224,E14001491,E07000126,E10000017
+2024,2024,Howick & Priory,South Ribble,South Ribble,Lancashire,E05010225,E14001491,E07000126,E10000017
+2024,2024,Leyland Central,South Ribble,South Ribble,Lancashire,E05010226,E14001491,E07000126,E10000017
+2024,2024,Longton & Hutton West,South Ribble,South Ribble,Lancashire,E05010227,E14001491,E07000126,E10000017
+2024,2024,Lostock Hall,Ribble Valley,South Ribble,Lancashire,E05010228,E14001443,E07000126,E10000017
+2024,2024,Oadby St Peter's,"Harborough, Oadby and Wigston",Oadby and Wigston,Leicestershire,E05005533,E14001266,E07000135,E10000018
+2024,2024,Middleforth,South Ribble,South Ribble,Lancashire,E05010229,E14001491,E07000126,E10000017
+2024,2024,Oadby Uplands,"Harborough, Oadby and Wigston",Oadby and Wigston,Leicestershire,E05005534,E14001266,E07000135,E10000018
+2024,2024,Moss Side,South Ribble,South Ribble,Lancashire,E05010230,E14001491,E07000126,E10000017
+2024,2024,Oadby Woodlands,"Harborough, Oadby and Wigston",Oadby and Wigston,Leicestershire,E05005535,E14001266,E07000135,E10000018
+2024,2024,New Longton & Hutton East,South Ribble,South Ribble,Lancashire,E05010231,E14001491,E07000126,E10000017
+2024,2024,South Wigston,"Harborough, Oadby and Wigston",Oadby and Wigston,Leicestershire,E05005536,E14001266,E07000135,E10000018
+2024,2024,St Ambrose,South Ribble,South Ribble,Lancashire,E05010232,E14001491,E07000126,E10000017
+2024,2024,Wigston All Saints,"Harborough, Oadby and Wigston",Oadby and Wigston,Leicestershire,E05005537,E14001266,E07000135,E10000018
+2024,2024,Samlesbury & Walton,Ribble Valley,South Ribble,Lancashire,E05010233,E14001443,E07000126,E10000017
+2024,2024,Wigston Fields,"Harborough, Oadby and Wigston",Oadby and Wigston,Leicestershire,E05005538,E14001266,E07000135,E10000018
+2024,2024,Seven Stars,South Ribble,South Ribble,Lancashire,E05010234,E14001491,E07000126,E10000017
+2024,2024,Wigston Meadowcourt,"Harborough, Oadby and Wigston",Oadby and Wigston,Leicestershire,E05005539,E14001266,E07000135,E10000018
+2024,2024,Wigston St Wolstan's,"Harborough, Oadby and Wigston",Oadby and Wigston,Leicestershire,E05005540,E14001266,E07000135,E10000018
+2024,2024,Coastal,Boston and Skegness,Boston,Lincolnshire,E05009621,E14001114,E07000136,E10000019
+2024,2024,Fenside,Boston and Skegness,Boston,Lincolnshire,E05009622,E14001114,E07000136,E10000019
+2024,2024,Fishtoft,Boston and Skegness,Boston,Lincolnshire,E05009623,E14001114,E07000136,E10000019
+2024,2024,Five Village,Boston and Skegness,Boston,Lincolnshire,E05009624,E14001114,E07000136,E10000019
+2024,2024,Kirton and Frampton,Boston and Skegness,Boston,Lincolnshire,E05009625,E14001114,E07000136,E10000019
+2024,2024,Old Leake and Wrangle,Boston and Skegness,Boston,Lincolnshire,E05009626,E14001114,E07000136,E10000019
+2024,2024,St Thomas',Boston and Skegness,Boston,Lincolnshire,E05009627,E14001114,E07000136,E10000019
+2024,2024,Skirbeck,Boston and Skegness,Boston,Lincolnshire,E05009628,E14001114,E07000136,E10000019
+2024,2024,Staniland,Boston and Skegness,Boston,Lincolnshire,E05009629,E14001114,E07000136,E10000019
+2024,2024,Station,Boston and Skegness,Boston,Lincolnshire,E05009630,E14001114,E07000136,E10000019
+2024,2024,Swineshead and Holland Fen,Boston and Skegness,Boston,Lincolnshire,E05009631,E14001114,E07000136,E10000019
+2024,2024,Trinity,Boston and Skegness,Boston,Lincolnshire,E05009632,E14001114,E07000136,E10000019
+2024,2024,West,Boston and Skegness,Boston,Lincolnshire,E05009633,E14001114,E07000136,E10000019
+2024,2024,Witham,Boston and Skegness,Boston,Lincolnshire,E05009634,E14001114,E07000136,E10000019
+2024,2024,Wyberton,Boston and Skegness,Boston,Lincolnshire,E05009635,E14001114,E07000136,E10000019
+2024,2024,Ashton,Preston,Preston,Lancashire,E05012193,E14001433,E07000123,E10000017
+2024,2024,Brookfield,Preston,Preston,Lancashire,E05012194,E14001433,E07000123,E10000017
+2024,2024,Cadley,Preston,Preston,Lancashire,E05012195,E14001433,E07000123,E10000017
+2024,2024,City Centre,Preston,Preston,Lancashire,E05012196,E14001433,E07000123,E10000017
+2024,2024,Deepdale,Preston,Preston,Lancashire,E05012197,E14001433,E07000123,E10000017
+2024,2024,Fishwick & Frenchwood,Preston,Preston,Lancashire,E05012198,E14001433,E07000123,E10000017
+2024,2024,Garrison,Preston,Preston,Lancashire,E05012199,E14001433,E07000123,E10000017
+2024,2024,Greyfriars,Ribble Valley,Preston,Lancashire,E05012200,E14001443,E07000123,E10000017
+2024,2024,Ingol & Cottam,Preston,Preston,Lancashire,E05012201,E14001433,E07000123,E10000017
+2024,2024,Lea & Larches,Preston,Preston,Lancashire,E05012202,E14001433,E07000123,E10000017
+2024,2024,Plungington,Preston,Preston,Lancashire,E05012203,E14001433,E07000123,E10000017
+2024,2024,Preston Rural East,Ribble Valley,Preston,Lancashire,E05012204,E14001443,E07000123,E10000017
+2024,2024,Preston Rural North,Ribble Valley,Preston,Lancashire,E05012205,E14001443,E07000123,E10000017
+2024,2024,Ribbleton,Preston,Preston,Lancashire,E05012206,E14001433,E07000123,E10000017
+2024,2024,St Matthew's,Preston,Preston,Lancashire,E05012207,E14001433,E07000123,E10000017
+2024,2024,Sharoe Green,Ribble Valley,Preston,Lancashire,E05012208,E14001443,E07000123,E10000017
+2024,2024,Alston & Hothersall,Ribble Valley,Ribble Valley,Lancashire,E05012000,E14001443,E07000124,E10000017
+2024,2024,Billington & Langho,Ribble Valley,Ribble Valley,Lancashire,E05012001,E14001443,E07000124,E10000017
+2024,2024,Bowland,Ribble Valley,Ribble Valley,Lancashire,E05012002,E14001443,E07000124,E10000017
+2024,2024,Brockhall & Dinckley,Ribble Valley,Ribble Valley,Lancashire,E05012003,E14001443,E07000124,E10000017
+2024,2024,Chatburn,Pendle and Clitheroe,Ribble Valley,Lancashire,E05012004,E14001422,E07000124,E10000017
+2024,2024,Chipping,Ribble Valley,Ribble Valley,Lancashire,E05012005,E14001443,E07000124,E10000017
+2024,2024,Clayton-le-Dale & Salesbury,Ribble Valley,Ribble Valley,Lancashire,E05012006,E14001443,E07000124,E10000017
+2024,2024,Derby & Thornley,Ribble Valley,Ribble Valley,Lancashire,E05012007,E14001443,E07000124,E10000017
+2024,2024,Dilworth,Ribble Valley,Ribble Valley,Lancashire,E05012008,E14001443,E07000124,E10000017
+2024,2024,"East Whalley, Read & Simonstone",Pendle and Clitheroe,Ribble Valley,Lancashire,E05012009,E14001422,E07000124,E10000017
+2024,2024,Diss & Roydon,Waveney Valley,South Norfolk,Norfolk,E05011872,E14001569,E07000149,E10000020
+2024,2024,Easton,South Norfolk,South Norfolk,Norfolk,E05011874,E14001489,E07000149,E10000020
+2024,2024,Forncett,South Norfolk,South Norfolk,Norfolk,E05011875,E14001489,E07000149,E10000020
+2024,2024,Hempnall,South Norfolk,South Norfolk,Norfolk,E05011877,E14001489,E07000149,E10000020
+2024,2024,Hethersett,South Norfolk,South Norfolk,Norfolk,E05011878,E14001489,E07000149,E10000020
+2024,2024,Hingham & Deopham,Mid Norfolk,South Norfolk,Norfolk,E05011879,E14001365,E07000149,E10000020
+2024,2024,Loddon & Chedgrave,South Norfolk,South Norfolk,Norfolk,E05011880,E14001489,E07000149,E10000020
+2024,2024,Mulbarton & Stoke Holy Cross,South Norfolk,South Norfolk,Norfolk,E05011881,E14001489,E07000149,E10000020
+2024,2024,New Costessey,Norwich South,South Norfolk,Norfolk,E05011882,E14001409,E07000149,E10000020
+2024,2024,Newton Flotman,South Norfolk,South Norfolk,Norfolk,E05011883,E14001489,E07000149,E10000020
+2024,2024,North Wymondham,South Norfolk,South Norfolk,Norfolk,E05011884,E14001489,E07000149,E10000020
+2024,2024,Old Costessey,South Norfolk,South Norfolk,Norfolk,E05011885,E14001489,E07000149,E10000020
+2024,2024,"Poringland, Framinghams & Trowse",South Norfolk,South Norfolk,Norfolk,E05011886,E14001489,E07000149,E10000020
+2024,2024,Rockland,South Norfolk,South Norfolk,Norfolk,E05011887,E14001489,E07000149,E10000020
+2024,2024,South Wymondham,South Norfolk,South Norfolk,Norfolk,E05011888,E14001489,E07000149,E10000020
+2024,2024,Stratton,South Norfolk,South Norfolk,Norfolk,E05011889,E14001489,E07000149,E10000020
+2024,2024,Thurlton,South Norfolk,South Norfolk,Norfolk,E05011890,E14001489,E07000149,E10000020
+2024,2024,Wicklewood,Mid Norfolk,South Norfolk,Norfolk,E05011891,E14001365,E07000149,E10000020
+2024,2024,Ditchingham & Earsham,Waveney Valley,South Norfolk,Norfolk,E05012851,E14001569,E07000149,E10000020
+2024,2024,Harleston,Waveney Valley,South Norfolk,Norfolk,E05012852,E14001569,E07000149,E10000020
+2024,2024,Abbey Hill,Ashfield,Ashfield,Nottinghamshire,E05010673,E14001068,E07000170,E10000024
+2024,2024,Annesley & Kirkby Woodhouse,Ashfield,Ashfield,Nottinghamshire,E05010674,E14001068,E07000170,E10000024
+2024,2024,Ashfields,Ashfield,Ashfield,Nottinghamshire,E05010675,E14001068,E07000170,E10000024
+2024,2024,Carsic,Ashfield,Ashfield,Nottinghamshire,E05010676,E14001068,E07000170,E10000024
+2024,2024,Sutton Central & New Cross,Ashfield,Ashfield,Nottinghamshire,E05010677,E14001068,E07000170,E10000024
+2024,2024,Hucknall Central,Sherwood Forest,Ashfield,Nottinghamshire,E05010678,E14001471,E07000170,E10000024
+2024,2024,Hucknall North,Sherwood Forest,Ashfield,Nottinghamshire,E05010679,E14001471,E07000170,E10000024
+2024,2024,Hucknall South,Sherwood Forest,Ashfield,Nottinghamshire,E05010680,E14001471,E07000170,E10000024
+2024,2024,Hucknall West,Sherwood Forest,Ashfield,Nottinghamshire,E05010681,E14001471,E07000170,E10000024
+2024,2024,Huthwaite & Brierley,Ashfield,Ashfield,Nottinghamshire,E05010682,E14001068,E07000170,E10000024
+2024,2024,Jacksdale & Westwood,Ashfield,Ashfield,Nottinghamshire,E05010683,E14001068,E07000170,E10000024
+2024,2024,Kingsway,Ashfield,Ashfield,Nottinghamshire,E05010684,E14001068,E07000170,E10000024
+2024,2024,Kirkby Cross & Portland,Ashfield,Ashfield,Nottinghamshire,E05010685,E14001068,E07000170,E10000024
+2024,2024,Larwood,Ashfield,Ashfield,Nottinghamshire,E05010686,E14001068,E07000170,E10000024
+2024,2024,Leamington,Ashfield,Ashfield,Nottinghamshire,E05010687,E14001068,E07000170,E10000024
+2024,2024,Sutton St Mary's,Ashfield,Ashfield,Nottinghamshire,E05010688,E14001068,E07000170,E10000024
+2024,2024,Selston,Ashfield,Ashfield,Nottinghamshire,E05010689,E14001068,E07000170,E10000024
+2024,2024,Skegby,Ashfield,Ashfield,Nottinghamshire,E05010690,E14001068,E07000170,E10000024
+2024,2024,Stanton Hill & Teversal,Ashfield,Ashfield,Nottinghamshire,E05010691,E14001068,E07000170,E10000024
+2024,2024,Greenwood & Summit,Ashfield,Ashfield,Nottinghamshire,E05010692,E14001068,E07000170,E10000024
+2024,2024,Sutton Junction & Harlow Wood,Ashfield,Ashfield,Nottinghamshire,E05010693,E14001068,E07000170,E10000024
+2024,2024,The Dales,Ashfield,Ashfield,Nottinghamshire,E05010694,E14001068,E07000170,E10000024
+2024,2024,Underwood,Ashfield,Ashfield,Nottinghamshire,E05010695,E14001068,E07000170,E10000024
+2024,2024,Beckingham,Bassetlaw,Bassetlaw,Nottinghamshire,E05006377,E14001079,E07000171,E10000024
+2024,2024,Blyth,Bassetlaw,Bassetlaw,Nottinghamshire,E05006378,E14001079,E07000171,E10000024
+2024,2024,Clayworth,Newark,Bassetlaw,Nottinghamshire,E05006380,E14001375,E07000171,E10000024
+2024,2024,East Markham,Newark,Bassetlaw,Nottinghamshire,E05006381,E14001375,E07000171,E10000024
+2024,2024,East Retford East,Bassetlaw,Bassetlaw,Nottinghamshire,E05006382,E14001079,E07000171,E10000024
+2024,2024,East Retford North,Bassetlaw,Bassetlaw,Nottinghamshire,E05006383,E14001079,E07000171,E10000024
+2024,2024,East Retford South,Bassetlaw,Bassetlaw,Nottinghamshire,E05006384,E14001079,E07000171,E10000024
+2024,2024,Beeston Regis & The Runtons,North Norfolk,North Norfolk,Norfolk,E05011835,E14001396,E07000147,E10000020
+2024,2024,Bilsthorpe,Sherwood Forest,Newark and Sherwood,Nottinghamshire,E05010066,E14001471,E07000175,E10000024
+2024,2024,Netherfield,Gedling,Gedling,Nottinghamshire,E05009700,E14001245,E07000173,E10000024
+2024,2024,Caister South,Great Yarmouth,Great Yarmouth,Norfolk,E05005787,E14001256,E07000145,E10000020
+2024,2024,Central And Northgate,Great Yarmouth,Great Yarmouth,Norfolk,E05005788,E14001256,E07000145,E10000020
+2024,2024,Claydon,Great Yarmouth,Great Yarmouth,Norfolk,E05005789,E14001256,E07000145,E10000020
+2024,2024,East Flegg,Great Yarmouth,Great Yarmouth,Norfolk,E05005790,E14001256,E07000145,E10000020
+2024,2024,Fleggburgh,Great Yarmouth,Great Yarmouth,Norfolk,E05005791,E14001256,E07000145,E10000020
+2024,2024,Gorleston,Great Yarmouth,Great Yarmouth,Norfolk,E05005792,E14001256,E07000145,E10000020
+2024,2024,Lothingland,Great Yarmouth,Great Yarmouth,Norfolk,E05005793,E14001256,E07000145,E10000020
+2024,2024,Magdalen,Great Yarmouth,Great Yarmouth,Norfolk,E05005794,E14001256,E07000145,E10000020
+2024,2024,Nelson,Great Yarmouth,Great Yarmouth,Norfolk,E05005795,E14001256,E07000145,E10000020
+2024,2024,Ormesby,Great Yarmouth,Great Yarmouth,Norfolk,E05005796,E14001256,E07000145,E10000020
+2024,2024,St Andrews,Great Yarmouth,Great Yarmouth,Norfolk,E05005797,E14001256,E07000145,E10000020
+2024,2024,Southtown and Cobholm,Great Yarmouth,Great Yarmouth,Norfolk,E05005798,E14001256,E07000145,E10000020
+2024,2024,West Flegg,Great Yarmouth,Great Yarmouth,Norfolk,E05005799,E14001256,E07000145,E10000020
+2024,2024,Yarmouth North,Great Yarmouth,Great Yarmouth,Norfolk,E05005800,E14001256,E07000145,E10000020
+2024,2024,Airfield,South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012321,E14001497,E07000146,E10000020
+2024,2024,Bircham with Rudhams,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012322,E14001405,E07000146,E10000020
+2024,2024,Brancaster,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012323,E14001405,E07000146,E10000020
+2024,2024,Burnham Market & Docking,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012324,E14001405,E07000146,E10000020
+2024,2024,Clenchwarton,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012325,E14001405,E07000146,E10000020
+2024,2024,Denver,South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012326,E14001497,E07000146,E10000020
+2024,2024,Dersingham,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012327,E14001405,E07000146,E10000020
+2024,2024,Dereham Withburga,Mid Norfolk,Breckland,Norfolk,E05010244,E14001365,E07000143,E10000020
+2024,2024,Downham Old Town,South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012328,E14001497,E07000146,E10000020
+2024,2024,East Downham,South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012329,E14001497,E07000146,E10000020
+2024,2024,Forest,South West Norfolk,Breckland,Norfolk,E05010245,E14001497,E07000143,E10000020
+2024,2024,Emneth & Outwell,South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012330,E14001497,E07000146,E10000020
+2024,2024,East Retford West,Bassetlaw,Bassetlaw,Nottinghamshire,E05006385,E14001079,E07000171,E10000024
+2024,2024,Guiltcross,South West Norfolk,Breckland,Norfolk,E05010246,E14001497,E07000143,E10000020
+2024,2024,Castle,Rutland and Stamford,South Kesteven,Lincolnshire,E05010155,E14001458,E07000141,E10000019
+2024,2024,Newstead Abbey,Sherwood Forest,Gedling,Nottinghamshire,E05009701,E14001471,E07000173,E10000024
+2024,2024,Deeping St James,South Holland and the Deepings,South Kesteven,Lincolnshire,E05010156,E14001487,E07000141,E10000019
+2024,2024,Phoenix,Gedling,Gedling,Nottinghamshire,E05009702,E14001245,E07000173,E10000024
+2024,2024,Dole Wood,Rutland and Stamford,South Kesteven,Lincolnshire,E05010157,E14001458,E07000141,E10000019
+2024,2024,Everton,Bassetlaw,Bassetlaw,Nottinghamshire,E05006386,E14001079,E07000171,E10000024
+2024,2024,Plains,Gedling,Gedling,Nottinghamshire,E05009703,E14001245,E07000173,E10000024
+2024,2024,Glen,Rutland and Stamford,South Kesteven,Lincolnshire,E05010158,E14001458,E07000141,E10000019
+2024,2024,Harling & Heathlands,South West Norfolk,Breckland,Norfolk,E05010247,E14001497,E07000143,E10000020
+2024,2024,Briston,North Norfolk,North Norfolk,Norfolk,E05011836,E14001396,E07000147,E10000020
+2024,2024,Boughton,Sherwood Forest,Newark and Sherwood,Nottinghamshire,E05010067,E14001471,E07000175,E10000024
+2024,2024,Fairstead,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012331,E14001405,E07000146,E10000020
+2024,2024,Feltwell,South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012332,E14001497,E07000146,E10000020
+2024,2024,Gayton & Grimston,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012333,E14001405,E07000146,E10000020
+2024,2024,Gaywood Chase,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012334,E14001405,E07000146,E10000020
+2024,2024,Gaywood Clock,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012335,E14001405,E07000146,E10000020
+2024,2024,Gaywood North Bank,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012336,E14001405,E07000146,E10000020
+2024,2024,Heacham,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012337,E14001405,E07000146,E10000020
+2024,2024,Hunstanton,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012338,E14001405,E07000146,E10000020
+2024,2024,Coastal,North Norfolk,North Norfolk,Norfolk,E05011837,E14001396,E07000147,E10000020
+2024,2024,Massingham with Castle Acre,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012339,E14001405,E07000146,E10000020
+2024,2024,Cromer Town,North Norfolk,North Norfolk,Norfolk,E05011838,E14001396,E07000147,E10000020
+2024,2024,Hermitage,Mid Norfolk,Breckland,Norfolk,E05010248,E14001365,E07000143,E10000020
+2024,2024,Grantham Arnoldfield,Grantham and Bourne,South Kesteven,Lincolnshire,E05010159,E14001253,E07000141,E10000019
+2024,2024,Erpingham,North Norfolk,North Norfolk,Norfolk,E05011839,E14001396,E07000147,E10000020
+2024,2024,Launditch,Mid Norfolk,Breckland,Norfolk,E05010249,E14001365,E07000143,E10000020
+2024,2024,Methwold,South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012340,E14001497,E07000146,E10000020
+2024,2024,Harworth,Bassetlaw,Bassetlaw,Nottinghamshire,E05006387,E14001079,E07000171,E10000024
+2024,2024,Porchester,Gedling,Gedling,Nottinghamshire,E05009704,E14001245,E07000173,E10000024
+2024,2024,Bridge,Newark,Newark and Sherwood,Nottinghamshire,E05010068,E14001375,E07000175,E10000024
+2024,2024,Langold,Bassetlaw,Bassetlaw,Nottinghamshire,E05006388,E14001079,E07000171,E10000024
+2024,2024,Collingham,Newark,Newark and Sherwood,Nottinghamshire,E05010070,E14001375,E07000175,E10000024
+2024,2024,Devon,Newark,Newark and Sherwood,Nottinghamshire,E05010071,E14001375,E07000175,E10000024
+2024,2024,Misterton,Bassetlaw,Bassetlaw,Nottinghamshire,E05006389,E14001079,E07000171,E10000024
+2024,2024,Dover Beck,Sherwood Forest,Newark and Sherwood,Nottinghamshire,E05010072,E14001471,E07000175,E10000024
+2024,2024,Rampton,Newark,Bassetlaw,Nottinghamshire,E05006390,E14001375,E07000171,E10000024
+2024,2024,Edwinstowe & Clipstone,Sherwood Forest,Newark and Sherwood,Nottinghamshire,E05010073,E14001471,E07000175,E10000024
+2024,2024,Ranskill,Bassetlaw,Bassetlaw,Nottinghamshire,E05006391,E14001079,E07000171,E10000024
+2024,2024,Farnsfield,Sherwood Forest,Newark and Sherwood,Nottinghamshire,E05010075,E14001471,E07000175,E10000024
+2024,2024,Lowdham,Sherwood Forest,Newark and Sherwood,Nottinghamshire,E05010076,E14001471,E07000175,E10000024
+2024,2024,Muskham,Newark,Newark and Sherwood,Nottinghamshire,E05010077,E14001375,E07000175,E10000024
+2024,2024,Ollerton,Sherwood Forest,Newark and Sherwood,Nottinghamshire,E05010078,E14001471,E07000175,E10000024
+2024,2024,Rainworth North & Rufford,Sherwood Forest,Newark and Sherwood,Nottinghamshire,E05010079,E14001471,E07000175,E10000024
+2024,2024,Rainworth South & Blidworth,Sherwood Forest,Newark and Sherwood,Nottinghamshire,E05010080,E14001471,E07000175,E10000024
+2024,2024,Southwell,Newark,Newark and Sherwood,Nottinghamshire,E05010081,E14001375,E07000175,E10000024
+2024,2024,Sutton-on-Trent,Newark,Newark and Sherwood,Nottinghamshire,E05010082,E14001375,E07000175,E10000024
+2024,2024,Trent,Newark,Newark and Sherwood,Nottinghamshire,E05010083,E14001375,E07000175,E10000024
+2024,2024,Balderton North & Coddington,Newark,Newark and Sherwood,Nottinghamshire,E05011552,E14001375,E07000175,E10000024
+2024,2024,Beacon,Newark,Newark and Sherwood,Nottinghamshire,E05011553,E14001375,E07000175,E10000024
+2024,2024,Castle,Newark,Newark and Sherwood,Nottinghamshire,E05011554,E14001375,E07000175,E10000024
+2024,2024,Farndon & Fernwood,Newark,Newark and Sherwood,Nottinghamshire,E05011555,E14001375,E07000175,E10000024
+2024,2024,Abbey,Rushcliffe,Rushcliffe,Nottinghamshire,E05014965,E14001457,E07000176,E10000024
+2024,2024,Bingham North,Newark,Rushcliffe,Nottinghamshire,E05014966,E14001375,E07000176,E10000024
+2024,2024,Bingham South,Newark,Rushcliffe,Nottinghamshire,E05014967,E14001375,E07000176,E10000024
+2024,2024,Bunny,Rushcliffe,Rushcliffe,Nottinghamshire,E05014968,E14001457,E07000176,E10000024
+2024,2024,Compton Acres,Rushcliffe,Rushcliffe,Nottinghamshire,E05014969,E14001457,E07000176,E10000024
+2024,2024,Cotgrave,Rushcliffe,Rushcliffe,Nottinghamshire,E05014970,E14001457,E07000176,E10000024
+2024,2024,Cranmer,Newark,Rushcliffe,Nottinghamshire,E05014971,E14001375,E07000176,E10000024
+2024,2024,Cropwell,Rushcliffe,Rushcliffe,Nottinghamshire,E05014972,E14001457,E07000176,E10000024
+2024,2024,East Bridgford,Newark,Rushcliffe,Nottinghamshire,E05014973,E14001375,E07000176,E10000024
+2024,2024,Edwalton,Rushcliffe,Rushcliffe,Nottinghamshire,E05014974,E14001457,E07000176,E10000024
+2024,2024,Gamston,Rushcliffe,Rushcliffe,Nottinghamshire,E05014975,E14001457,E07000176,E10000024
+2024,2024,Gotham,Rushcliffe,Rushcliffe,Nottinghamshire,E05014976,E14001457,E07000176,E10000024
+2024,2024,Keyworth & Wolds,Rushcliffe,Rushcliffe,Nottinghamshire,E05014977,E14001457,E07000176,E10000024
+2024,2024,Lady Bay,Rushcliffe,Rushcliffe,Nottinghamshire,E05014978,E14001457,E07000176,E10000024
+2024,2024,Leake,Rushcliffe,Rushcliffe,Nottinghamshire,E05014979,E14001457,E07000176,E10000024
+2024,2024,Lutterell,Rushcliffe,Rushcliffe,Nottinghamshire,E05014980,E14001457,E07000176,E10000024
+2024,2024,Musters,Rushcliffe,Rushcliffe,Nottinghamshire,E05014981,E14001457,E07000176,E10000024
+2024,2024,Nevile & Langar,Newark,Rushcliffe,Nottinghamshire,E05014982,E14001375,E07000176,E10000024
+2024,2024,Nevile & Langar,Rushcliffe,Rushcliffe,Nottinghamshire,E05014982,E14001457,E07000176,E10000024
+2024,2024,Newton,Newark,Rushcliffe,Nottinghamshire,E05014983,E14001375,E07000176,E10000024
+2024,2024,Newton,Rushcliffe,Rushcliffe,Nottinghamshire,E05014983,E14001457,E07000176,E10000024
+2024,2024,Radcliffe on Trent,Rushcliffe,Rushcliffe,Nottinghamshire,E05014984,E14001457,E07000176,E10000024
+2024,2024,Ruddington,Rushcliffe,Rushcliffe,Nottinghamshire,E05014985,E14001457,E07000176,E10000024
+2024,2024,Grantham Barrowby Gate,Grantham and Bourne,South Kesteven,Lincolnshire,E05010160,E14001253,E07000141,E10000019
+2024,2024,Lincoln,Mid Norfolk,Breckland,Norfolk,E05010250,E14001365,E07000143,E10000020
+2024,2024,Gresham,North Norfolk,North Norfolk,Norfolk,E05011840,E14001396,E07000147,E10000020
+2024,2024,North Downham,South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012341,E14001497,E07000146,E10000020
+2024,2024,Redhill,Gedling,Gedling,Nottinghamshire,E05009705,E14001245,E07000173,E10000024
+2024,2024,Soar Valley,Rushcliffe,Rushcliffe,Nottinghamshire,E05014986,E14001457,E07000176,E10000024
+2024,2024,Tollerton,Rushcliffe,Rushcliffe,Nottinghamshire,E05014987,E14001457,E07000176,E10000024
+2024,2024,Trent Bridge,Rushcliffe,Rushcliffe,Nottinghamshire,E05014988,E14001457,E07000176,E10000024
+2024,2024,Banbury Cross and Neithrop,Banbury,Cherwell,Oxfordshire,E05010921,E14001072,E07000177,E10000025
+2024,2024,Banbury Grimsbury and Hightown,Banbury,Cherwell,Oxfordshire,E05010922,E14001072,E07000177,E10000025
+2024,2024,Banbury Hardwick,Banbury,Cherwell,Oxfordshire,E05010923,E14001072,E07000177,E10000025
+2024,2024,Banbury Ruscote,Banbury,Cherwell,Oxfordshire,E05010924,E14001072,E07000177,E10000025
+2024,2024,Mattishall,Mid Norfolk,Breckland,Norfolk,E05010251,E14001365,E07000143,E10000020
+2024,2024,Nar Valley,South West Norfolk,Breckland,Norfolk,E05010252,E14001497,E07000143,E10000020
+2024,2024,Necton,Mid Norfolk,Breckland,Norfolk,E05010253,E14001365,E07000143,E10000020
+2024,2024,Saham Toney,Mid Norfolk,Breckland,Norfolk,E05010254,E14001365,E07000143,E10000020
+2024,2024,Shipdham-with-Scarning,Mid Norfolk,Breckland,Norfolk,E05010255,E14001365,E07000143,E10000020
+2024,2024,Swaffham,South West Norfolk,Breckland,Norfolk,E05010256,E14001497,E07000143,E10000020
+2024,2024,The Buckenhams & Banham,Mid Norfolk,Breckland,Norfolk,E05010257,E14001365,E07000143,E10000020
+2024,2024,Thetford Boudica,South West Norfolk,Breckland,Norfolk,E05010258,E14001497,E07000143,E10000020
+2024,2024,Thetford Burrell,South West Norfolk,Breckland,Norfolk,E05010259,E14001497,E07000143,E10000020
+2024,2024,Thetford Castle,South West Norfolk,Breckland,Norfolk,E05010260,E14001497,E07000143,E10000020
+2024,2024,Thetford Priory,South West Norfolk,Breckland,Norfolk,E05010261,E14001497,E07000143,E10000020
+2024,2024,Upper Wensum,Mid Norfolk,Breckland,Norfolk,E05010262,E14001365,E07000143,E10000020
+2024,2024,Watton,Mid Norfolk,Breckland,Norfolk,E05010263,E14001365,E07000143,E10000020
+2024,2024,Acle,Broadland and Fakenham,Broadland,Norfolk,E05005757,E14001136,E07000144,E10000020
+2024,2024,Aylsham,Broadland and Fakenham,Broadland,Norfolk,E05005758,E14001136,E07000144,E10000020
+2024,2024,Blofield with South Walsham,Broadland and Fakenham,Broadland,Norfolk,E05005759,E14001136,E07000144,E10000020
+2024,2024,Happisburgh,North Norfolk,North Norfolk,Norfolk,E05011841,E14001396,E07000147,E10000020
+2024,2024,Brundall,Broadland and Fakenham,Broadland,Norfolk,E05005760,E14001136,E07000144,E10000020
+2024,2024,Burlingham,Broadland and Fakenham,Broadland,Norfolk,E05005761,E14001136,E07000144,E10000020
+2024,2024,Hickling,North Norfolk,North Norfolk,Norfolk,E05011842,E14001396,E07000147,E10000020
+2024,2024,Buxton,Broadland and Fakenham,Broadland,Norfolk,E05005762,E14001136,E07000144,E10000020
+2024,2024,North Lynn,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012342,E14001405,E07000146,E10000020
+2024,2024,Grantham Earlesfield,Grantham and Bourne,South Kesteven,Lincolnshire,E05010161,E14001253,E07000141,E10000019
+2024,2024,Holt,North Norfolk,North Norfolk,Norfolk,E05011843,E14001396,E07000147,E10000020
+2024,2024,Trent Valley,Gedling,Gedling,Nottinghamshire,E05009706,E14001245,E07000173,E10000024
+2024,2024,Drayton North,Norwich North,Broadland,Norfolk,E05005764,E14001408,E07000144,E10000020
+2024,2024,Sturton,Newark,Bassetlaw,Nottinghamshire,E05006392,E14001375,E07000171,E10000024
+2024,2024,St. Margaret's with St. Nicholas,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012343,E14001405,E07000146,E10000020
+2024,2024,Sutton,Bassetlaw,Bassetlaw,Nottinghamshire,E05006393,E14001079,E07000171,E10000024
+2024,2024,Drayton South,Norwich North,Broadland,Norfolk,E05005765,E14001408,E07000144,E10000020
+2024,2024,Snettisham,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012344,E14001405,E07000146,E10000020
+2024,2024,South & West Lynn,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012345,E14001405,E07000146,E10000020
+2024,2024,South Downham,South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012346,E14001497,E07000146,E10000020
+2024,2024,Springwood,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012347,E14001405,E07000146,E10000020
+2024,2024,Terrington,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012348,E14001405,E07000146,E10000020
+2024,2024,The Woottons,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012349,E14001405,E07000146,E10000020
+2024,2024,"Tilney, Mershe Lande & Wiggenhall",South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012350,E14001497,E07000146,E10000020
+2024,2024,Upwell & Delph,South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012351,E14001497,E07000146,E10000020
+2024,2024,"Walsoken, West Walton & Walpole",North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012352,E14001405,E07000146,E10000020
+2024,2024,Watlington,South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012353,E14001497,E07000146,E10000020
+2024,2024,West Winch,North West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012354,E14001405,E07000146,E10000020
+2024,2024,Grantham Harrowby,Grantham and Bourne,South Kesteven,Lincolnshire,E05010162,E14001253,E07000141,E10000019
+2024,2024,Eynesford,Broadland and Fakenham,Broadland,Norfolk,E05005766,E14001136,E07000144,E10000020
+2024,2024,Tuxford and Trent,Newark,Bassetlaw,Nottinghamshire,E05006394,E14001375,E07000171,E10000024
+2024,2024,Wissey,South West Norfolk,King's Lynn and West Norfolk,Norfolk,E05012355,E14001497,E07000146,E10000020
+2024,2024,Great Witchingham,Broadland and Fakenham,Broadland,Norfolk,E05005767,E14001136,E07000144,E10000020
+2024,2024,Woodthorpe,Gedling,Gedling,Nottinghamshire,E05009707,E14001245,E07000173,E10000024
+2024,2024,Hoveton & Tunstead,North Norfolk,North Norfolk,Norfolk,E05011844,E14001396,E07000147,E10000020
+2024,2024,Bancroft,Mansfield,Mansfield,Nottinghamshire,E05014610,E14001355,E07000174,E10000024
+2024,2024,Hellesdon North West,Norwich North,Broadland,Norfolk,E05005768,E14001408,E07000144,E10000020
+2024,2024,Welbeck,Bassetlaw,Bassetlaw,Nottinghamshire,E05006395,E14001079,E07000171,E10000024
+2024,2024,Bacton,North Norfolk,North Norfolk,Norfolk,E05011834,E14001396,E07000147,E10000020
+2024,2024,Grantham St Vincent's,Grantham and Bourne,South Kesteven,Lincolnshire,E05010163,E14001253,E07000141,E10000019
+2024,2024,Grantham St Wulfram's,Grantham and Bourne,South Kesteven,Lincolnshire,E05010164,E14001253,E07000141,E10000019
+2024,2024,Grantham Springfield,Grantham and Bourne,South Kesteven,Lincolnshire,E05010165,E14001253,E07000141,E10000019
+2024,2024,Isaac Newton,Rutland and Stamford,South Kesteven,Lincolnshire,E05010166,E14001458,E07000141,E10000019
+2024,2024,Lincrest,Grantham and Bourne,South Kesteven,Lincolnshire,E05010167,E14001253,E07000141,E10000019
+2024,2024,Loveden Heath,Grantham and Bourne,South Kesteven,Lincolnshire,E05010168,E14001253,E07000141,E10000019
+2024,2024,Market & West Deeping,South Holland and the Deepings,South Kesteven,Lincolnshire,E05010169,E14001487,E07000141,E10000019
+2024,2024,Morton,Grantham and Bourne,South Kesteven,Lincolnshire,E05010170,E14001253,E07000141,E10000019
+2024,2024,Peascliffe & Ridgeway,Grantham and Bourne,South Kesteven,Lincolnshire,E05010171,E14001253,E07000141,E10000019
+2024,2024,Stamford All Saints,Rutland and Stamford,South Kesteven,Lincolnshire,E05010172,E14001458,E07000141,E10000019
+2024,2024,Stamford St George's,Rutland and Stamford,South Kesteven,Lincolnshire,E05010173,E14001458,E07000141,E10000019
+2024,2024,Stamford St John's,Rutland and Stamford,South Kesteven,Lincolnshire,E05010174,E14001458,E07000141,E10000019
+2024,2024,Stamford St Mary's,Rutland and Stamford,South Kesteven,Lincolnshire,E05010175,E14001458,E07000141,E10000019
+2024,2024,Toller,Grantham and Bourne,South Kesteven,Lincolnshire,E05010176,E14001253,E07000141,E10000019
+2024,2024,Viking,Grantham and Bourne,South Kesteven,Lincolnshire,E05010177,E14001253,E07000141,E10000019
+2024,2024,Bardney,Gainsborough,West Lindsey,Lincolnshire,E05009636,E14001243,E07000142,E10000019
+2024,2024,Caistor and Yarborough,Gainsborough,West Lindsey,Lincolnshire,E05009637,E14001243,E07000142,E10000019
+2024,2024,Cherry Willingham,Gainsborough,West Lindsey,Lincolnshire,E05009638,E14001243,E07000142,E10000019
+2024,2024,Dunholme and Welton,Gainsborough,West Lindsey,Lincolnshire,E05009639,E14001243,E07000142,E10000019
+2024,2024,Gainsborough East,Gainsborough,West Lindsey,Lincolnshire,E05009640,E14001243,E07000142,E10000019
+2024,2024,Gainsborough North,Gainsborough,West Lindsey,Lincolnshire,E05009641,E14001243,E07000142,E10000019
+2024,2024,Gainsborough South-West,Gainsborough,West Lindsey,Lincolnshire,E05009642,E14001243,E07000142,E10000019
+2024,2024,Hemswell,Gainsborough,West Lindsey,Lincolnshire,E05009643,E14001243,E07000142,E10000019
+2024,2024,Kelsey Wold,Gainsborough,West Lindsey,Lincolnshire,E05009644,E14001243,E07000142,E10000019
+2024,2024,Lea,Gainsborough,West Lindsey,Lincolnshire,E05009645,E14001243,E07000142,E10000019
+2024,2024,Market Rasen,Gainsborough,West Lindsey,Lincolnshire,E05009646,E14001243,E07000142,E10000019
+2024,2024,Nettleham,Gainsborough,West Lindsey,Lincolnshire,E05009647,E14001243,E07000142,E10000019
+2024,2024,Lancaster North,Broadland and Fakenham,North Norfolk,Norfolk,E05011845,E14001136,E07000147,E10000020
+2024,2024,Berry Hill,Mansfield,Mansfield,Nottinghamshire,E05014611,E14001355,E07000174,E10000024
+2024,2024,Saxilby,Gainsborough,West Lindsey,Lincolnshire,E05009648,E14001243,E07000142,E10000019
+2024,2024,Lancaster South,Broadland and Fakenham,North Norfolk,Norfolk,E05011846,E14001136,E07000147,E10000020
+2024,2024,Worksop East,Bassetlaw,Bassetlaw,Nottinghamshire,E05006396,E14001079,E07000171,E10000024
+2024,2024,Hellesdon South East,Norwich North,Broadland,Norfolk,E05005769,E14001408,E07000144,E10000020
+2024,2024,Mundesley,North Norfolk,North Norfolk,Norfolk,E05011847,E14001396,E07000147,E10000020
+2024,2024,Hevingham,Broadland and Fakenham,Broadland,Norfolk,E05005770,E14001136,E07000144,E10000020
+2024,2024,Worksop North,Bassetlaw,Bassetlaw,Nottinghamshire,E05006397,E14001079,E07000171,E10000024
+2024,2024,North Walsham East,North Norfolk,North Norfolk,Norfolk,E05011848,E14001396,E07000147,E10000020
+2024,2024,Horsford and Felthorpe,Broadland and Fakenham,Broadland,Norfolk,E05005771,E14001136,E07000144,E10000020
+2024,2024,Brick Kiln,Mansfield,Mansfield,Nottinghamshire,E05014612,E14001355,E07000174,E10000024
+2024,2024,Worksop North West,Bassetlaw,Bassetlaw,Nottinghamshire,E05006399,E14001079,E07000171,E10000024
+2024,2024,Scampton,Gainsborough,West Lindsey,Lincolnshire,E05009649,E14001243,E07000142,E10000019
+2024,2024,North Walsham Market Cross,North Norfolk,North Norfolk,Norfolk,E05011849,E14001396,E07000147,E10000020
+2024,2024,Marshes,Broadland and Fakenham,Broadland,Norfolk,E05005772,E14001136,E07000144,E10000020
+2024,2024,Carr Bank,Mansfield,Mansfield,Nottinghamshire,E05014613,E14001355,E07000174,E10000024
+2024,2024,Worksop South,Bassetlaw,Bassetlaw,Nottinghamshire,E05006400,E14001079,E07000171,E10000024
+2024,2024,Scotter and Blyton,Gainsborough,West Lindsey,Lincolnshire,E05009650,E14001243,E07000142,E10000019
+2024,2024,North Walsham West,North Norfolk,North Norfolk,Norfolk,E05011850,E14001396,E07000147,E10000020
+2024,2024,Old Catton and Sprowston West,Norwich North,Broadland,Norfolk,E05005773,E14001408,E07000144,E10000020
+2024,2024,Central,Mansfield,Mansfield,Nottinghamshire,E05014614,E14001355,E07000174,E10000024
+2024,2024,Worksop South East,Bassetlaw,Bassetlaw,Nottinghamshire,E05006401,E14001079,E07000171,E10000024
+2024,2024,Poppyland,North Norfolk,North Norfolk,Norfolk,E05011851,E14001396,E07000147,E10000020
+2024,2024,Stow,Gainsborough,West Lindsey,Lincolnshire,E05009651,E14001243,E07000142,E10000019
+2024,2024,Priory,North Norfolk,North Norfolk,Norfolk,E05011852,E14001396,E07000147,E10000020
+2024,2024,Sudbrooke,Gainsborough,West Lindsey,Lincolnshire,E05009652,E14001243,E07000142,E10000019
+2024,2024,Roughton,North Norfolk,North Norfolk,Norfolk,E05011853,E14001396,E07000147,E10000020
+2024,2024,Torksey,Gainsborough,West Lindsey,Lincolnshire,E05009653,E14001243,E07000142,E10000019
+2024,2024,St Benet's,North Norfolk,North Norfolk,Norfolk,E05011854,E14001396,E07000147,E10000020
+2024,2024,Waddingham and Spital,Gainsborough,West Lindsey,Lincolnshire,E05009654,E14001243,E07000142,E10000019
+2024,2024,Carlton,Bassetlaw,Bassetlaw,Nottinghamshire,E05015476,E14001079,E07000171,E10000024
+2024,2024,Plumstead,Broadland and Fakenham,Broadland,Norfolk,E05005774,E14001136,E07000144,E10000020
+2024,2024,Sheringham North,North Norfolk,North Norfolk,Norfolk,E05011855,E14001396,E07000147,E10000020
+2024,2024,Worksop North East,Bassetlaw,Bassetlaw,Nottinghamshire,E05015477,E14001079,E07000171,E10000024
+2024,2024,Wold View,Gainsborough,West Lindsey,Lincolnshire,E05009655,E14001243,E07000142,E10000019
+2024,2024,Eakring,Mansfield,Mansfield,Nottinghamshire,E05014615,E14001355,E07000174,E10000024
+2024,2024,Reepham,Broadland and Fakenham,Broadland,Norfolk,E05005775,E14001136,E07000144,E10000020
+2024,2024,All Saints & Wayland,Mid Norfolk,Breckland,Norfolk,E05010237,E14001365,E07000143,E10000020
+2024,2024,Grange Farm,Mansfield,Mansfield,Nottinghamshire,E05014616,E14001355,E07000174,E10000024
+2024,2024,Sprowston Central,Norwich North,Broadland,Norfolk,E05005777,E14001408,E07000144,E10000020
+2024,2024,Sheringham South,North Norfolk,North Norfolk,Norfolk,E05011856,E14001396,E07000147,E10000020
+2024,2024,Ashill,South West Norfolk,Breckland,Norfolk,E05010238,E14001497,E07000143,E10000020
+2024,2024,Holly Forest Town,Mansfield,Mansfield,Nottinghamshire,E05014617,E14001355,E07000174,E10000024
+2024,2024,Sprowston East,Norwich North,Broadland,Norfolk,E05005778,E14001408,E07000144,E10000020
+2024,2024,Attenborough & Chilwell East,Broxtowe,Broxtowe,Nottinghamshire,E05010514,E14001140,E07000172,E10000024
+2024,2024,Stalham,North Norfolk,North Norfolk,Norfolk,E05011857,E14001396,E07000147,E10000020
+2024,2024,Bedingfeld,South West Norfolk,Breckland,Norfolk,E05010239,E14001497,E07000143,E10000020
+2024,2024,Hornby,Mansfield,Mansfield,Nottinghamshire,E05014618,E14001355,E07000174,E10000024
+2024,2024,Taverham North,Broadland and Fakenham,Broadland,Norfolk,E05005779,E14001136,E07000144,E10000020
+2024,2024,Beeston Central,Broxtowe,Broxtowe,Nottinghamshire,E05010516,E14001140,E07000172,E10000024
+2024,2024,Stibbard,Broadland and Fakenham,North Norfolk,Norfolk,E05011858,E14001136,E07000147,E10000020
+2024,2024,Attleborough Burgh & Haverscroft,Mid Norfolk,Breckland,Norfolk,E05010240,E14001365,E07000143,E10000020
+2024,2024,Kings Walk,Mansfield,Mansfield,Nottinghamshire,E05014619,E14001355,E07000174,E10000024
+2024,2024,Taverham South,Broadland and Fakenham,Broadland,Norfolk,E05005780,E14001136,E07000144,E10000020
+2024,2024,Beeston North,Broxtowe,Broxtowe,Nottinghamshire,E05010517,E14001140,E07000172,E10000024
+2024,2024,Stody,North Norfolk,North Norfolk,Norfolk,E05011859,E14001396,E07000147,E10000020
+2024,2024,Attleborough Queens & Besthorpe,Mid Norfolk,Breckland,Norfolk,E05010241,E14001365,E07000143,E10000020
+2024,2024,Kingsway Forest Town,Mansfield,Mansfield,Nottinghamshire,E05014620,E14001355,E07000174,E10000024
+2024,2024,Thorpe St Andrew North West,Norwich North,Broadland,Norfolk,E05005781,E14001408,E07000144,E10000020
+2024,2024,Thorpe St Andrew South East,Norwich North,Broadland,Norfolk,E05005782,E14001408,E07000144,E10000020
+2024,2024,Wroxham,Broadland and Fakenham,Broadland,Norfolk,E05005783,E14001136,E07000144,E10000020
+2024,2024,Coltishall,Broadland and Fakenham,Broadland,Norfolk,E05015560,E14001136,E07000144,E10000020
+2024,2024,Spixworth with St Faiths,Broadland and Fakenham,Broadland,Norfolk,E05015561,E14001136,E07000144,E10000020
+2024,2024,Bradwell North,Great Yarmouth,Great Yarmouth,Norfolk,E05005784,E14001256,E07000145,E10000020
+2024,2024,Bradwell South and Hopton,Great Yarmouth,Great Yarmouth,Norfolk,E05005785,E14001256,E07000145,E10000020
+2024,2024,Caister North,Great Yarmouth,Great Yarmouth,Norfolk,E05005786,E14001256,E07000145,E10000020
+2024,2024,Lindhurst,Bolsover,Mansfield,Nottinghamshire,E05014621,E14001109,E07000174,E10000024
+2024,2024,Lindhurst,Mansfield,Mansfield,Nottinghamshire,E05014621,E14001355,E07000174,E10000024
+2024,2024,Ling Forest,Mansfield,Mansfield,Nottinghamshire,E05014622,E14001355,E07000174,E10000024
+2024,2024,Manor,Mansfield,Mansfield,Nottinghamshire,E05014623,E14001355,E07000174,E10000024
+2024,2024,Market Warsop,Mansfield,Mansfield,Nottinghamshire,E05014624,E14001355,E07000174,E10000024
+2024,2024,Maun Valley Forest Town,Mansfield,Mansfield,Nottinghamshire,E05014625,E14001355,E07000174,E10000024
+2024,2024,Meden,Mansfield,Mansfield,Nottinghamshire,E05014626,E14001355,E07000174,E10000024
+2024,2024,Mill Lane,Mansfield,Mansfield,Nottinghamshire,E05014627,E14001355,E07000174,E10000024
+2024,2024,Netherfield,Mansfield,Mansfield,Nottinghamshire,E05014628,E14001355,E07000174,E10000024
+2024,2024,Newlands Forest Town,Mansfield,Mansfield,Nottinghamshire,E05014629,E14001355,E07000174,E10000024
+2024,2024,Oak Tree,Mansfield,Mansfield,Nottinghamshire,E05014630,E14001355,E07000174,E10000024
+2024,2024,Beeston Rylands,Broxtowe,Broxtowe,Nottinghamshire,E05010518,E14001140,E07000172,E10000024
+2024,2024,Oakham,Mansfield,Mansfield,Nottinghamshire,E05014631,E14001355,E07000174,E10000024
+2024,2024,Suffield Park,North Norfolk,North Norfolk,Norfolk,E05011860,E14001396,E07000147,E10000020
+2024,2024,Beeston West,Broxtowe,Broxtowe,Nottinghamshire,E05010519,E14001140,E07000172,E10000024
+2024,2024,Park Hall,Mansfield,Mansfield,Nottinghamshire,E05014632,E14001355,E07000174,E10000024
+2024,2024,Dereham Neatherd,Mid Norfolk,Breckland,Norfolk,E05010242,E14001365,E07000143,E10000020
+2024,2024,The Raynhams,Broadland and Fakenham,North Norfolk,Norfolk,E05011861,E14001136,E07000147,E10000020
+2024,2024,Brinsley,Broxtowe,Broxtowe,Nottinghamshire,E05010521,E14001140,E07000172,E10000024
+2024,2024,Penniment,Mansfield,Mansfield,Nottinghamshire,E05014633,E14001355,E07000174,E10000024
+2024,2024,Dereham Toftwood,Mid Norfolk,Breckland,Norfolk,E05010243,E14001365,E07000143,E10000020
+2024,2024,Trunch,North Norfolk,North Norfolk,Norfolk,E05011862,E14001396,E07000147,E10000020
+2024,2024,Chilwell West,Broxtowe,Broxtowe,Nottinghamshire,E05010522,E14001140,E07000172,E10000024
+2024,2024,Pleasley,Bolsover,Mansfield,Nottinghamshire,E05014634,E14001109,E07000174,E10000024
+2024,2024,Walsingham,Broadland and Fakenham,North Norfolk,Norfolk,E05011863,E14001136,E07000147,E10000020
+2024,2024,Eastwood Hall,Broxtowe,Broxtowe,Nottinghamshire,E05010523,E14001140,E07000172,E10000024
+2024,2024,Pleasley,Mansfield,Mansfield,Nottinghamshire,E05014634,E14001355,E07000174,E10000024
+2024,2024,Wells with Holkham,North Norfolk,North Norfolk,Norfolk,E05011864,E14001396,E07000147,E10000020
+2024,2024,Eastwood Hilltop,Broxtowe,Broxtowe,Nottinghamshire,E05010524,E14001140,E07000172,E10000024
+2024,2024,Worstead,North Norfolk,North Norfolk,Norfolk,E05011865,E14001396,E07000147,E10000020
+2024,2024,Racecourse,Mansfield,Mansfield,Nottinghamshire,E05014635,E14001355,E07000174,E10000024
+2024,2024,Eastwood St Mary's,Broxtowe,Broxtowe,Nottinghamshire,E05010525,E14001140,E07000172,E10000024
+2024,2024,Rock Hill,Mansfield,Mansfield,Nottinghamshire,E05014636,E14001355,E07000174,E10000024
+2024,2024,Bowthorpe,Norwich South,Norwich,Norfolk,E05012901,E14001409,E07000148,E10000020
+2024,2024,Stapleford South West,Broxtowe,Broxtowe,Nottinghamshire,E05010531,E14001140,E07000172,E10000024
+2024,2024,Rufford,Bolsover,Mansfield,Nottinghamshire,E05014637,E14001109,E07000174,E10000024
+2024,2024,Catton Grove,Norwich North,Norwich,Norfolk,E05012902,E14001408,E07000148,E10000020
+2024,2024,Toton & Chilwell Meadows,Broxtowe,Broxtowe,Nottinghamshire,E05010532,E14001140,E07000172,E10000024
+2024,2024,Rufford,Mansfield,Mansfield,Nottinghamshire,E05014637,E14001355,E07000174,E10000024
+2024,2024,Crome,Norwich North,Norwich,Norfolk,E05012903,E14001408,E07000148,E10000020
+2024,2024,Watnall & Nuthall West,Nottingham North and Kimberley,Broxtowe,Nottinghamshire,E05010533,E14001411,E07000172,E10000024
+2024,2024,Sherwood,Bolsover,Mansfield,Nottinghamshire,E05014638,E14001109,E07000174,E10000024
+2024,2024,Eaton,Norwich South,Norwich,Norfolk,E05012904,E14001409,E07000148,E10000020
+2024,2024,"Awsworth, Cossall & Trowell",Broxtowe,Broxtowe,Nottinghamshire,E05015564,E14001140,E07000172,E10000024
+2024,2024,Sherwood,Mansfield,Mansfield,Nottinghamshire,E05014638,E14001355,E07000174,E10000024
+2024,2024,Lakenham,Norwich South,Norwich,Norfolk,E05012905,E14001409,E07000148,E10000020
+2024,2024,"Awsworth, Cossall & Trowell",Nottingham North and Kimberley,Broxtowe,Nottinghamshire,E05015564,E14001411,E07000172,E10000024
+2024,2024,Southwell,Mansfield,Mansfield,Nottinghamshire,E05014639,E14001355,E07000174,E10000024
+2024,2024,Mancroft,Norwich South,Norwich,Norfolk,E05012906,E14001409,E07000148,E10000020
+2024,2024,Bramcote,Broxtowe,Broxtowe,Nottinghamshire,E05015565,E14001140,E07000172,E10000024
+2024,2024,Thompsons,Mansfield,Mansfield,Nottinghamshire,E05014640,E14001355,E07000174,E10000024
+2024,2024,Mile Cross,Norwich North,Norwich,Norfolk,E05012907,E14001408,E07000148,E10000020
+2024,2024,Greasley,Broxtowe,Broxtowe,Nottinghamshire,E05015566,E14001140,E07000172,E10000024
+2024,2024,Vale,Bolsover,Mansfield,Nottinghamshire,E05014641,E14001109,E07000174,E10000024
+2024,2024,Nelson,Norwich South,Norwich,Norfolk,E05012908,E14001409,E07000148,E10000020
+2024,2024,Kimberley,Nottingham North and Kimberley,Broxtowe,Nottinghamshire,E05015567,E14001411,E07000172,E10000024
+2024,2024,Vale,Mansfield,Mansfield,Nottinghamshire,E05014641,E14001355,E07000174,E10000024
+2024,2024,Sewell,Norwich North,Norwich,Norfolk,E05012909,E14001408,E07000148,E10000020
+2024,2024,Nuthall East & Strelley,Nottingham North and Kimberley,Broxtowe,Nottinghamshire,E05015568,E14001411,E07000172,E10000024
+2024,2024,Wainwright,Mansfield,Mansfield,Nottinghamshire,E05014642,E14001355,E07000174,E10000024
+2024,2024,Thorpe Hamlet,Norwich South,Norwich,Norfolk,E05012910,E14001409,E07000148,E10000020
+2024,2024,Stapleford North,Broxtowe,Broxtowe,Nottinghamshire,E05015569,E14001140,E07000172,E10000024
+2024,2024,Warsop Carrs,Mansfield,Mansfield,Nottinghamshire,E05014643,E14001355,E07000174,E10000024
+2024,2024,Town Close,Norwich South,Norwich,Norfolk,E05012911,E14001409,E07000148,E10000020
+2024,2024,Stapleford South East,Broxtowe,Broxtowe,Nottinghamshire,E05015570,E14001140,E07000172,E10000024
+2024,2024,Bestwood St Albans,Gedling,Gedling,Nottinghamshire,E05009689,E14001245,E07000173,E10000024
+2024,2024,West Bank,Mansfield,Mansfield,Nottinghamshire,E05014644,E14001355,E07000174,E10000024
+2024,2024,Calverton,Sherwood Forest,Gedling,Nottinghamshire,E05009690,E14001471,E07000173,E10000024
+2024,2024,University,Norwich South,Norwich,Norfolk,E05012912,E14001409,E07000148,E10000020
+2024,2024,Carlton,Gedling,Gedling,Nottinghamshire,E05009691,E14001245,E07000173,E10000024
+2024,2024,Wensum,Norwich South,Norwich,Norfolk,E05012913,E14001409,E07000148,E10000020
+2024,2024,Carlton Hill,Gedling,Gedling,Nottinghamshire,E05009692,E14001245,E07000173,E10000024
+2024,2024,"Beck Vale, Dickleburgh & Scole",Waveney Valley,South Norfolk,Norfolk,E05011866,E14001569,E07000149,E10000020
+2024,2024,Cavendish,Gedling,Gedling,Nottinghamshire,E05009693,E14001245,E07000173,E10000024
+2024,2024,Bressingham & Burston,Waveney Valley,South Norfolk,Norfolk,E05011867,E14001569,E07000149,E10000020
+2024,2024,Colwick,Gedling,Gedling,Nottinghamshire,E05009694,E14001245,E07000173,E10000024
+2024,2024,Brooke,South Norfolk,South Norfolk,Norfolk,E05011868,E14001489,E07000149,E10000020
+2024,2024,Coppice,Gedling,Gedling,Nottinghamshire,E05009695,E14001245,E07000173,E10000024
+2024,2024,Bunwell,Waveney Valley,South Norfolk,Norfolk,E05011869,E14001569,E07000149,E10000020
+2024,2024,Daybrook,Gedling,Gedling,Nottinghamshire,E05009696,E14001245,E07000173,E10000024
+2024,2024,Central Wymondham,South Norfolk,South Norfolk,Norfolk,E05011870,E14001489,E07000149,E10000020
+2024,2024,Dumbles,Gedling,Gedling,Nottinghamshire,E05009697,E14001245,E07000173,E10000024
+2024,2024,Cringleford,South Norfolk,South Norfolk,Norfolk,E05011871,E14001489,E07000149,E10000020
+2024,2024,Ernehale,Gedling,Gedling,Nottinghamshire,E05009698,E14001245,E07000173,E10000024
+2024,2024,Gedling,Gedling,Gedling,Nottinghamshire,E05009699,E14001245,E07000173,E10000024
+2024,2024,Yeoman Hill,Mansfield,Mansfield,Nottinghamshire,E05014645,E14001355,E07000174,E10000024
+2024,2024,Balderton South,Newark,Newark and Sherwood,Nottinghamshire,E05010064,E14001375,E07000175,E10000024
+2024,2024,Manifold,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007064,E14001514,E07000198,E10000028
+2024,2024,Bicester East,Bicester and Woodstock,Cherwell,Oxfordshire,E05010925,E14001090,E07000177,E10000025
+2024,2024,Werrington,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007065,E14001514,E07000198,E10000028
+2024,2024,Amington,Tamworth,Tamworth,Staffordshire,E05007066,E14001538,E07000199,E10000028
+2024,2024,Bicester North and Caversfield,Bicester and Woodstock,Cherwell,Oxfordshire,E05010926,E14001090,E07000177,E10000025
+2024,2024,Belgrave,Tamworth,Tamworth,Staffordshire,E05007067,E14001538,E07000199,E10000028
+2024,2024,Bicester West,Bicester and Woodstock,Cherwell,Oxfordshire,E05010928,E14001090,E07000177,E10000025
+2024,2024,Bolehall,Tamworth,Tamworth,Staffordshire,E05007068,E14001538,E07000199,E10000028
+2024,2024,"Cropredy, Sibfords and Wroxton",Banbury,Cherwell,Oxfordshire,E05010929,E14001072,E07000177,E10000025
+2024,2024,Castle,Tamworth,Tamworth,Staffordshire,E05007069,E14001538,E07000199,E10000028
+2024,2024,Deddington,Banbury,Cherwell,Oxfordshire,E05010930,E14001072,E07000177,E10000025
+2024,2024,Glascote,Tamworth,Tamworth,Staffordshire,E05007070,E14001538,E07000199,E10000028
+2024,2024,Kidlington East,Bicester and Woodstock,Cherwell,Oxfordshire,E05010932,E14001090,E07000177,E10000025
+2024,2024,Witney West,Witney,West Oxfordshire,Oxfordshire,E05006652,E14001591,E07000181,E10000025
+2024,2024,Whitehouse,Central Suffolk and North Ipswich,Ipswich,Suffolk,E05007131,E14001156,E07000202,E10000029
+2024,2024,Mercian,Tamworth,Tamworth,Staffordshire,E05007071,E14001538,E07000199,E10000028
+2024,2024,Spital,Tamworth,Tamworth,Staffordshire,E05007072,E14001538,E07000199,E10000028
+2024,2024,Stonydelph,Tamworth,Tamworth,Staffordshire,E05007073,E14001538,E07000199,E10000028
+2024,2024,Trinity,Tamworth,Tamworth,Staffordshire,E05007074,E14001538,E07000199,E10000028
+2024,2024,Wilnecote,Tamworth,Tamworth,Staffordshire,E05007075,E14001538,E07000199,E10000028
+2024,2024,Assington,South Suffolk,Babergh,Suffolk,E05012565,E14001494,E07000200,E10000029
+2024,2024,Box Vale,South Suffolk,Babergh,Suffolk,E05012566,E14001494,E07000200,E10000029
+2024,2024,Brantham,South Suffolk,Babergh,Suffolk,E05012567,E14001494,E07000200,E10000029
+2024,2024,Brett Vale,South Suffolk,Babergh,Suffolk,E05012568,E14001494,E07000200,E10000029
+2024,2024,Bures St Mary & Nayland,South Suffolk,Babergh,Suffolk,E05012569,E14001494,E07000200,E10000029
+2024,2024,Capel St Mary,South Suffolk,Babergh,Suffolk,E05012570,E14001494,E07000200,E10000029
+2024,2024,Chadacre,South Suffolk,Babergh,Suffolk,E05012571,E14001494,E07000200,E10000029
+2024,2024,Copdock & Washbrook,South Suffolk,Babergh,Suffolk,E05012572,E14001494,E07000200,E10000029
+2024,2024,East Bergholt,South Suffolk,Babergh,Suffolk,E05012573,E14001494,E07000200,E10000029
+2024,2024,Ganges,South Suffolk,Babergh,Suffolk,E05012574,E14001494,E07000200,E10000029
+2024,2024,Great Cornard,South Suffolk,Babergh,Suffolk,E05012575,E14001494,E07000200,E10000029
+2024,2024,Hadleigh North,South Suffolk,Babergh,Suffolk,E05012576,E14001494,E07000200,E10000029
+2024,2024,Hadleigh South,South Suffolk,Babergh,Suffolk,E05012577,E14001494,E07000200,E10000029
+2024,2024,Lavenham,South Suffolk,Babergh,Suffolk,E05012578,E14001494,E07000200,E10000029
+2024,2024,Long Melford,South Suffolk,Babergh,Suffolk,E05012579,E14001494,E07000200,E10000029
+2024,2024,North West Cosford,South Suffolk,Babergh,Suffolk,E05012580,E14001494,E07000200,E10000029
+2024,2024,Orwell,South Suffolk,Babergh,Suffolk,E05012581,E14001494,E07000200,E10000029
+2024,2024,South East Cosford,South Suffolk,Babergh,Suffolk,E05012582,E14001494,E07000200,E10000029
+2024,2024,Sproughton & Pinewood,South Suffolk,Babergh,Suffolk,E05012583,E14001494,E07000200,E10000029
+2024,2024,Stour,South Suffolk,Babergh,Suffolk,E05012584,E14001494,E07000200,E10000029
+2024,2024,Sudbury North East,South Suffolk,Babergh,Suffolk,E05012585,E14001494,E07000200,E10000029
+2024,2024,Sudbury North West,South Suffolk,Babergh,Suffolk,E05012586,E14001494,E07000200,E10000029
+2024,2024,Sudbury South East,South Suffolk,Babergh,Suffolk,E05012587,E14001494,E07000200,E10000029
+2024,2024,Sudbury South West,South Suffolk,Babergh,Suffolk,E05012588,E14001494,E07000200,E10000029
+2024,2024,Alexandra,Ipswich,Ipswich,Suffolk,E05007117,E14001302,E07000202,E10000029
+2024,2024,Bixley,Ipswich,Ipswich,Suffolk,E05007118,E14001302,E07000202,E10000029
+2024,2024,Bridge,Ipswich,Ipswich,Suffolk,E05007119,E14001302,E07000202,E10000029
+2024,2024,Castle Hill,Central Suffolk and North Ipswich,Ipswich,Suffolk,E05007120,E14001156,E07000202,E10000029
+2024,2024,Gainsborough,Ipswich,Ipswich,Suffolk,E05007121,E14001302,E07000202,E10000029
+2024,2024,Gipping,Ipswich,Ipswich,Suffolk,E05007122,E14001302,E07000202,E10000029
+2024,2024,Holywells,Ipswich,Ipswich,Suffolk,E05007123,E14001302,E07000202,E10000029
+2024,2024,Priory Heath,Ipswich,Ipswich,Suffolk,E05007124,E14001302,E07000202,E10000029
+2024,2024,Rushmere,Ipswich,Ipswich,Suffolk,E05007125,E14001302,E07000202,E10000029
+2024,2024,St John's,Ipswich,Ipswich,Suffolk,E05007126,E14001302,E07000202,E10000029
+2024,2024,St Margaret's,Ipswich,Ipswich,Suffolk,E05007127,E14001302,E07000202,E10000029
+2024,2024,Wombourne North,Kingswinford and South Staffordshire,South Staffordshire,Staffordshire,E05015072,E14001316,E07000196,E10000028
+2024,2024,Kidmore End & Whitchurch,Henley and Thame,South Oxfordshire,Oxfordshire,E05011707,E14001280,E07000179,E10000025
+2024,2024,Sprites,Ipswich,Ipswich,Suffolk,E05007128,E14001302,E07000202,E10000029
+2024,2024,Stoke Park,Ipswich,Ipswich,Suffolk,E05007129,E14001302,E07000202,E10000029
+2024,2024,Westgate,Ipswich,Ipswich,Suffolk,E05007130,E14001302,E07000202,E10000029
+2024,2024,Horton,Epsom and Ewell,Epsom and Ewell,Surrey,E05015099,E14001227,E07000208,E10000030
+2024,2024,Kidlington West,Bicester and Woodstock,Cherwell,Oxfordshire,E05010933,E14001090,E07000177,E10000025
+2024,2024,Wombourne South,Kingswinford and South Staffordshire,South Staffordshire,Staffordshire,E05015073,E14001316,E07000196,E10000028
+2024,2024,Woodstock and Bladon,Bicester and Woodstock,West Oxfordshire,Oxfordshire,E05006653,E14001090,E07000181,E10000025
+2024,2024,Nonsuch,Epsom and Ewell,Epsom and Ewell,Surrey,E05015100,E14001227,E07000208,E10000030
+2024,2024,Burford,Witney,West Oxfordshire,Oxfordshire,E05009363,E14001591,E07000181,E10000025
+2024,2024,Ruxley,Epsom and Ewell,Epsom and Ewell,Surrey,E05015101,E14001227,E07000208,E10000030
+2024,2024,Brize Norton and Shilton,Witney,West Oxfordshire,Oxfordshire,E05009364,E14001591,E07000181,E10000025
+2024,2024,Stamford,Epsom and Ewell,Epsom and Ewell,Surrey,E05015102,E14001227,E07000208,E10000030
+2024,2024,Carterton North West,Witney,West Oxfordshire,Oxfordshire,E05009365,E14001591,E07000181,E10000025
+2024,2024,Stoneleigh,Epsom and Ewell,Epsom and Ewell,Surrey,E05015103,E14001227,E07000208,E10000030
+2024,2024,Chadlington and Churchill,Banbury,West Oxfordshire,Oxfordshire,E05010781,E14001072,E07000181,E10000025
+2024,2024,Town,Epsom and Ewell,Epsom and Ewell,Surrey,E05015104,E14001227,E07000208,E10000030
+2024,2024,Charlbury and Finstock,Banbury,West Oxfordshire,Oxfordshire,E05010782,E14001072,E07000181,E10000025
+2024,2024,West Ewell,Epsom and Ewell,Epsom and Ewell,Surrey,E05015105,E14001227,E07000208,E10000030
+2024,2024,"Hailey, Minster Lovell and Leafield",Witney,West Oxfordshire,Oxfordshire,E05010783,E14001591,E07000181,E10000025
+2024,2024,Woodcote & Langley Vale,Epsom and Ewell,Epsom and Ewell,Surrey,E05015106,E14001227,E07000208,E10000030
+2024,2024,Brereton & Ravenhill,Cannock Chase,Cannock Chase,Staffordshire,E05015742,E14001150,E07000192,E10000028
+2024,2024,Whitton,Central Suffolk and North Ipswich,Ipswich,Suffolk,E05007132,E14001156,E07000202,E10000029
+2024,2024,Ash South,Guildford,Guildford,Surrey,E05014944,E14001258,E07000209,E10000030
+2024,2024,Chadsmoor,Cannock Chase,Cannock Chase,Staffordshire,E05015743,E14001150,E07000192,E10000028
+2024,2024,Bacton,Waveney Valley,Mid Suffolk,Suffolk,E05012589,E14001569,E07000203,E10000029
+2024,2024,Barlaston,Stoke-on-Trent South,Stafford,Staffordshire,E05010479,E14001522,E07000197,E10000028
+2024,2024,Ash Vale,Guildford,Guildford,Surrey,E05014945,E14001258,E07000209,E10000030
+2024,2024,Sandford & the Wittenhams,Didcot and Wantage,South Oxfordshire,Oxfordshire,E05011708,E14001197,E07000179,E10000025
+2024,2024,Launton and Otmoor,Bicester and Woodstock,Cherwell,Oxfordshire,E05010934,E14001090,E07000177,E10000025
+2024,2024,Cannock Longford & Bridgtown,Cannock Chase,Cannock Chase,Staffordshire,E05015744,E14001150,E07000192,E10000028
+2024,2024,Battisford & Ringshall,Central Suffolk and North Ipswich,Mid Suffolk,Suffolk,E05012590,E14001156,E07000203,E10000029
+2024,2024,Baswich,Stafford,Stafford,Staffordshire,E05010480,E14001513,E07000197,E10000028
+2024,2024,Ash Wharf,Guildford,Guildford,Surrey,E05014946,E14001258,E07000209,E10000030
+2024,2024,Wallingford,Didcot and Wantage,South Oxfordshire,Oxfordshire,E05011710,E14001197,E07000179,E10000025
+2024,2024,"Adderbury, Bloxham and Bodicote",Banbury,Cherwell,Oxfordshire,E05011348,E14001072,E07000177,E10000025
+2024,2024,Cannock Park & Old Fallow,Cannock Chase,Cannock Chase,Staffordshire,E05015745,E14001150,E07000192,E10000028
+2024,2024,Blakenham,Central Suffolk and North Ipswich,Mid Suffolk,Suffolk,E05012591,E14001156,E07000203,E10000029
+2024,2024,Common,Stafford,Stafford,Staffordshire,E05010481,E14001513,E07000197,E10000028
+2024,2024,Bellfields & Slyfield,Guildford,Guildford,Surrey,E05014947,E14001258,E07000209,E10000030
+2024,2024,Burpham,Guildford,Guildford,Surrey,E05014948,E14001258,E07000209,E10000030
+2024,2024,Castle,Guildford,Guildford,Surrey,E05014949,E14001258,E07000209,E10000030
+2024,2024,Clandon & Horsley,Guildford,Guildford,Surrey,E05014950,E14001258,E07000209,E10000030
+2024,2024,Effingham,Guildford,Guildford,Surrey,E05014951,E14001258,E07000209,E10000030
+2024,2024,Merrow,Guildford,Guildford,Surrey,E05014952,E14001258,E07000209,E10000030
+2024,2024,Normandy & Pirbright,Surrey Heath,Guildford,Surrey,E05014953,E14001532,E07000209,E10000030
+2024,2024,Onslow,Guildford,Guildford,Surrey,E05014954,E14001258,E07000209,E10000030
+2024,2024,Pilgrims,Godalming and Ash,Guildford,Surrey,E05014955,E14001249,E07000209,E10000030
+2024,2024,Send & Lovelace,Guildford,Guildford,Surrey,E05014956,E14001258,E07000209,E10000030
+2024,2024,Shalford,Godalming and Ash,Guildford,Surrey,E05014957,E14001249,E07000209,E10000030
+2024,2024,St Nicolas,Guildford,Guildford,Surrey,E05014958,E14001258,E07000209,E10000030
+2024,2024,Stoke,Guildford,Guildford,Surrey,E05014959,E14001258,E07000209,E10000030
+2024,2024,Stoughton North,Guildford,Guildford,Surrey,E05014960,E14001258,E07000209,E10000030
+2024,2024,Stoughton South,Guildford,Guildford,Surrey,E05014961,E14001258,E07000209,E10000030
+2024,2024,Tillingbourne,Godalming and Ash,Guildford,Surrey,E05014962,E14001249,E07000209,E10000030
+2024,2024,Westborough,Guildford,Guildford,Surrey,E05014963,E14001258,E07000209,E10000030
+2024,2024,Worplesdon,Guildford,Guildford,Surrey,E05014964,E14001258,E07000209,E10000030
+2024,2024,Ashtead Lanes & Common,Epsom and Ewell,Mole Valley,Surrey,E05015341,E14001227,E07000210,E10000030
+2024,2024,Ashtead Park,Epsom and Ewell,Mole Valley,Surrey,E05015342,E14001227,E07000210,E10000030
+2024,2024,Bookham East & Eastwick Park,Dorking and Horley,Mole Valley,Surrey,E05015343,E14001201,E07000210,E10000030
+2024,2024,Bookham West,Dorking and Horley,Mole Valley,Surrey,E05015344,E14001201,E07000210,E10000030
+2024,2024,"Brockham, Betchworth, Buckland, Box Hill & Headley",Dorking and Horley,Mole Valley,Surrey,E05015345,E14001201,E07000210,E10000030
+2024,2024,"Brockham, Betchworth, Buckland, Box Hill & Headley",Epsom and Ewell,Mole Valley,Surrey,E05015345,E14001227,E07000210,E10000030
+2024,2024,"Capel, Leigh, Newdigate & Charlwood",Dorking and Horley,Mole Valley,Surrey,E05015346,E14001201,E07000210,E10000030
+2024,2024,Dorking North,Dorking and Horley,Mole Valley,Surrey,E05015347,E14001201,E07000210,E10000030
+2024,2024,Dorking South,Dorking and Horley,Mole Valley,Surrey,E05015348,E14001201,E07000210,E10000030
+2024,2024,Fetcham,Dorking and Horley,Mole Valley,Surrey,E05015349,E14001201,E07000210,E10000030
+2024,2024,Holmwoods & Beare Green,Dorking and Horley,Mole Valley,Surrey,E05015350,E14001201,E07000210,E10000030
+2024,2024,Leatherhead North,Epsom and Ewell,Mole Valley,Surrey,E05015351,E14001227,E07000210,E10000030
+2024,2024,Leatherhead South,Epsom and Ewell,Mole Valley,Surrey,E05015352,E14001227,E07000210,E10000030
+2024,2024,"Mickleham, Westcott & Okewood",Dorking and Horley,Mole Valley,Surrey,E05015353,E14001201,E07000210,E10000030
+2024,2024,Banstead Village,Reigate,Reigate and Banstead,Surrey,E05012872,E14001442,E07000211,E10000030
+2024,2024,"Chipstead, Kingswood & Woodmansterne",Reigate,Reigate and Banstead,Surrey,E05012873,E14001442,E07000211,E10000030
+2024,2024,Earlswood & Whitebushes,Reigate,Reigate and Banstead,Surrey,E05012874,E14001442,E07000211,E10000030
+2024,2024,"Hooley, Merstham & Netherne",East Surrey,Reigate and Banstead,Surrey,E05012875,E14001215,E07000211,E10000030
+2024,2024,Horley Central & South,Dorking and Horley,Reigate and Banstead,Surrey,E05012876,E14001201,E07000211,E10000030
+2024,2024,Horley East & Salfords,Dorking and Horley,Reigate and Banstead,Surrey,E05012877,E14001201,E07000211,E10000030
+2024,2024,Horley West & Sidlow,Dorking and Horley,Reigate and Banstead,Surrey,E05012878,E14001201,E07000211,E10000030
+2024,2024,Wheatley,Henley and Thame,South Oxfordshire,Oxfordshire,E05011711,E14001280,E07000179,E10000025
+2024,2024,Sonning Common,Henley and Thame,South Oxfordshire,Oxfordshire,E05012854,E14001280,E07000179,E10000025
+2024,2024,Henley-on-Thames,Henley and Thame,South Oxfordshire,Oxfordshire,E05015558,E14001280,E07000179,E10000025
+2024,2024,Woodcote & Rotherfield,Henley and Thame,South Oxfordshire,Oxfordshire,E05015559,E14001280,E07000179,E10000025
+2024,2024,Abingdon Abbey Northcourt,Oxford West and Abingdon,Vale of White Horse,Oxfordshire,E05009754,E14001420,E07000180,E10000025
+2024,2024,Abingdon Caldecott,Oxford West and Abingdon,Vale of White Horse,Oxfordshire,E05009755,E14001420,E07000180,E10000025
+2024,2024,Abingdon Fitzharris,Oxford West and Abingdon,Vale of White Horse,Oxfordshire,E05009757,E14001420,E07000180,E10000025
+2024,2024,Ridgeway,Didcot and Wantage,Vale of White Horse,Oxfordshire,E05009769,E14001197,E07000180,E10000025
+2024,2024,Stanford,Didcot and Wantage,Vale of White Horse,Oxfordshire,E05009770,E14001197,E07000180,E10000025
+2024,2024,Steventon & the Hanneys,Didcot and Wantage,Vale of White Horse,Oxfordshire,E05009771,E14001197,E07000180,E10000025
+2024,2024,Blewbury & Harwell,Didcot and Wantage,Vale of White Horse,Oxfordshire,E05011713,E14001197,E07000180,E10000025
+2024,2024,Cumnor,Oxford West and Abingdon,Vale of White Horse,Oxfordshire,E05011714,E14001420,E07000180,E10000025
+2024,2024,Drayton,Didcot and Wantage,Vale of White Horse,Oxfordshire,E05011715,E14001197,E07000180,E10000025
+2024,2024,Sutton Courtenay,Didcot and Wantage,Vale of White Horse,Oxfordshire,E05011717,E14001197,E07000180,E10000025
+2024,2024,Thames,Witney,Vale of White Horse,Oxfordshire,E05011718,E14001591,E07000180,E10000025
+2024,2024,Wootton,Oxford West and Abingdon,Vale of White Horse,Oxfordshire,E05011719,E14001420,E07000180,E10000025
+2024,2024,Abingdon Dunmore,Oxford West and Abingdon,Vale of White Horse,Oxfordshire,E05012970,E14001420,E07000180,E10000025
+2024,2024,Abingdon Peachcroft,Oxford West and Abingdon,Vale of White Horse,Oxfordshire,E05012971,E14001420,E07000180,E10000025
+2024,2024,Faringdon,Witney,Vale of White Horse,Oxfordshire,E05012973,E14001591,E07000180,E10000025
+2024,2024,Grove North,Didcot and Wantage,Vale of White Horse,Oxfordshire,E05012974,E14001197,E07000180,E10000025
+2024,2024,Hendreds,Didcot and Wantage,Vale of White Horse,Oxfordshire,E05012975,E14001197,E07000180,E10000025
+2024,2024,Marcham,Oxford West and Abingdon,Vale of White Horse,Oxfordshire,E05012977,E14001420,E07000180,E10000025
+2024,2024,Wantage & Grove Brook,Didcot and Wantage,Vale of White Horse,Oxfordshire,E05012978,E14001197,E07000180,E10000025
+2024,2024,Wantage Charlton,Didcot and Wantage,Vale of White Horse,Oxfordshire,E05012979,E14001197,E07000180,E10000025
+2024,2024,Watchfield & Shrivenham,Witney,Vale of White Horse,Oxfordshire,E05012980,E14001591,E07000180,E10000025
+2024,2024,Kingston Bagpuize,Witney,Vale of White Horse,Oxfordshire,E05012992,E14001591,E07000180,E10000025
+2024,2024,Botley & Sunningwell,Oxford West and Abingdon,Vale of White Horse,Oxfordshire,E05015562,E14001420,E07000180,E10000025
+2024,2024,Kennington & Radley,Oxford West and Abingdon,Vale of White Horse,Oxfordshire,E05015563,E14001420,E07000180,E10000025
+2024,2024,Alvescot and Filkins,Witney,West Oxfordshire,Oxfordshire,E05006627,E14001591,E07000181,E10000025
+2024,2024,Ascott and Shipton,Witney,West Oxfordshire,Oxfordshire,E05006628,E14001591,E07000181,E10000025
+2024,2024,Bampton and Clanfield,Witney,West Oxfordshire,Oxfordshire,E05006629,E14001591,E07000181,E10000025
+2024,2024,Carterton North East,Witney,West Oxfordshire,Oxfordshire,E05006632,E14001591,E07000181,E10000025
+2024,2024,Carterton South,Witney,West Oxfordshire,Oxfordshire,E05006634,E14001591,E07000181,E10000025
+2024,2024,Chipping Norton,Banbury,West Oxfordshire,Oxfordshire,E05006637,E14001072,E07000181,E10000025
+2024,2024,Ducklington,Witney,West Oxfordshire,Oxfordshire,E05006638,E14001591,E07000181,E10000025
+2024,2024,Eynsham and Cassington,Bicester and Woodstock,West Oxfordshire,Oxfordshire,E05006639,E14001090,E07000181,E10000025
+2024,2024,Freeland and Hanborough,Bicester and Woodstock,West Oxfordshire,Oxfordshire,E05006640,E14001090,E07000181,E10000025
+2024,2024,"Kingham, Rollright and Enstone",Banbury,West Oxfordshire,Oxfordshire,E05006642,E14001072,E07000181,E10000025
+2024,2024,Milton-under-Wychwood,Witney,West Oxfordshire,Oxfordshire,E05006643,E14001591,E07000181,E10000025
+2024,2024,North Leigh,Bicester and Woodstock,West Oxfordshire,Oxfordshire,E05006644,E14001090,E07000181,E10000025
+2024,2024,"Standlake, Aston and Stanton Harcourt",Witney,West Oxfordshire,Oxfordshire,E05006645,E14001591,E07000181,E10000025
+2024,2024,Stonesfield and Tackley,Bicester and Woodstock,West Oxfordshire,Oxfordshire,E05006646,E14001090,E07000181,E10000025
+2024,2024,The Bartons,Banbury,West Oxfordshire,Oxfordshire,E05006647,E14001072,E07000181,E10000025
+2024,2024,Witney Central,Witney,West Oxfordshire,Oxfordshire,E05006648,E14001591,E07000181,E10000025
+2024,2024,Witney East,Witney,West Oxfordshire,Oxfordshire,E05006649,E14001591,E07000181,E10000025
+2024,2024,Witney North,Witney,West Oxfordshire,Oxfordshire,E05006650,E14001591,E07000181,E10000025
+2024,2024,Witney South,Witney,West Oxfordshire,Oxfordshire,E05006651,E14001591,E07000181,E10000025
+2024,2024,Coton,Stafford,Stafford,Staffordshire,E05010482,E14001513,E07000197,E10000028
+2024,2024,Doxey & Castletown,Stafford,Stafford,Staffordshire,E05010483,E14001513,E07000197,E10000028
+2024,2024,Eccleshall,Stafford,Stafford,Staffordshire,E05010484,E14001513,E07000197,E10000028
+2024,2024,Forebridge,Stafford,Stafford,Staffordshire,E05010485,E14001513,E07000197,E10000028
+2024,2024,Fulford,Stoke-on-Trent South,Stafford,Staffordshire,E05010486,E14001522,E07000197,E10000028
+2024,2024,Gnosall & Woodseaves,Stafford,Stafford,Staffordshire,E05010487,E14001513,E07000197,E10000028
+2024,2024,Haywood & Hixon,"Stone, Great Wyrley and Penkridge",Stafford,Staffordshire,E05010488,E14001523,E07000197,E10000028
+2024,2024,Highfields & Western Downs,Stafford,Stafford,Staffordshire,E05010489,E14001513,E07000197,E10000028
+2024,2024,Holmcroft,Stafford,Stafford,Staffordshire,E05010490,E14001513,E07000197,E10000028
+2024,2024,Littleworth,Stafford,Stafford,Staffordshire,E05010491,E14001513,E07000197,E10000028
+2024,2024,Manor,Stafford,Stafford,Staffordshire,E05010492,E14001513,E07000197,E10000028
+2024,2024,Milford,"Stone, Great Wyrley and Penkridge",Stafford,Staffordshire,E05010493,E14001523,E07000197,E10000028
+2024,2024,Milwich,"Stone, Great Wyrley and Penkridge",Stafford,Staffordshire,E05010494,E14001523,E07000197,E10000028
+2024,2024,Penkside,Stafford,Stafford,Staffordshire,E05010495,E14001513,E07000197,E10000028
+2024,2024,Rowley,Stafford,Stafford,Staffordshire,E05010496,E14001513,E07000197,E10000028
+2024,2024,St Michael's & Stonefield,"Stone, Great Wyrley and Penkridge",Stafford,Staffordshire,E05010497,E14001523,E07000197,E10000028
+2024,2024,Seighford & Church Eaton,Stafford,Stafford,Staffordshire,E05010498,E14001513,E07000197,E10000028
+2024,2024,Swynnerton & Oulton,Stoke-on-Trent South,Stafford,Staffordshire,E05010499,E14001522,E07000197,E10000028
+2024,2024,Walton,"Stone, Great Wyrley and Penkridge",Stafford,Staffordshire,E05010500,E14001523,E07000197,E10000028
+2024,2024,Weeping Cross & Wildwood,Stafford,Stafford,Staffordshire,E05010501,E14001513,E07000197,E10000028
+2024,2024,Alton,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007039,E14001514,E07000198,E10000028
+2024,2024,Bagnall and Stanley,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007040,E14001514,E07000198,E10000028
+2024,2024,Biddulph East,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007041,E14001514,E07000198,E10000028
+2024,2024,Biddulph Moor,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007042,E14001514,E07000198,E10000028
+2024,2024,Biddulph North,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007043,E14001514,E07000198,E10000028
+2024,2024,Biddulph South,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007044,E14001514,E07000198,E10000028
+2024,2024,Biddulph West,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007045,E14001514,E07000198,E10000028
+2024,2024,Brown Edge and Endon,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007046,E14001514,E07000198,E10000028
+2024,2024,Caverswall,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007047,E14001514,E07000198,E10000028
+2024,2024,Cellarhead,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007048,E14001514,E07000198,E10000028
+2024,2024,Cheadle North East,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007049,E14001514,E07000198,E10000028
+2024,2024,Cheadle South East,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007050,E14001514,E07000198,E10000028
+2024,2024,Cheadle West,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007051,E14001514,E07000198,E10000028
+2024,2024,Checkley,Stoke-on-Trent South,Staffordshire Moorlands,Staffordshire,E05007052,E14001522,E07000198,E10000028
+2024,2024,Cheddleton,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007053,E14001514,E07000198,E10000028
+2024,2024,Churnet,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007054,E14001514,E07000198,E10000028
+2024,2024,Dane,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007055,E14001514,E07000198,E10000028
+2024,2024,Forsbrook,Stoke-on-Trent South,Staffordshire Moorlands,Staffordshire,E05007056,E14001522,E07000198,E10000028
+2024,2024,Hamps Valley,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007057,E14001514,E07000198,E10000028
+2024,2024,Horton,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007058,E14001514,E07000198,E10000028
+2024,2024,Ipstones,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007059,E14001514,E07000198,E10000028
+2024,2024,Leek East,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007060,E14001514,E07000198,E10000028
+2024,2024,Leek North,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007061,E14001514,E07000198,E10000028
+2024,2024,Leek South,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007062,E14001514,E07000198,E10000028
+2024,2024,Leek West,Staffordshire Moorlands,Staffordshire Moorlands,Staffordshire,E05007063,E14001514,E07000198,E10000028
+2024,2024,Banbury Calthorpe and Easington,Banbury,Cherwell,Oxfordshire,E05011349,E14001072,E07000177,E10000025
+2024,2024,Bramford,Central Suffolk and North Ipswich,Mid Suffolk,Suffolk,E05012592,E14001156,E07000203,E10000029
+2024,2024,Etching Hill & the Heath,Cannock Chase,Cannock Chase,Staffordshire,E05015746,E14001150,E07000192,E10000028
+2024,2024,Highfield,Lichfield,Lichfield,Staffordshire,E05010663,E14001335,E07000194,E10000028
+2024,2024,Chilton,Bury St Edmunds and Stowmarket,Mid Suffolk,Suffolk,E05012593,E14001146,E07000203,E10000029
+2024,2024,Claydon & Barham,Central Suffolk and North Ipswich,Mid Suffolk,Suffolk,E05012594,E14001156,E07000203,E10000029
+2024,2024,Combs Ford,Bury St Edmunds and Stowmarket,Mid Suffolk,Suffolk,E05012595,E14001146,E07000203,E10000029
+2024,2024,Debenham,Central Suffolk and North Ipswich,Mid Suffolk,Suffolk,E05012596,E14001156,E07000203,E10000029
+2024,2024,Elmswell & Woolpit,Bury St Edmunds and Stowmarket,Mid Suffolk,Suffolk,E05012597,E14001146,E07000203,E10000029
+2024,2024,Eye,Waveney Valley,Mid Suffolk,Suffolk,E05012598,E14001569,E07000203,E10000029
+2024,2024,Fressingfield,Waveney Valley,Mid Suffolk,Suffolk,E05012599,E14001569,E07000203,E10000029
+2024,2024,Gislingham,Waveney Valley,Mid Suffolk,Suffolk,E05012600,E14001569,E07000203,E10000029
+2024,2024,"Haughley, Stowupland & Wetherden",Waveney Valley,Mid Suffolk,Suffolk,E05012601,E14001569,E07000203,E10000029
+2024,2024,Hoxne & Worlingworth,Waveney Valley,Mid Suffolk,Suffolk,E05012602,E14001569,E07000203,E10000029
+2024,2024,Mendlesham,Waveney Valley,Mid Suffolk,Suffolk,E05012603,E14001569,E07000203,E10000029
+2024,2024,Needham Market,Central Suffolk and North Ipswich,Mid Suffolk,Suffolk,E05012604,E14001156,E07000203,E10000029
+2024,2024,Onehouse,Bury St Edmunds and Stowmarket,Mid Suffolk,Suffolk,E05012605,E14001146,E07000203,E10000029
+2024,2024,Palgrave,Waveney Valley,Mid Suffolk,Suffolk,E05012606,E14001569,E07000203,E10000029
+2024,2024,Rattlesden,Bury St Edmunds and Stowmarket,Mid Suffolk,Suffolk,E05012607,E14001146,E07000203,E10000029
+2024,2024,Rickinghall,Waveney Valley,Mid Suffolk,Suffolk,E05012608,E14001569,E07000203,E10000029
+2024,2024,St Peter's,Bury St Edmunds and Stowmarket,Mid Suffolk,Suffolk,E05012609,E14001146,E07000203,E10000029
+2024,2024,Stonham,Central Suffolk and North Ipswich,Mid Suffolk,Suffolk,E05012610,E14001156,E07000203,E10000029
+2024,2024,Stow Thorney,Bury St Edmunds and Stowmarket,Mid Suffolk,Suffolk,E05012611,E14001146,E07000203,E10000029
+2024,2024,Stradbroke & Laxfield,Waveney Valley,Mid Suffolk,Suffolk,E05012612,E14001569,E07000203,E10000029
+2024,2024,Thurston,Bury St Edmunds and Stowmarket,Mid Suffolk,Suffolk,E05012613,E14001146,E07000203,E10000029
+2024,2024,Walsham-le-Willows,Waveney Valley,Mid Suffolk,Suffolk,E05012614,E14001569,E07000203,E10000029
+2024,2024,Claygate,Esher and Walton,Elmbridge,Surrey,E05011074,E14001230,E07000207,E10000030
+2024,2024,Cobham and Downside,Runnymede and Weybridge,Elmbridge,Surrey,E05011075,E14001456,E07000207,E10000030
+2024,2024,Esher,Esher and Walton,Elmbridge,Surrey,E05011076,E14001230,E07000207,E10000030
+2024,2024,Hersham Village,Esher and Walton,Elmbridge,Surrey,E05011077,E14001230,E07000207,E10000030
+2024,2024,Hinchley Wood and Weston Green,Esher and Walton,Elmbridge,Surrey,E05011078,E14001230,E07000207,E10000030
+2024,2024,Long Ditton,Esher and Walton,Elmbridge,Surrey,E05011079,E14001230,E07000207,E10000030
+2024,2024,Molesey East,Esher and Walton,Elmbridge,Surrey,E05011080,E14001230,E07000207,E10000030
+2024,2024,Molesey West,Esher and Walton,Elmbridge,Surrey,E05011081,E14001230,E07000207,E10000030
+2024,2024,Oatlands and Burwood Park,Esher and Walton,Elmbridge,Surrey,E05011082,E14001230,E07000207,E10000030
+2024,2024,Oxshott and Stoke D'Abernon,Runnymede and Weybridge,Elmbridge,Surrey,E05011083,E14001456,E07000207,E10000030
+2024,2024,Thames Ditton,Esher and Walton,Elmbridge,Surrey,E05011084,E14001230,E07000207,E10000030
+2024,2024,Walton Central,Esher and Walton,Elmbridge,Surrey,E05011085,E14001230,E07000207,E10000030
+2024,2024,Walton North,Esher and Walton,Elmbridge,Surrey,E05011086,E14001230,E07000207,E10000030
+2024,2024,Walton South,Esher and Walton,Elmbridge,Surrey,E05011087,E14001230,E07000207,E10000030
+2024,2024,Weybridge Riverside,Runnymede and Weybridge,Elmbridge,Surrey,E05011088,E14001456,E07000207,E10000030
+2024,2024,Weybridge St George's Hill,Runnymede and Weybridge,Elmbridge,Surrey,E05011089,E14001456,E07000207,E10000030
+2024,2024,Hawks Green with Rumer Hill,Cannock Chase,Cannock Chase,Staffordshire,E05015747,E14001150,E07000192,E10000028
+2024,2024,Bicester South and Ambrosden,Bicester and Woodstock,Cherwell,Oxfordshire,E05012968,E14001090,E07000177,E10000025
+2024,2024,Leomansley,Lichfield,Lichfield,Staffordshire,E05010664,E14001335,E07000194,E10000028
+2024,2024,Auriol,Epsom and Ewell,Epsom and Ewell,Surrey,E05015093,E14001227,E07000208,E10000030
+2024,2024,College,Epsom and Ewell,Epsom and Ewell,Surrey,E05015094,E14001227,E07000208,E10000030
+2024,2024,Court,Epsom and Ewell,Epsom and Ewell,Surrey,E05015095,E14001227,E07000208,E10000030
+2024,2024,Cuddington,Epsom and Ewell,Epsom and Ewell,Surrey,E05015096,E14001227,E07000208,E10000030
+2024,2024,Ewell Court,Epsom and Ewell,Epsom and Ewell,Surrey,E05015097,E14001227,E07000208,E10000030
+2024,2024,Ewell Village,Epsom and Ewell,Epsom and Ewell,Surrey,E05015098,E14001227,E07000208,E10000030
+2024,2024,Little Aston & Stonnall,Tamworth,Lichfield,Staffordshire,E05010665,E14001538,E07000194,E10000028
+2024,2024,Longdon,Lichfield,Lichfield,Staffordshire,E05010666,E14001335,E07000194,E10000028
+2024,2024,Mease Valley,Tamworth,Lichfield,Staffordshire,E05010667,E14001538,E07000194,E10000028
+2024,2024,St John's,Lichfield,Lichfield,Staffordshire,E05010668,E14001335,E07000194,E10000028
+2024,2024,Shenstone,Tamworth,Lichfield,Staffordshire,E05010669,E14001538,E07000194,E10000028
+2024,2024,Stowe,Lichfield,Lichfield,Staffordshire,E05010670,E14001335,E07000194,E10000028
+2024,2024,Summerfield & All Saints,Lichfield,Lichfield,Staffordshire,E05010671,E14001335,E07000194,E10000028
+2024,2024,Whittington & Streethay,Lichfield,Lichfield,Staffordshire,E05010672,E14001335,E07000194,E10000028
+2024,2024,Whittington & Streethay,Tamworth,Lichfield,Staffordshire,E05010672,E14001538,E07000194,E10000028
+2024,2024,Audley,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011415,E14001380,E07000195,E10000028
+2024,2024,Bradwell,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011416,E14001380,E07000195,E10000028
+2024,2024,Clayton,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011417,E14001380,E07000195,E10000028
+2024,2024,Crackley & Red Street,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011418,E14001380,E07000195,E10000028
+2024,2024,Cross Heath,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011419,E14001380,E07000195,E10000028
+2024,2024,Holditch & Chesterton,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011420,E14001380,E07000195,E10000028
+2024,2024,Keele,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011421,E14001380,E07000195,E10000028
+2024,2024,Kidsgrove & Ravenscliffe,Stoke-on-Trent North,Newcastle-under-Lyme,Staffordshire,E05011422,E14001521,E07000195,E10000028
+2024,2024,Knutton,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011423,E14001380,E07000195,E10000028
+2024,2024,Loggerheads,Stafford,Newcastle-under-Lyme,Staffordshire,E05011424,E14001513,E07000195,E10000028
+2024,2024,Madeley & Betley,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011425,E14001380,E07000195,E10000028
+2024,2024,Maer & Whitmore,Stafford,Newcastle-under-Lyme,Staffordshire,E05011426,E14001513,E07000195,E10000028
+2024,2024,May Bank,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011427,E14001380,E07000195,E10000028
+2024,2024,Newchapel & Mow Cop,Stoke-on-Trent North,Newcastle-under-Lyme,Staffordshire,E05011428,E14001521,E07000195,E10000028
+2024,2024,Silverdale,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011429,E14001380,E07000195,E10000028
+2024,2024,Talke & Butt Lane,Stoke-on-Trent North,Newcastle-under-Lyme,Staffordshire,E05011430,E14001521,E07000195,E10000028
+2024,2024,Thistleberry,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011431,E14001380,E07000195,E10000028
+2024,2024,Town,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011432,E14001380,E07000195,E10000028
+2024,2024,Westbury Park & Northwood,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011433,E14001380,E07000195,E10000028
+2024,2024,Westlands,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011434,E14001380,E07000195,E10000028
+2024,2024,Wolstanton,Newcastle-under-Lyme,Newcastle-under-Lyme,Staffordshire,E05011435,E14001380,E07000195,E10000028
+2024,2024,Bilbrook,Kingswinford and South Staffordshire,South Staffordshire,Staffordshire,E05015054,E14001316,E07000196,E10000028
+2024,2024,"Brewood, Coven & Blymhill","Stone, Great Wyrley and Penkridge",South Staffordshire,Staffordshire,E05015055,E14001523,E07000196,E10000028
+2024,2024,Cheslyn Hay Village,"Stone, Great Wyrley and Penkridge",South Staffordshire,Staffordshire,E05015056,E14001523,E07000196,E10000028
+2024,2024,Codsall,Kingswinford and South Staffordshire,South Staffordshire,Staffordshire,E05015057,E14001316,E07000196,E10000028
+2024,2024,Essington,"Stone, Great Wyrley and Penkridge",South Staffordshire,Staffordshire,E05015058,E14001523,E07000196,E10000028
+2024,2024,"Featherstone, Sharehill & Saredon","Stone, Great Wyrley and Penkridge",South Staffordshire,Staffordshire,E05015059,E14001523,E07000196,E10000028
+2024,2024,Great Wyrley Landywood,"Stone, Great Wyrley and Penkridge",South Staffordshire,Staffordshire,E05015060,E14001523,E07000196,E10000028
+2024,2024,Great Wyrley Town,"Stone, Great Wyrley and Penkridge",South Staffordshire,Staffordshire,E05015061,E14001523,E07000196,E10000028
+2024,2024,Himley & Swindon,Kingswinford and South Staffordshire,South Staffordshire,Staffordshire,E05015062,E14001316,E07000196,E10000028
+2024,2024,Huntington & Hatherton,"Stone, Great Wyrley and Penkridge",South Staffordshire,Staffordshire,E05015063,E14001523,E07000196,E10000028
+2024,2024,Kinver & Enville,Kingswinford and South Staffordshire,South Staffordshire,Staffordshire,E05015064,E14001316,E07000196,E10000028
+2024,2024,"Lapley, Stretton & Wheaton Aston","Stone, Great Wyrley and Penkridge",South Staffordshire,Staffordshire,E05015065,E14001523,E07000196,E10000028
+2024,2024,"Pattingham, Trysull, Bobbington & Lower Penn",Kingswinford and South Staffordshire,South Staffordshire,Staffordshire,E05015066,E14001316,E07000196,E10000028
+2024,2024,Penkridge North & Acton Trussell,"Stone, Great Wyrley and Penkridge",South Staffordshire,Staffordshire,E05015067,E14001523,E07000196,E10000028
+2024,2024,Penkridge South & Gailey,"Stone, Great Wyrley and Penkridge",South Staffordshire,Staffordshire,E05015068,E14001523,E07000196,E10000028
+2024,2024,Perton East,Kingswinford and South Staffordshire,South Staffordshire,Staffordshire,E05015069,E14001316,E07000196,E10000028
+2024,2024,Perton Lakeside,Kingswinford and South Staffordshire,South Staffordshire,Staffordshire,E05015070,E14001316,E07000196,E10000028
+2024,2024,Perton Wrottesley,Kingswinford and South Staffordshire,South Staffordshire,Staffordshire,E05015071,E14001316,E07000196,E10000028
+2024,2024,Fringford and Heyfords,Bicester and Woodstock,Cherwell,Oxfordshire,E05012969,E14001090,E07000177,E10000025
+2024,2024,Heath Hayes & Wimblebury,Cannock Chase,Cannock Chase,Staffordshire,E05015748,E14001150,E07000192,E10000028
+2024,2024,Barton & Sandhills,Oxford East,Oxford,Oxfordshire,E05013096,E14001419,E07000178,E10000025
+2024,2024,Blackbird Leys,Oxford East,Oxford,Oxfordshire,E05013097,E14001419,E07000178,E10000025
+2024,2024,Carfax & Jericho,Oxford West and Abingdon,Oxford,Oxfordshire,E05013098,E14001420,E07000178,E10000025
+2024,2024,Churchill,Oxford East,Oxford,Oxfordshire,E05013099,E14001419,E07000178,E10000025
+2024,2024,Cowley,Oxford East,Oxford,Oxfordshire,E05013100,E14001419,E07000178,E10000025
+2024,2024,Cutteslowe & Sunnymead,Oxford West and Abingdon,Oxford,Oxfordshire,E05013101,E14001420,E07000178,E10000025
+2024,2024,Donnington,Oxford East,Oxford,Oxfordshire,E05013102,E14001419,E07000178,E10000025
+2024,2024,Headington,Oxford East,Oxford,Oxfordshire,E05013103,E14001419,E07000178,E10000025
+2024,2024,Headington Hill & Northway,Oxford East,Oxford,Oxfordshire,E05013104,E14001419,E07000178,E10000025
+2024,2024,Hinksey Park,Oxford East,Oxford,Oxfordshire,E05013105,E14001419,E07000178,E10000025
+2024,2024,Hednesford Green Heath,Cannock Chase,Cannock Chase,Staffordshire,E05015749,E14001150,E07000192,E10000028
+2024,2024,Holywell,Oxford West and Abingdon,Oxford,Oxfordshire,E05013106,E14001420,E07000178,E10000025
+2024,2024,Hednesford Hills & Rawnsley,Cannock Chase,Cannock Chase,Staffordshire,E05015750,E14001150,E07000192,E10000028
+2024,2024,Hednesford Pye Green,Cannock Chase,Cannock Chase,Staffordshire,E05015751,E14001150,E07000192,E10000028
+2024,2024,Littlemore,Oxford East,Oxford,Oxfordshire,E05013107,E14001419,E07000178,E10000025
+2024,2024,Norton Canes,Cannock Chase,Cannock Chase,Staffordshire,E05015752,E14001150,E07000192,E10000028
+2024,2024,Lye Valley,Oxford East,Oxford,Oxfordshire,E05013108,E14001419,E07000178,E10000025
+2024,2024,Western Springs,Cannock Chase,Cannock Chase,Staffordshire,E05015753,E14001150,E07000192,E10000028
+2024,2024,Marston,Oxford East,Oxford,Oxfordshire,E05013109,E14001419,E07000178,E10000025
+2024,2024,Anglesey,Lichfield,East Staffordshire,Staffordshire,E05014473,E14001335,E07000193,E10000028
+2024,2024,Northfield Brook,Oxford East,Oxford,Oxfordshire,E05013110,E14001419,E07000178,E10000025
+2024,2024,Bagots & Needwood,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014474,E14001143,E07000193,E10000028
+2024,2024,Osney & St Thomas,Oxford West and Abingdon,Oxford,Oxfordshire,E05013111,E14001420,E07000178,E10000025
+2024,2024,Blythe,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014475,E14001143,E07000193,E10000028
+2024,2024,Quarry & Risinghurst,Oxford East,Oxford,Oxfordshire,E05013112,E14001419,E07000178,E10000025
+2024,2024,Blythe,Lichfield,East Staffordshire,Staffordshire,E05014475,E14001335,E07000193,E10000028
+2024,2024,Rose Hill & Iffley,Oxford East,Oxford,Oxfordshire,E05013113,E14001419,E07000178,E10000025
+2024,2024,Branston,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014476,E14001143,E07000193,E10000028
+2024,2024,St Clement's,Oxford East,Oxford,Oxfordshire,E05013114,E14001419,E07000178,E10000025
+2024,2024,Brizlincote,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014477,E14001143,E07000193,E10000028
+2024,2024,St Mary's,Oxford East,Oxford,Oxfordshire,E05013115,E14001419,E07000178,E10000025
+2024,2024,Burton & Eton,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014478,E14001143,E07000193,E10000028
+2024,2024,Summertown,Oxford West and Abingdon,Oxford,Oxfordshire,E05013116,E14001420,E07000178,E10000025
+2024,2024,Crown,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014479,E14001143,E07000193,E10000028
+2024,2024,Temple Cowley,Oxford East,Oxford,Oxfordshire,E05013117,E14001419,E07000178,E10000025
+2024,2024,Crown,Lichfield,East Staffordshire,Staffordshire,E05014479,E14001335,E07000193,E10000028
+2024,2024,Walton Manor,Oxford West and Abingdon,Oxford,Oxfordshire,E05013118,E14001420,E07000178,E10000025
+2024,2024,Dove,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014480,E14001143,E07000193,E10000028
+2024,2024,Wolvercote,Oxford West and Abingdon,Oxford,Oxfordshire,E05013119,E14001420,E07000178,E10000025
+2024,2024,Heath,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014481,E14001143,E07000193,E10000028
+2024,2024,Benson & Crowmarsh,Henley and Thame,South Oxfordshire,Oxfordshire,E05009733,E14001280,E07000179,E10000025
+2024,2024,Horninglow & Outwoods,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014482,E14001143,E07000193,E10000028
+2024,2024,Berinsfield,Henley and Thame,South Oxfordshire,Oxfordshire,E05009734,E14001280,E07000179,E10000025
+2024,2024,Shobnall,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014483,E14001143,E07000193,E10000028
+2024,2024,Stapenhill,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014484,E14001143,E07000193,E10000028
+2024,2024,Chalgrove,Henley and Thame,South Oxfordshire,Oxfordshire,E05009735,E14001280,E07000179,E10000025
+2024,2024,Stramshall & Weaver,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014485,E14001143,E07000193,E10000028
+2024,2024,Chinnor,Henley and Thame,South Oxfordshire,Oxfordshire,E05009736,E14001280,E07000179,E10000025
+2024,2024,Stretton,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014486,E14001143,E07000193,E10000028
+2024,2024,Didcot West,Didcot and Wantage,South Oxfordshire,Oxfordshire,E05009740,E14001197,E07000179,E10000025
+2024,2024,Town,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014487,E14001143,E07000193,E10000028
+2024,2024,Garsington & Horspath,Henley and Thame,South Oxfordshire,Oxfordshire,E05009742,E14001280,E07000179,E10000025
+2024,2024,Winshill,Burton and Uttoxeter,East Staffordshire,Staffordshire,E05014488,E14001143,E07000193,E10000028
+2024,2024,Goring,Henley and Thame,South Oxfordshire,Oxfordshire,E05009743,E14001280,E07000179,E10000025
+2024,2024,Alrewas & Fradley,Lichfield,Lichfield,Staffordshire,E05010651,E14001335,E07000194,E10000028
+2024,2024,Thame,Henley and Thame,South Oxfordshire,Oxfordshire,E05009749,E14001280,E07000179,E10000025
+2024,2024,Armitage with Handsacre,Lichfield,Lichfield,Staffordshire,E05010652,E14001335,E07000194,E10000028
+2024,2024,Watlington,Henley and Thame,South Oxfordshire,Oxfordshire,E05009751,E14001280,E07000179,E10000025
+2024,2024,Boley Park,Lichfield,Lichfield,Staffordshire,E05010653,E14001335,E07000194,E10000028
+2024,2024,Cholsey,Didcot and Wantage,South Oxfordshire,Oxfordshire,E05011701,E14001197,E07000179,E10000025
+2024,2024,Boney Hay & Central,Lichfield,Lichfield,Staffordshire,E05010654,E14001335,E07000194,E10000028
+2024,2024,Didcot North East,Didcot and Wantage,South Oxfordshire,Oxfordshire,E05011702,E14001197,E07000179,E10000025
+2024,2024,Bourne Vale,Tamworth,Lichfield,Staffordshire,E05010655,E14001538,E07000194,E10000028
+2024,2024,Didcot South,Didcot and Wantage,South Oxfordshire,Oxfordshire,E05011703,E14001197,E07000179,E10000025
+2024,2024,Chadsmead,Lichfield,Lichfield,Staffordshire,E05010656,E14001335,E07000194,E10000028
+2024,2024,Forest Hill & Holton,Henley and Thame,South Oxfordshire,Oxfordshire,E05011704,E14001280,E07000179,E10000025
+2024,2024,Chase Terrace,Lichfield,Lichfield,Staffordshire,E05010657,E14001335,E07000194,E10000028
+2024,2024,Haseley Brook,Henley and Thame,South Oxfordshire,Oxfordshire,E05011705,E14001280,E07000179,E10000025
+2024,2024,Chasetown,Lichfield,Lichfield,Staffordshire,E05010658,E14001335,E07000194,E10000028
+2024,2024,Colton & the Ridwares,Lichfield,Lichfield,Staffordshire,E05010659,E14001335,E07000194,E10000028
+2024,2024,Curborough,Lichfield,Lichfield,Staffordshire,E05010660,E14001335,E07000194,E10000028
+2024,2024,Fazeley,Tamworth,Lichfield,Staffordshire,E05010661,E14001538,E07000194,E10000028
+2024,2024,Hammerwich with Wall,Lichfield,Lichfield,Staffordshire,E05010662,E14001335,E07000194,E10000028
+2024,2024,Mount Hermon,Woking,Woking,Surrey,E05010802,E14001592,E07000217,E10000030
+2024,2024,Pyrford,Woking,Woking,Surrey,E05010803,E14001592,E07000217,E10000030
+2024,2024,St John's,Woking,Woking,Surrey,E05010804,E14001592,E07000217,E10000030
+2024,2024,Arley and Whitacre,Nuneaton,North Warwickshire,Warwickshire,E05007457,E14001413,E07000218,E10000031
+2024,2024,Rustington East,Bognor Regis and Littlehampton,Arun,West Sussex,E05009820,E14001108,E07000224,E10000032
+2024,2024,Rokeby and Overslade,Rugby,Rugby,Warwickshire,E05008985,E14001453,E07000220,E10000031
+2024,2024,Atherstone Central,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007458,E14001400,E07000218,E10000031
+2024,2024,Atherstone North,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007459,E14001400,E07000218,E10000031
+2024,2024,Atherstone South and Mancetter,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007460,E14001400,E07000218,E10000031
+2024,2024,Baddesley and Grendon,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007461,E14001400,E07000218,E10000031
+2024,2024,Coleshill North,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007462,E14001400,E07000218,E10000031
+2024,2024,Coleshill South,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007463,E14001400,E07000218,E10000031
+2024,2024,Curdworth,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007464,E14001400,E07000218,E10000031
+2024,2024,Dordon,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007465,E14001400,E07000218,E10000031
+2024,2024,Fillongley,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007466,E14001400,E07000218,E10000031
+2024,2024,Hartshill,Nuneaton,North Warwickshire,Warwickshire,E05007467,E14001413,E07000218,E10000031
+2024,2024,Hurley and Wood End,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007468,E14001400,E07000218,E10000031
+2024,2024,Kingsbury,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007469,E14001400,E07000218,E10000031
+2024,2024,Newton Regis and Warton,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007470,E14001400,E07000218,E10000031
+2024,2024,Polesworth East,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007471,E14001400,E07000218,E10000031
+2024,2024,Polesworth West,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007472,E14001400,E07000218,E10000031
+2024,2024,Water Orton,North Warwickshire and Bedworth,North Warwickshire,Warwickshire,E05007473,E14001400,E07000218,E10000031
+2024,2024,Arbury,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015827,E14001413,E07000219,E10000031
+2024,2024,Attleborough,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015828,E14001413,E07000219,E10000031
+2024,2024,Bede,North Warwickshire and Bedworth,Nuneaton and Bedworth,Warwickshire,E05015829,E14001400,E07000219,E10000031
+2024,2024,Bulkington,Rugby,Nuneaton and Bedworth,Warwickshire,E05015830,E14001453,E07000219,E10000031
+2024,2024,Camp Hill,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015831,E14001413,E07000219,E10000031
+2024,2024,Chilvers Coton,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015832,E14001413,E07000219,E10000031
+2024,2024,Eastboro,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015833,E14001413,E07000219,E10000031
+2024,2024,Exhall,North Warwickshire and Bedworth,Nuneaton and Bedworth,Warwickshire,E05015834,E14001400,E07000219,E10000031
+2024,2024,Galley Common,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015835,E14001413,E07000219,E10000031
+2024,2024,Heath,North Warwickshire and Bedworth,Nuneaton and Bedworth,Warwickshire,E05015836,E14001400,E07000219,E10000031
+2024,2024,Milby,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015837,E14001413,E07000219,E10000031
+2024,2024,Poplar,North Warwickshire and Bedworth,Nuneaton and Bedworth,Warwickshire,E05015838,E14001400,E07000219,E10000031
+2024,2024,Slough,North Warwickshire and Bedworth,Nuneaton and Bedworth,Warwickshire,E05015839,E14001400,E07000219,E10000031
+2024,2024,St Mary's,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015840,E14001413,E07000219,E10000031
+2024,2024,St Nicolas,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015841,E14001413,E07000219,E10000031
+2024,2024,Stockingford East,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015842,E14001413,E07000219,E10000031
+2024,2024,Stockingford West,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015843,E14001413,E07000219,E10000031
+2024,2024,Weddington,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015844,E14001413,E07000219,E10000031
+2024,2024,Whitestone,Nuneaton,Nuneaton and Bedworth,Warwickshire,E05015845,E14001413,E07000219,E10000031
+2024,2024,Whitestone,Rugby,Nuneaton and Bedworth,Warwickshire,E05015845,E14001453,E07000219,E10000031
+2024,2024,Benn,Rugby,Rugby,Warwickshire,E05008974,E14001453,E07000220,E10000031
+2024,2024,Bilton,Rugby,Rugby,Warwickshire,E05008975,E14001453,E07000220,E10000031
+2024,2024,"Clifton, Newton and Churchover",Rugby,Rugby,Warwickshire,E05008976,E14001453,E07000220,E10000031
+2024,2024,Coton and Boughton,Rugby,Rugby,Warwickshire,E05008977,E14001453,E07000220,E10000031
+2024,2024,Hillmorton,Rugby,Rugby,Warwickshire,E05008979,E14001453,E07000220,E10000031
+2024,2024,Leam Valley,Kenilworth and Southam,Rugby,Warwickshire,E05008980,E14001309,E07000220,E10000031
+2024,2024,New Bilton,Rugby,Rugby,Warwickshire,E05008981,E14001453,E07000220,E10000031
+2024,2024,Newbold and Brownsover,Rugby,Rugby,Warwickshire,E05008982,E14001453,E07000220,E10000031
+2024,2024,Paddox,Rugby,Rugby,Warwickshire,E05008983,E14001453,E07000220,E10000031
+2024,2024,Revel and Binley Woods,Rugby,Rugby,Warwickshire,E05008984,E14001453,E07000220,E10000031
+2024,2024,"Lower Kingswood, Tadworth & Walton",Reigate,Reigate and Banstead,Surrey,E05012879,E14001442,E07000211,E10000030
+2024,2024,"Pulborough, Coldwaltham & Amberley",Arundel and South Downs,Horsham,West Sussex,E05011824,E14001067,E07000227,E10000032
+2024,2024,Cubbington & Leek Wootton,Kenilworth and Southam,Warwick,Warwickshire,E05012617,E14001309,E07000222,E10000031
+2024,2024,"Burstow, Horne & Outwood",East Surrey,Tandridge,Surrey,E05015886,E14001215,E07000215,E10000030
+2024,2024,Selden,East Worthing and Shoreham,Worthing,West Sussex,E05007705,E14001218,E07000229,E10000032
+2024,2024,Kenilworth Abbey & Arden,Kenilworth and Southam,Warwick,Warwickshire,E05012618,E14001309,E07000222,E10000031
+2024,2024,Kenilworth Park Hill,Kenilworth and Southam,Warwick,Warwickshire,E05012619,E14001309,E07000222,E10000031
+2024,2024,Kenilworth St John's,Kenilworth and Southam,Warwick,Warwickshire,E05012620,E14001309,E07000222,E10000031
+2024,2024,Leamington Brunswick,Warwick and Leamington,Warwick,Warwickshire,E05012621,E14001566,E07000222,E10000031
+2024,2024,Leamington Clarendon,Warwick and Leamington,Warwick,Warwickshire,E05012622,E14001566,E07000222,E10000031
+2024,2024,Leamington Lillington,Warwick and Leamington,Warwick,Warwickshire,E05012623,E14001566,E07000222,E10000031
+2024,2024,Leamington Milverton,Warwick and Leamington,Warwick,Warwickshire,E05012624,E14001566,E07000222,E10000031
+2024,2024,Leamington Willes,Warwick and Leamington,Warwick,Warwickshire,E05012625,E14001566,E07000222,E10000031
+2024,2024,Radford Semele,Warwick and Leamington,Warwick,Warwickshire,E05012626,E14001566,E07000222,E10000031
+2024,2024,Warwick All Saints & Woodloes,Warwick and Leamington,Warwick,Warwickshire,E05012627,E14001566,E07000222,E10000031
+2024,2024,Warwick Aylesford,Warwick and Leamington,Warwick,Warwickshire,E05012628,E14001566,E07000222,E10000031
+2024,2024,Warwick Myton & Heathcote,Warwick and Leamington,Warwick,Warwickshire,E05012629,E14001566,E07000222,E10000031
+2024,2024,Warwick Saltisford,Warwick and Leamington,Warwick,Warwickshire,E05012630,E14001566,E07000222,E10000031
+2024,2024,Whitnash,Warwick and Leamington,Warwick,Warwickshire,E05012631,E14001566,E07000222,E10000031
+2024,2024,Buckingham,East Worthing and Shoreham,Adur,West Sussex,E05007562,E14001218,E07000223,E10000032
+2024,2024,Churchill,East Worthing and Shoreham,Adur,West Sussex,E05007563,E14001218,E07000223,E10000032
+2024,2024,Cokeham,East Worthing and Shoreham,Adur,West Sussex,E05007564,E14001218,E07000223,E10000032
+2024,2024,Eastbrook,East Worthing and Shoreham,Adur,West Sussex,E05007565,E14001218,E07000223,E10000032
+2024,2024,Hillside,East Worthing and Shoreham,Adur,West Sussex,E05007566,E14001218,E07000223,E10000032
+2024,2024,Manor,East Worthing and Shoreham,Adur,West Sussex,E05007567,E14001218,E07000223,E10000032
+2024,2024,Marine,East Worthing and Shoreham,Adur,West Sussex,E05007568,E14001218,E07000223,E10000032
+2024,2024,Mash Barn,East Worthing and Shoreham,Adur,West Sussex,E05007569,E14001218,E07000223,E10000032
+2024,2024,Peverel,East Worthing and Shoreham,Adur,West Sussex,E05007570,E14001218,E07000223,E10000032
+2024,2024,St Mary's,East Worthing and Shoreham,Adur,West Sussex,E05007571,E14001218,E07000223,E10000032
+2024,2024,St Nicolas,East Worthing and Shoreham,Adur,West Sussex,E05007572,E14001218,E07000223,E10000032
+2024,2024,Southlands,East Worthing and Shoreham,Adur,West Sussex,E05007573,E14001218,E07000223,E10000032
+2024,2024,Southwick Green,East Worthing and Shoreham,Adur,West Sussex,E05007574,E14001218,E07000223,E10000032
+2024,2024,Widewater,East Worthing and Shoreham,Adur,West Sussex,E05007575,E14001218,E07000223,E10000032
+2024,2024,Aldwick East,Bognor Regis and Littlehampton,Arun,West Sussex,E05009800,E14001108,E07000224,E10000032
+2024,2024,Aldwick West,Bognor Regis and Littlehampton,Arun,West Sussex,E05009801,E14001108,E07000224,E10000032
+2024,2024,Angmering & Findon,Worthing West,Arun,West Sussex,E05009802,E14001599,E07000224,E10000032
+2024,2024,Arundel & Walberton,Arundel and South Downs,Arun,West Sussex,E05009803,E14001067,E07000224,E10000032
+2024,2024,Barnham,Arundel and South Downs,Arun,West Sussex,E05009804,E14001067,E07000224,E10000032
+2024,2024,Beach,Bognor Regis and Littlehampton,Arun,West Sussex,E05009805,E14001108,E07000224,E10000032
+2024,2024,Bersted,Chichester,Arun,West Sussex,E05009806,E14001166,E07000224,E10000032
+2024,2024,Brookfield,Bognor Regis and Littlehampton,Arun,West Sussex,E05009807,E14001108,E07000224,E10000032
+2024,2024,Courtwick with Toddington,Bognor Regis and Littlehampton,Arun,West Sussex,E05009808,E14001108,E07000224,E10000032
+2024,2024,East Preston,Worthing West,Arun,West Sussex,E05009809,E14001599,E07000224,E10000032
+2024,2024,Felpham East,Arundel and South Downs,Arun,West Sussex,E05009810,E14001067,E07000224,E10000032
+2024,2024,Felpham East,Bognor Regis and Littlehampton,Arun,West Sussex,E05009810,E14001108,E07000224,E10000032
+2024,2024,Felpham West,Bognor Regis and Littlehampton,Arun,West Sussex,E05009811,E14001108,E07000224,E10000032
+2024,2024,Ferring,Worthing West,Arun,West Sussex,E05009812,E14001599,E07000224,E10000032
+2024,2024,Hotham,Bognor Regis and Littlehampton,Arun,West Sussex,E05009813,E14001108,E07000224,E10000032
+2024,2024,Marine,Bognor Regis and Littlehampton,Arun,West Sussex,E05009814,E14001108,E07000224,E10000032
+2024,2024,Middleton-on-Sea,Bognor Regis and Littlehampton,Arun,West Sussex,E05009815,E14001108,E07000224,E10000032
+2024,2024,Orchard,Bognor Regis and Littlehampton,Arun,West Sussex,E05009816,E14001108,E07000224,E10000032
+2024,2024,Pagham,Chichester,Arun,West Sussex,E05009817,E14001166,E07000224,E10000032
+2024,2024,Pevensey,Bognor Regis and Littlehampton,Arun,West Sussex,E05009818,E14001108,E07000224,E10000032
+2024,2024,River,Bognor Regis and Littlehampton,Arun,West Sussex,E05009819,E14001108,E07000224,E10000032
+2024,2024,Roffey North,Horsham,Horsham,West Sussex,E05011825,E14001294,E07000227,E10000032
+2024,2024,Meadvale & St John's,Reigate,Reigate and Banstead,Surrey,E05012880,E14001442,E07000211,E10000030
+2024,2024,Eastlands,Rugby,Rugby,Warwickshire,E05008986,E14001453,E07000220,E10000031
+2024,2024,Chaldon,East Surrey,Tandridge,Surrey,E05015887,E14001215,E07000215,E10000030
+2024,2024,Tarring,Worthing West,Worthing,West Sussex,E05007706,E14001599,E07000229,E10000032
+2024,2024,Rustington West,Bognor Regis and Littlehampton,Arun,West Sussex,E05009821,E14001108,E07000224,E10000032
+2024,2024,Alvechurch South,Bromsgrove,Bromsgrove,Worcestershire,E05009823,E14001138,E07000234,E10000034
+2024,2024,Alvechurch Village,Bromsgrove,Bromsgrove,Worcestershire,E05009824,E14001138,E07000234,E10000034
+2024,2024,Aston Fields,Bromsgrove,Bromsgrove,Worcestershire,E05009825,E14001138,E07000234,E10000034
+2024,2024,Avoncroft,Bromsgrove,Bromsgrove,Worcestershire,E05009826,E14001138,E07000234,E10000034
+2024,2024,Barnt Green & Hopwood,Bromsgrove,Bromsgrove,Worcestershire,E05009827,E14001138,E07000234,E10000034
+2024,2024,Belbroughton & Romsley,Bromsgrove,Bromsgrove,Worcestershire,E05009828,E14001138,E07000234,E10000034
+2024,2024,Bromsgrove Central,Bromsgrove,Bromsgrove,Worcestershire,E05009829,E14001138,E07000234,E10000034
+2024,2024,Catshill North,Bromsgrove,Bromsgrove,Worcestershire,E05009830,E14001138,E07000234,E10000034
+2024,2024,Catshill South,Bromsgrove,Bromsgrove,Worcestershire,E05009831,E14001138,E07000234,E10000034
+2024,2024,Charford,Bromsgrove,Bromsgrove,Worcestershire,E05009832,E14001138,E07000234,E10000034
+2024,2024,Cofton,Bromsgrove,Bromsgrove,Worcestershire,E05009833,E14001138,E07000234,E10000034
+2024,2024,Drakes Cross,Bromsgrove,Bromsgrove,Worcestershire,E05009834,E14001138,E07000234,E10000034
+2024,2024,Hagley East,Bromsgrove,Bromsgrove,Worcestershire,E05009835,E14001138,E07000234,E10000034
+2024,2024,Hagley West,Bromsgrove,Bromsgrove,Worcestershire,E05009836,E14001138,E07000234,E10000034
+2024,2024,Hill Top,Bromsgrove,Bromsgrove,Worcestershire,E05009837,E14001138,E07000234,E10000034
+2024,2024,Hollywood,Bromsgrove,Bromsgrove,Worcestershire,E05009838,E14001138,E07000234,E10000034
+2024,2024,Lickey Hills,Bromsgrove,Bromsgrove,Worcestershire,E05009839,E14001138,E07000234,E10000034
+2024,2024,Lowes Hill,Bromsgrove,Bromsgrove,Worcestershire,E05009840,E14001138,E07000234,E10000034
+2024,2024,Marlbrook,Bromsgrove,Bromsgrove,Worcestershire,E05009841,E14001138,E07000234,E10000034
+2024,2024,Norton,Bromsgrove,Bromsgrove,Worcestershire,E05009842,E14001138,E07000234,E10000034
+2024,2024,Perryfields,Bromsgrove,Bromsgrove,Worcestershire,E05009843,E14001138,E07000234,E10000034
+2024,2024,Rock Hill,Bromsgrove,Bromsgrove,Worcestershire,E05009844,E14001138,E07000234,E10000034
+2024,2024,Rubery North,Bromsgrove,Bromsgrove,Worcestershire,E05009845,E14001138,E07000234,E10000034
+2024,2024,Rubery South,Bromsgrove,Bromsgrove,Worcestershire,E05009846,E14001138,E07000234,E10000034
+2024,2024,Sanders Park,Bromsgrove,Bromsgrove,Worcestershire,E05009847,E14001138,E07000234,E10000034
+2024,2024,Sidemoor,Bromsgrove,Bromsgrove,Worcestershire,E05009848,E14001138,E07000234,E10000034
+2024,2024,Slideslow,Bromsgrove,Bromsgrove,Worcestershire,E05009849,E14001138,E07000234,E10000034
+2024,2024,Tardebigge,Bromsgrove,Bromsgrove,Worcestershire,E05009850,E14001138,E07000234,E10000034
+2024,2024,Wythall East,Bromsgrove,Bromsgrove,Worcestershire,E05009851,E14001138,E07000234,E10000034
+2024,2024,Wythall West,Bromsgrove,Bromsgrove,Worcestershire,E05009852,E14001138,E07000234,E10000034
+2024,2024,"Alfrick, Leigh & Rushwick",West Worcestershire,Malvern Hills,Worcestershire,E05015380,E14001579,E07000235,E10000034
+2024,2024,Baldwin,West Worcestershire,Malvern Hills,Worcestershire,E05015381,E14001579,E07000235,E10000034
+2024,2024,Barnards Green,West Worcestershire,Malvern Hills,Worcestershire,E05015382,E14001579,E07000235,E10000034
+2024,2024,Broadheath,West Worcestershire,Malvern Hills,Worcestershire,E05015383,E14001579,E07000235,E10000034
+2024,2024,"Castlemorton, Welland & Wells",West Worcestershire,Malvern Hills,Worcestershire,E05015384,E14001579,E07000235,E10000034
+2024,2024,Great Malvern,West Worcestershire,Malvern Hills,Worcestershire,E05015385,E14001579,E07000235,E10000034
+2024,2024,Hallow & Holt,West Worcestershire,Malvern Hills,Worcestershire,E05015386,E14001579,E07000235,E10000034
+2024,2024,Kempsey,West Worcestershire,Malvern Hills,Worcestershire,E05015387,E14001579,E07000235,E10000034
+2024,2024,Lindridge,West Worcestershire,Malvern Hills,Worcestershire,E05015388,E14001579,E07000235,E10000034
+2024,2024,Link,West Worcestershire,Malvern Hills,Worcestershire,E05015389,E14001579,E07000235,E10000034
+2024,2024,Longdon,West Worcestershire,Malvern Hills,Worcestershire,E05015390,E14001579,E07000235,E10000034
+2024,2024,Nork,Reigate,Reigate and Banstead,Surrey,E05012881,E14001442,E07000211,E10000030
+2024,2024,Roffey South,Horsham,Horsham,West Sussex,E05011826,E14001294,E07000227,E10000032
+2024,2024,Dormansland & Felbridge,East Surrey,Tandridge,Surrey,E05015888,E14001215,E07000215,E10000030
+2024,2024,Wolvey and Shilton,Rugby,Rugby,Warwickshire,E05008988,E14001453,E07000220,E10000031
+2024,2024,Yapton,Bognor Regis and Littlehampton,Arun,West Sussex,E05009822,E14001108,E07000224,E10000032
+2024,2024,Martley,West Worcestershire,Malvern Hills,Worcestershire,E05015391,E14001579,E07000235,E10000034
+2024,2024,Pickersleigh,West Worcestershire,Malvern Hills,Worcestershire,E05015392,E14001579,E07000235,E10000034
+2024,2024,Powick & the Hanleys,West Worcestershire,Malvern Hills,Worcestershire,E05015393,E14001579,E07000235,E10000034
+2024,2024,Tenbury,West Worcestershire,Malvern Hills,Worcestershire,E05015394,E14001579,E07000235,E10000034
+2024,2024,Upper Howsell,West Worcestershire,Malvern Hills,Worcestershire,E05015395,E14001579,E07000235,E10000034
+2024,2024,Upton & Ripple,West Worcestershire,Malvern Hills,Worcestershire,E05015396,E14001579,E07000235,E10000034
+2024,2024,West,West Worcestershire,Malvern Hills,Worcestershire,E05015397,E14001579,E07000235,E10000034
+2024,2024,Chichester Central,Chichester,Chichester,West Sussex,E05011666,E14001166,E07000225,E10000032
+2024,2024,Chichester East,Chichester,Chichester,West Sussex,E05011667,E14001166,E07000225,E10000032
+2024,2024,Chichester North,Chichester,Chichester,West Sussex,E05011668,E14001166,E07000225,E10000032
+2024,2024,Chichester South,Chichester,Chichester,West Sussex,E05011669,E14001166,E07000225,E10000032
+2024,2024,Chichester West,Chichester,Chichester,West Sussex,E05011670,E14001166,E07000225,E10000032
+2024,2024,Easebourne,Arundel and South Downs,Chichester,West Sussex,E05011671,E14001067,E07000225,E10000032
+2024,2024,Fernhurst,Arundel and South Downs,Chichester,West Sussex,E05011672,E14001067,E07000225,E10000032
+2024,2024,Fittleworth,Arundel and South Downs,Chichester,West Sussex,E05011673,E14001067,E07000225,E10000032
+2024,2024,Goodwood,Arundel and South Downs,Chichester,West Sussex,E05011674,E14001067,E07000225,E10000032
+2024,2024,Goodwood,Chichester,Chichester,West Sussex,E05011674,E14001166,E07000225,E10000032
+2024,2024,Harbour Villages,Chichester,Chichester,West Sussex,E05011675,E14001166,E07000225,E10000032
+2024,2024,Harting,Arundel and South Downs,Chichester,West Sussex,E05011676,E14001067,E07000225,E10000032
+2024,2024,Lavant,Chichester,Chichester,West Sussex,E05011677,E14001166,E07000225,E10000032
+2024,2024,Loxwood,Arundel and South Downs,Chichester,West Sussex,E05011678,E14001067,E07000225,E10000032
+2024,2024,Midhurst,Arundel and South Downs,Chichester,West Sussex,E05011679,E14001067,E07000225,E10000032
+2024,2024,North Mundham & Tangmere,Chichester,Chichester,West Sussex,E05011680,E14001166,E07000225,E10000032
+2024,2024,Petworth,Arundel and South Downs,Chichester,West Sussex,E05011681,E14001067,E07000225,E10000032
+2024,2024,Rudgwick,Horsham,Horsham,West Sussex,E05011827,E14001294,E07000227,E10000032
+2024,2024,Selsey South,Chichester,Chichester,West Sussex,E05011682,E14001166,E07000225,E10000032
+2024,2024,Southwater North,Horsham,Horsham,West Sussex,E05011828,E14001294,E07000227,E10000032
+2024,2024,Sidlesham with Selsey North,Chichester,Chichester,West Sussex,E05011683,E14001166,E07000225,E10000032
+2024,2024,Southwater South & Shipley,Horsham,Horsham,West Sussex,E05011829,E14001294,E07000227,E10000032
+2024,2024,Godstone,East Surrey,Tandridge,Surrey,E05015889,E14001215,E07000215,E10000030
+2024,2024,Admirals and Cawston,Rugby,Rugby,Warwickshire,E05010758,E14001453,E07000220,E10000031
+2024,2024,Southbourne,Chichester,Chichester,West Sussex,E05011684,E14001166,E07000225,E10000032
+2024,2024,Redhill East,Reigate,Reigate and Banstead,Surrey,E05012882,E14001442,E07000211,E10000030
+2024,2024,Steyning & Ashurst,Arundel and South Downs,Horsham,West Sussex,E05011830,E14001067,E07000227,E10000032
+2024,2024,Harestone,East Surrey,Tandridge,Surrey,E05015890,E14001215,E07000215,E10000030
+2024,2024,Dunsmore,Kenilworth and Southam,Rugby,Warwickshire,E05010759,E14001309,E07000220,E10000031
+2024,2024,Wolston and the Lawfords,Rugby,Rugby,Warwickshire,E05010760,E14001453,E07000220,E10000031
+2024,2024,Storrington & Washington,Arundel and South Downs,Horsham,West Sussex,E05011831,E14001067,E07000227,E10000032
+2024,2024,Limpsfield,East Surrey,Tandridge,Surrey,E05015891,E14001215,E07000215,E10000030
+2024,2024,Alcester East,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015107,E14001526,E07000221,E10000031
+2024,2024,Trafalgar,Horsham,Horsham,West Sussex,E05011832,E14001294,E07000227,E10000032
+2024,2024,Redhill West & Wray Common,Reigate,Reigate and Banstead,Surrey,E05012883,E14001442,E07000211,E10000030
+2024,2024,The Witterings,Chichester,Chichester,West Sussex,E05011685,E14001166,E07000225,E10000032
+2024,2024,"West Chiltington, Thakeham & Ashington",Arundel and South Downs,Horsham,West Sussex,E05011833,E14001067,E07000227,E10000032
+2024,2024,"Ardingly, Balcombe & Turners Hill",East Grinstead and Uckfield,Mid Sussex,West Sussex,E05014708,E14001212,E07000228,E10000032
+2024,2024,"Ardingly, Balcombe & Turners Hill",Mid Sussex,Mid Sussex,West Sussex,E05014708,E14001366,E07000228,E10000032
+2024,2024,Ashurst Wood & East Grinstead South,East Grinstead and Uckfield,Mid Sussex,West Sussex,E05014709,E14001212,E07000228,E10000032
+2024,2024,Burgess Hill Dunstall,Mid Sussex,Mid Sussex,West Sussex,E05014710,E14001366,E07000228,E10000032
+2024,2024,Burgess Hill Franklands,Mid Sussex,Mid Sussex,West Sussex,E05014711,E14001366,E07000228,E10000032
+2024,2024,Burgess Hill Leylands,Mid Sussex,Mid Sussex,West Sussex,E05014712,E14001366,E07000228,E10000032
+2024,2024,Burgess Hill Meeds & Hammonds,Mid Sussex,Mid Sussex,West Sussex,E05014713,E14001366,E07000228,E10000032
+2024,2024,Burgess Hill St Andrews,Mid Sussex,Mid Sussex,West Sussex,E05014714,E14001366,E07000228,E10000032
+2024,2024,Burgess Hill Victoria,Mid Sussex,Mid Sussex,West Sussex,E05014715,E14001366,E07000228,E10000032
+2024,2024,Copthorne & Worth,East Grinstead and Uckfield,Mid Sussex,West Sussex,E05014716,E14001212,E07000228,E10000032
+2024,2024,Crawley Down,East Grinstead and Uckfield,Mid Sussex,West Sussex,E05014717,E14001212,E07000228,E10000032
+2024,2024,"Cuckfield, Bolney & Ansty",Mid Sussex,Mid Sussex,West Sussex,E05014718,E14001366,E07000228,E10000032
+2024,2024,Downland Villages,Mid Sussex,Mid Sussex,West Sussex,E05014719,E14001366,E07000228,E10000032
+2024,2024,East Grinstead Ashplats,East Grinstead and Uckfield,Mid Sussex,West Sussex,E05014720,E14001212,E07000228,E10000032
+2024,2024,East Grinstead Baldwins,East Grinstead and Uckfield,Mid Sussex,West Sussex,E05014721,E14001212,E07000228,E10000032
+2024,2024,East Grinstead Herontye,East Grinstead and Uckfield,Mid Sussex,West Sussex,E05014722,E14001212,E07000228,E10000032
+2024,2024,East Grinstead Imberhorne,East Grinstead and Uckfield,Mid Sussex,West Sussex,E05014723,E14001212,E07000228,E10000032
+2024,2024,Alcester West,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015108,E14001526,E07000221,E10000031
+2024,2024,East Grinstead Town,East Grinstead and Uckfield,Mid Sussex,West Sussex,E05014724,E14001212,E07000228,E10000032
+2024,2024,Handcross & Pease Pottage,East Grinstead and Uckfield,Mid Sussex,West Sussex,E05014725,E14001212,E07000228,E10000032
+2024,2024,Bidford East,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015109,E14001526,E07000221,E10000031
+2024,2024,Hassocks,Mid Sussex,Mid Sussex,West Sussex,E05014726,E14001366,E07000228,E10000032
+2024,2024,Reigate,Reigate,Reigate and Banstead,Surrey,E05012884,E14001442,E07000211,E10000030
+2024,2024,Westbourne,Chichester,Chichester,West Sussex,E05011686,E14001166,E07000225,E10000032
+2024,2024,Bewbush & North Broadfield,Crawley,Crawley,West Sussex,E05012914,E14001184,E07000226,E10000032
+2024,2024,South Park & Woodhatch,Reigate,Reigate and Banstead,Surrey,E05012885,E14001442,E07000211,E10000030
+2024,2024,Haywards Heath Ashenground,Mid Sussex,Mid Sussex,West Sussex,E05014727,E14001366,E07000228,E10000032
+2024,2024,Tattenham Corner & Preston,Reigate,Reigate and Banstead,Surrey,E05012886,E14001442,E07000211,E10000030
+2024,2024,Broadfield,Crawley,Crawley,West Sussex,E05012915,E14001184,E07000226,E10000032
+2024,2024,Bidford West,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015110,E14001526,E07000221,E10000031
+2024,2024,Lingfield & Crowhurst,East Surrey,Tandridge,Surrey,E05015892,E14001215,E07000215,E10000030
+2024,2024,Addlestone North,Runnymede and Weybridge,Runnymede,Surrey,E05012887,E14001456,E07000212,E10000030
+2024,2024,Oxted North,East Surrey,Tandridge,Surrey,E05015893,E14001215,E07000215,E10000030
+2024,2024,Oxted South,East Surrey,Tandridge,Surrey,E05015894,E14001215,E07000215,E10000030
+2024,2024,Portley & Queens Park,East Surrey,Tandridge,Surrey,E05015895,E14001215,E07000215,E10000030
+2024,2024,Tatsfield & Titsey,East Surrey,Tandridge,Surrey,E05015896,E14001215,E07000215,E10000030
+2024,2024,Valley,East Surrey,Tandridge,Surrey,E05015897,E14001215,E07000215,E10000030
+2024,2024,Addlestone South,Runnymede and Weybridge,Runnymede,Surrey,E05012888,E14001456,E07000212,E10000030
+2024,2024,Warlingham East & Chelsham & Farleigh,East Surrey,Tandridge,Surrey,E05015898,E14001215,E07000215,E10000030
+2024,2024,Chertsey Riverside,Runnymede and Weybridge,Runnymede,Surrey,E05012889,E14001456,E07000212,E10000030
+2024,2024,Warlingham West,East Surrey,Tandridge,Surrey,E05015899,E14001215,E07000215,E10000030
+2024,2024,Chertsey St Ann's,Runnymede and Weybridge,Runnymede,Surrey,E05012890,E14001456,E07000212,E10000030
+2024,2024,Westway,East Surrey,Tandridge,Surrey,E05015900,E14001215,E07000215,E10000030
+2024,2024,Egham Hythe,Runnymede and Weybridge,Runnymede,Surrey,E05012891,E14001456,E07000212,E10000030
+2024,2024,Whyteleafe,East Surrey,Tandridge,Surrey,E05015901,E14001215,E07000215,E10000030
+2024,2024,Egham Town,Runnymede and Weybridge,Runnymede,Surrey,E05012892,E14001456,E07000212,E10000030
+2024,2024,Woldingham,East Surrey,Tandridge,Surrey,E05015902,E14001215,E07000215,E10000030
+2024,2024,Englefield Green East,Windsor,Runnymede,Surrey,E05012893,E14001588,E07000212,E10000030
+2024,2024,"Alfold, Dunsfold & Hascombe",Godalming and Ash,Waverley,Surrey,E05015146,E14001249,E07000216,E10000030
+2024,2024,Englefield Green West,Windsor,Runnymede,Surrey,E05012894,E14001588,E07000212,E10000030
+2024,2024,Bramley & Wonersh,Godalming and Ash,Waverley,Surrey,E05015147,E14001249,E07000216,E10000030
+2024,2024,"Longcross, Lyne & Chertsey South",Runnymede and Weybridge,Runnymede,Surrey,E05012895,E14001456,E07000212,E10000030
+2024,2024,Chiddingfold,Godalming and Ash,Waverley,Surrey,E05015148,E14001249,E07000216,E10000030
+2024,2024,New Haw,Runnymede and Weybridge,Runnymede,Surrey,E05012896,E14001456,E07000212,E10000030
+2024,2024,Cranleigh East,Godalming and Ash,Waverley,Surrey,E05015149,E14001249,E07000216,E10000030
+2024,2024,Ottershaw,Runnymede and Weybridge,Runnymede,Surrey,E05012897,E14001456,E07000212,E10000030
+2024,2024,Cranleigh West,Godalming and Ash,Waverley,Surrey,E05015150,E14001249,E07000216,E10000030
+2024,2024,Thorpe,Runnymede and Weybridge,Runnymede,Surrey,E05012898,E14001456,E07000212,E10000030
+2024,2024,Elstead & Peper Harow,Godalming and Ash,Waverley,Surrey,E05015151,E14001249,E07000216,E10000030
+2024,2024,Virginia Water,Windsor,Runnymede,Surrey,E05012899,E14001588,E07000212,E10000030
+2024,2024,Ewhurst & Ellens Green,Dorking and Horley,Waverley,Surrey,E05015152,E14001201,E07000216,E10000030
+2024,2024,Woodham & Rowtown,Runnymede and Weybridge,Runnymede,Surrey,E05012900,E14001456,E07000212,E10000030
+2024,2024,Ewhurst & Ellens Green,Godalming and Ash,Waverley,Surrey,E05015152,E14001249,E07000216,E10000030
+2024,2024,Ashford Common,Spelthorne,Spelthorne,Surrey,E05007362,E14001505,E07000213,E10000030
+2024,2024,Farnham Bourne,Farnham and Bordon,Waverley,Surrey,E05015153,E14001234,E07000216,E10000030
+2024,2024,Ashford East,Spelthorne,Spelthorne,Surrey,E05007363,E14001505,E07000213,E10000030
+2024,2024,Farnham Castle,Farnham and Bordon,Waverley,Surrey,E05015154,E14001234,E07000216,E10000030
+2024,2024,Ashford North and Stanwell South,Spelthorne,Spelthorne,Surrey,E05007364,E14001505,E07000213,E10000030
+2024,2024,Farnham Firgrove,Farnham and Bordon,Waverley,Surrey,E05015155,E14001234,E07000216,E10000030
+2024,2024,Ashford Town,Spelthorne,Spelthorne,Surrey,E05007365,E14001505,E07000213,E10000030
+2024,2024,Farnham Heath End,Farnham and Bordon,Waverley,Surrey,E05015156,E14001234,E07000216,E10000030
+2024,2024,Halliford and Sunbury West,Spelthorne,Spelthorne,Surrey,E05007366,E14001505,E07000213,E10000030
+2024,2024,Farnham Moor Park,Farnham and Bordon,Waverley,Surrey,E05015157,E14001234,E07000216,E10000030
+2024,2024,Laleham and Shepperton Green,Spelthorne,Spelthorne,Surrey,E05007367,E14001505,E07000213,E10000030
+2024,2024,Farnham North West,Farnham and Bordon,Waverley,Surrey,E05015158,E14001234,E07000216,E10000030
+2024,2024,Riverside and Laleham,Spelthorne,Spelthorne,Surrey,E05007368,E14001505,E07000213,E10000030
+2024,2024,Farnham Rowledge,Farnham and Bordon,Waverley,Surrey,E05015159,E14001234,E07000216,E10000030
+2024,2024,Shepperton Town,Spelthorne,Spelthorne,Surrey,E05007369,E14001505,E07000213,E10000030
+2024,2024,Furnace Green,Crawley,Crawley,West Sussex,E05012916,E14001184,E07000226,E10000032
+2024,2024,"Bishop's Itchington, Fenny Compton & Napton",Kenilworth and Southam,Stratford-on-Avon,Warwickshire,E05015111,E14001309,E07000221,E10000031
+2024,2024,Gossops Green & North East Broadfield,Crawley,Crawley,West Sussex,E05012917,E14001184,E07000226,E10000032
+2024,2024,Staines,Spelthorne,Spelthorne,Surrey,E05007370,E14001505,E07000213,E10000030
+2024,2024,Farnham Weybourne,Farnham and Bordon,Waverley,Surrey,E05015160,E14001234,E07000216,E10000030
+2024,2024,Haywards Heath Bentswood & Heath,Mid Sussex,Mid Sussex,West Sussex,E05014728,E14001366,E07000228,E10000032
+2024,2024,Haywards Heath Franklands,Mid Sussex,Mid Sussex,West Sussex,E05014729,E14001366,E07000228,E10000032
+2024,2024,Haywards Heath Lucastes & Bolnore,Mid Sussex,Mid Sussex,West Sussex,E05014730,E14001366,E07000228,E10000032
+2024,2024,Haywards Heath North,Mid Sussex,Mid Sussex,West Sussex,E05014731,E14001366,E07000228,E10000032
+2024,2024,Hurstpierpoint,Mid Sussex,Mid Sussex,West Sussex,E05014732,E14001366,E07000228,E10000032
+2024,2024,Lindfield,Mid Sussex,Mid Sussex,West Sussex,E05014733,E14001366,E07000228,E10000032
+2024,2024,Lindfield Rural & High Weald,East Grinstead and Uckfield,Mid Sussex,West Sussex,E05014734,E14001212,E07000228,E10000032
+2024,2024,Lindfield Rural & High Weald,Mid Sussex,Mid Sussex,West Sussex,E05014734,E14001366,E07000228,E10000032
+2024,2024,Broadwater,East Worthing and Shoreham,Worthing,West Sussex,E05007694,E14001218,E07000229,E10000032
+2024,2024,Castle,Worthing West,Worthing,West Sussex,E05007695,E14001599,E07000229,E10000032
+2024,2024,Central,Worthing West,Worthing,West Sussex,E05007696,E14001599,E07000229,E10000032
+2024,2024,Durrington,Worthing West,Worthing,West Sussex,E05007697,E14001599,E07000229,E10000032
+2024,2024,Gaisford,East Worthing and Shoreham,Worthing,West Sussex,E05007698,E14001218,E07000229,E10000032
+2024,2024,Goring,Worthing West,Worthing,West Sussex,E05007699,E14001599,E07000229,E10000032
+2024,2024,Heene,Worthing West,Worthing,West Sussex,E05007700,E14001599,E07000229,E10000032
+2024,2024,Staines South,Spelthorne,Spelthorne,Surrey,E05007371,E14001505,E07000213,E10000030
+2024,2024,Marine,Worthing West,Worthing,West Sussex,E05007701,E14001599,E07000229,E10000032
+2024,2024,Godalming Binscombe & Charterhouse,Godalming and Ash,Waverley,Surrey,E05015161,E14001249,E07000216,E10000030
+2024,2024,Stanwell North,Spelthorne,Spelthorne,Surrey,E05007372,E14001505,E07000213,E10000030
+2024,2024,Northbrook,Worthing West,Worthing,West Sussex,E05007702,E14001599,E07000229,E10000032
+2024,2024,Godalming Central & Ockford,Godalming and Ash,Waverley,Surrey,E05015162,E14001249,E07000216,E10000030
+2024,2024,Sunbury Common,Spelthorne,Spelthorne,Surrey,E05007373,E14001505,E07000213,E10000030
+2024,2024,Offington,East Worthing and Shoreham,Worthing,West Sussex,E05007703,E14001218,E07000229,E10000032
+2024,2024,Brailes & Compton,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015112,E14001526,E07000221,E10000031
+2024,2024,Ifield,Crawley,Crawley,West Sussex,E05012918,E14001184,E07000226,E10000032
+2024,2024,Salvington,Worthing West,Worthing,West Sussex,E05007704,E14001599,E07000229,E10000032
+2024,2024,Langley Green & Tushmore,Crawley,Crawley,West Sussex,E05012919,E14001184,E07000226,E10000032
+2024,2024,Maidenbower,Crawley,Crawley,West Sussex,E05012920,E14001184,E07000226,E10000032
+2024,2024,Claverdon & Snitterfield,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015113,E14001526,E07000221,E10000031
+2024,2024,Northgate & West Green,Crawley,Crawley,West Sussex,E05012921,E14001184,E07000226,E10000032
+2024,2024,"Gaydon, Kineton & Upper Lighthorne",Kenilworth and Southam,Stratford-on-Avon,Warwickshire,E05015114,E14001309,E07000221,E10000031
+2024,2024,Pound Hill North & Forge Wood,Crawley,Crawley,West Sussex,E05012922,E14001184,E07000226,E10000032
+2024,2024,Harbury,Kenilworth and Southam,Stratford-on-Avon,Warwickshire,E05015115,E14001309,E07000221,E10000031
+2024,2024,Pound Hill South & Worth,Crawley,Crawley,West Sussex,E05012923,E14001184,E07000226,E10000032
+2024,2024,Henley-in-Arden,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015116,E14001526,E07000221,E10000031
+2024,2024,Kinwarton,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015117,E14001526,E07000221,E10000031
+2024,2024,Long Marston,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015118,E14001526,E07000221,E10000031
+2024,2024,Quinton,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015119,E14001526,E07000221,E10000031
+2024,2024,Salford Priors & Alcester Rural,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015120,E14001526,E07000221,E10000031
+2024,2024,Shipston North,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015121,E14001526,E07000221,E10000031
+2024,2024,Shipston South,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015122,E14001526,E07000221,E10000031
+2024,2024,"Southam East, Central & Stockton",Kenilworth and Southam,Stratford-on-Avon,Warwickshire,E05015123,E14001309,E07000221,E10000031
+2024,2024,Godalming Farncombe & Catteshall,Godalming and Ash,Waverley,Surrey,E05015163,E14001249,E07000216,E10000030
+2024,2024,Southam North & Long Itchington,Kenilworth and Southam,Stratford-on-Avon,Warwickshire,E05015124,E14001309,E07000221,E10000031
+2024,2024,Sunbury East,Spelthorne,Spelthorne,Surrey,E05007374,E14001505,E07000213,E10000030
+2024,2024,Southgate,Crawley,Crawley,West Sussex,E05012924,E14001184,E07000226,E10000032
+2024,2024,Three Bridges,Crawley,Crawley,West Sussex,E05012925,E14001184,E07000226,E10000032
+2024,2024,Tilgate,Crawley,Crawley,West Sussex,E05012926,E14001184,E07000226,E10000032
+2024,2024,Godalming Holloway,Godalming and Ash,Waverley,Surrey,E05015164,E14001249,E07000216,E10000030
+2024,2024,Billingshurst,Horsham,Horsham,West Sussex,E05011812,E14001294,E07000227,E10000032
+2024,2024,"Bramber, Upper Beeding & Woodmancote",Arundel and South Downs,Horsham,West Sussex,E05011813,E14001067,E07000227,E10000032
+2024,2024,Haslemere East,Farnham and Bordon,Waverley,Surrey,E05015165,E14001234,E07000216,E10000030
+2024,2024,Broadbridge Heath,Horsham,Horsham,West Sussex,E05011814,E14001294,E07000227,E10000032
+2024,2024,Haslemere West,Farnham and Bordon,Waverley,Surrey,E05015166,E14001234,E07000216,E10000030
+2024,2024,Colgate & Rusper,Horsham,Horsham,West Sussex,E05011815,E14001294,E07000227,E10000032
+2024,2024,Hindhead & Beacon Hill,Farnham and Bordon,Waverley,Surrey,E05015167,E14001234,E07000216,E10000030
+2024,2024,"Cowfold, Shermanbury & West Grinstead",Horsham,Horsham,West Sussex,E05011816,E14001294,E07000227,E10000032
+2024,2024,Milford & Witley,Godalming and Ash,Waverley,Surrey,E05015168,E14001249,E07000216,E10000030
+2024,2024,Denne,Horsham,Horsham,West Sussex,E05011817,E14001294,E07000227,E10000032
+2024,2024,Western Commons,Farnham and Bordon,Waverley,Surrey,E05015169,E14001234,E07000216,E10000030
+2024,2024,Forest,Horsham,Horsham,West Sussex,E05011818,E14001294,E07000227,E10000032
+2024,2024,Western Commons,Godalming and Ash,Waverley,Surrey,E05015169,E14001249,E07000216,E10000030
+2024,2024,Henfield,Arundel and South Downs,Horsham,West Sussex,E05011819,E14001067,E07000227,E10000032
+2024,2024,Byfleet and West Byfleet,Woking,Woking,Surrey,E05010795,E14001592,E07000217,E10000030
+2024,2024,Holbrook East,Horsham,Horsham,West Sussex,E05011820,E14001294,E07000227,E10000032
+2024,2024,Canalside,Woking,Woking,Surrey,E05010796,E14001592,E07000217,E10000030
+2024,2024,Holbrook West,Horsham,Horsham,West Sussex,E05011821,E14001294,E07000227,E10000032
+2024,2024,Goldsworth Park,Woking,Woking,Surrey,E05010797,E14001592,E07000217,E10000030
+2024,2024,"Itchingfield, Slinfold & Warnham",Horsham,Horsham,West Sussex,E05011822,E14001294,E07000227,E10000032
+2024,2024,Heathlands,Woking,Woking,Surrey,E05010798,E14001592,E07000217,E10000030
+2024,2024,Nuthurst & Lower Beeding,Horsham,Horsham,West Sussex,E05011823,E14001294,E07000227,E10000032
+2024,2024,Hoe Valley,Woking,Woking,Surrey,E05010799,E14001592,E07000217,E10000030
+2024,2024,Horsell,Woking,Woking,Surrey,E05010800,E14001592,E07000217,E10000030
+2024,2024,Southam South,Kenilworth and Southam,Stratford-on-Avon,Warwickshire,E05015125,E14001309,E07000221,E10000031
+2024,2024,Bagshot,Surrey Heath,Surrey Heath,Surrey,E05012026,E14001532,E07000214,E10000030
+2024,2024,Knaphill,Woking,Woking,Surrey,E05010801,E14001592,E07000217,E10000030
+2024,2024,Bisley & West End,Surrey Heath,Surrey Heath,Surrey,E05012027,E14001532,E07000214,E10000030
+2024,2024,Southam West,Kenilworth and Southam,Stratford-on-Avon,Warwickshire,E05015126,E14001309,E07000221,E10000031
+2024,2024,Frimley,Surrey Heath,Surrey Heath,Surrey,E05012028,E14001532,E07000214,E10000030
+2024,2024,Stratford Avenue,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015127,E14001526,E07000221,E10000031
+2024,2024,Frimley Green,Surrey Heath,Surrey Heath,Surrey,E05012029,E14001532,E07000214,E10000030
+2024,2024,Stratford Bishopton,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015128,E14001526,E07000221,E10000031
+2024,2024,Heatherside,Surrey Heath,Surrey Heath,Surrey,E05012030,E14001532,E07000214,E10000030
+2024,2024,Stratford Clopton,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015129,E14001526,E07000221,E10000031
+2024,2024,Lightwater,Surrey Heath,Surrey Heath,Surrey,E05012031,E14001532,E07000214,E10000030
+2024,2024,Stratford Guildhall & Bridgetown,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015130,E14001526,E07000221,E10000031
+2024,2024,Mytchett & Deepcut,Surrey Heath,Surrey Heath,Surrey,E05012032,E14001532,E07000214,E10000030
+2024,2024,Stratford Hathaway,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015131,E14001526,E07000221,E10000031
+2024,2024,Old Dean,Surrey Heath,Surrey Heath,Surrey,E05012033,E14001532,E07000214,E10000030
+2024,2024,Stratford Orchard Hill,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015132,E14001526,E07000221,E10000031
+2024,2024,Parkside,Surrey Heath,Surrey Heath,Surrey,E05012034,E14001532,E07000214,E10000030
+2024,2024,Stratford Shottery,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015133,E14001526,E07000221,E10000031
+2024,2024,St Michaels,Surrey Heath,Surrey Heath,Surrey,E05012035,E14001532,E07000214,E10000030
+2024,2024,Stratford Tiddington,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015134,E14001526,E07000221,E10000031
+2024,2024,St Pauls,Surrey Heath,Surrey Heath,Surrey,E05012036,E14001532,E07000214,E10000030
+2024,2024,Stratford Welcombe,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015135,E14001526,E07000221,E10000031
+2024,2024,Town,Surrey Heath,Surrey Heath,Surrey,E05012037,E14001532,E07000214,E10000030
+2024,2024,Studley North,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015136,E14001526,E07000221,E10000031
+2024,2024,Watchetts,Surrey Heath,Surrey Heath,Surrey,E05012038,E14001532,E07000214,E10000030
+2024,2024,Studley South,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015137,E14001526,E07000221,E10000031
+2024,2024,Windlesham & Chobham,Surrey Heath,Surrey Heath,Surrey,E05012039,E14001532,E07000214,E10000030
+2024,2024,Tanworth-in-Arden,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015138,E14001526,E07000221,E10000031
+2024,2024,Bletchingley & Nutfield,East Surrey,Tandridge,Surrey,E05015885,E14001215,E07000215,E10000030
+2024,2024,Tredington,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015139,E14001526,E07000221,E10000031
+2024,2024,Tysoe,Kenilworth and Southam,Stratford-on-Avon,Warwickshire,E05015140,E14001309,E07000221,E10000031
+2024,2024,Tysoe,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015140,E14001526,E07000221,E10000031
+2024,2024,Welford-on-Avon,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015141,E14001526,E07000221,E10000031
+2024,2024,Wellesbourne East & Rural,Kenilworth and Southam,Stratford-on-Avon,Warwickshire,E05015142,E14001309,E07000221,E10000031
+2024,2024,Wellesbourne East & Rural,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015142,E14001526,E07000221,E10000031
+2024,2024,Wellesbourne North & Rural,Kenilworth and Southam,Stratford-on-Avon,Warwickshire,E05015143,E14001309,E07000221,E10000031
+2024,2024,Wellesbourne North & Rural,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015143,E14001526,E07000221,E10000031
+2024,2024,Wellesbourne South,Kenilworth and Southam,Stratford-on-Avon,Warwickshire,E05015144,E14001309,E07000221,E10000031
+2024,2024,Wootton Wawen,Stratford-on-Avon,Stratford-on-Avon,Warwickshire,E05015145,E14001526,E07000221,E10000031
+2024,2024,Bishop's Tachbrook,Warwick and Leamington,Warwick,Warwickshire,E05012615,E14001566,E07000222,E10000031
+2024,2024,Budbrooke,Kenilworth and Southam,Warwick,Warwickshire,E05012616,E14001309,E07000222,E10000031
+2024,2024,Astwood Bank & Feckenham,Redditch,Redditch,Worcestershire,E05015615,E14001441,E07000236,E10000034
+2024,2024,Batchley & Brockhill,Redditch,Redditch,Worcestershire,E05015616,E14001441,E07000236,E10000034
+2024,2024,Central,Redditch,Redditch,Worcestershire,E05015617,E14001441,E07000236,E10000034
+2024,2024,Greenlands & Lakeside,Redditch,Redditch,Worcestershire,E05015618,E14001441,E07000236,E10000034
+2024,2024,Headless Cross & Oakenshaw,Redditch,Redditch,Worcestershire,E05015619,E14001441,E07000236,E10000034
+2024,2024,Matchborough & Woodrow,Redditch,Redditch,Worcestershire,E05015620,E14001441,E07000236,E10000034
+2024,2024,North,Redditch,Redditch,Worcestershire,E05015621,E14001441,E07000236,E10000034
+2024,2024,Webheath & Callow Hill,Redditch,Redditch,Worcestershire,E05015622,E14001441,E07000236,E10000034
+2024,2024,Winyates,Redditch,Redditch,Worcestershire,E05015623,E14001441,E07000236,E10000034
+2024,2024,Arboretum,Worcester,Worcester,Worcestershire,E05015849,E14001597,E07000237,E10000034
+2024,2024,Battenhall,Worcester,Worcester,Worcestershire,E05015850,E14001597,E07000237,E10000034
+2024,2024,Cathedral,Worcester,Worcester,Worcestershire,E05015851,E14001597,E07000237,E10000034
+2024,2024,Claines,Worcester,Worcester,Worcestershire,E05015852,E14001597,E07000237,E10000034
+2024,2024,Dines Green & Grove Farm,Worcester,Worcester,Worcestershire,E05015853,E14001597,E07000237,E10000034
+2024,2024,Fort Royal,Worcester,Worcester,Worcestershire,E05015854,E14001597,E07000237,E10000034
+2024,2024,Leopard Hill,Worcester,Worcester,Worcestershire,E05015855,E14001597,E07000237,E10000034
+2024,2024,Lower Wick & Pitmaston,Worcester,Worcester,Worcestershire,E05015856,E14001597,E07000237,E10000034
+2024,2024,Nunnery,Worcester,Worcester,Worcestershire,E05015857,E14001597,E07000237,E10000034
+2024,2024,Rainbow Hill,Worcester,Worcester,Worcestershire,E05015858,E14001597,E07000237,E10000034
+2024,2024,St Clement,Worcester,Worcester,Worcestershire,E05015859,E14001597,E07000237,E10000034
+2024,2024,St John's,Worcester,Worcester,Worcestershire,E05015860,E14001597,E07000237,E10000034
+2024,2024,St Nicholas,Worcester,Worcester,Worcestershire,E05015861,E14001597,E07000237,E10000034
+2024,2024,St Peter's Parish,Worcester,Worcester,Worcestershire,E05015862,E14001597,E07000237,E10000034
+2024,2024,Coldhurst,Oldham East and Saddleworth,Oldham,Oldham,E05014650,E14001415,E08000004,E08000004
+2024,2024,St Stephen,Worcester,Worcester,Worcestershire,E05015863,E14001597,E07000237,E10000034
+2024,2024,Warndon & Elbury Park,Worcester,Worcester,Worcestershire,E05015864,E14001597,E07000237,E10000034
+2024,2024,Coldhurst,"Oldham West, Chadderton and Royton",Oldham,Oldham,E05014650,E14001416,E08000004,E08000004
+2024,2024,North Claines & Salwarpe,Droitwich and Evesham,Wychavon,Worcestershire,E05015461,E14001203,E07000238,E10000034
+2024,2024,Carlford & Fynn Valley,Central Suffolk and North Ipswich,East Suffolk,Suffolk,E05012737,E14001156,E07000244,E10000029
+2024,2024,Badsey & Aldington,Droitwich and Evesham,Wychavon,Worcestershire,E05015439,E14001203,E07000238,E10000034
+2024,2024,Carlton & Whitton,Lowestoft,East Suffolk,Suffolk,E05012738,E14001344,E07000244,E10000029
+2024,2024,Bengeworth,Droitwich and Evesham,Wychavon,Worcestershire,E05015440,E14001203,E07000238,E10000034
+2024,2024,Carlton Colville,Lowestoft,East Suffolk,Suffolk,E05012739,E14001344,E07000244,E10000029
+2024,2024,Bowbrook,Droitwich and Evesham,Wychavon,Worcestershire,E05015441,E14001203,E07000238,E10000034
+2024,2024,Deben,Suffolk Coastal,East Suffolk,Suffolk,E05012740,E14001530,E07000244,E10000029
+2024,2024,Ombersley,Droitwich and Evesham,Wychavon,Worcestershire,E05015462,E14001203,E07000238,E10000034
+2024,2024,Crompton,Oldham East and Saddleworth,Oldham,Oldham,E05014651,E14001415,E08000004,E08000004
+2024,2024,Crompton,"Oldham West, Chadderton and Royton",Oldham,Oldham,E05014651,E14001416,E08000004,E08000004
+2024,2024,Failsworth East,Manchester Central,Oldham,Oldham,E05014652,E14001352,E08000004,E08000004
+2024,2024,Failsworth East,"Oldham West, Chadderton and Royton",Oldham,Oldham,E05014652,E14001416,E08000004,E08000004
+2024,2024,Failsworth West,Manchester Central,Oldham,Oldham,E05014653,E14001352,E08000004,E08000004
+2024,2024,Hollinwood,"Oldham West, Chadderton and Royton",Oldham,Oldham,E05014654,E14001416,E08000004,E08000004
+2024,2024,Medlock Vale,"Oldham West, Chadderton and Royton",Oldham,Oldham,E05014655,E14001416,E08000004,E08000004
+2024,2024,Royton North,Oldham East and Saddleworth,Oldham,Oldham,E05014656,E14001415,E08000004,E08000004
+2024,2024,Royton North,"Oldham West, Chadderton and Royton",Oldham,Oldham,E05014656,E14001416,E08000004,E08000004
+2024,2024,Royton South,Oldham East and Saddleworth,Oldham,Oldham,E05014657,E14001415,E08000004,E08000004
+2024,2024,Boothstown & Ellenbrook,Worsley and Eccles,Salford,Salford,E05013020,E14001598,E08000006,E08000006
+2024,2024,Mildenhall Queensway,West Suffolk,West Suffolk,Suffolk,E05012788,E14001578,E07000245,E10000029
+2024,2024,Moorside,Bury North,Bury,Bury,E05014157,E14001144,E08000002,E08000002
+2024,2024,Northaw and Cuffley,Hertsmere,Welwyn Hatfield,Hertfordshire,E05011067,E14001284,E07000241,E10000015
+2024,2024,Royton South,"Oldham West, Chadderton and Royton",Oldham,Oldham,E05014657,E14001416,E08000004,E08000004
+2024,2024,Saddleworth North,Oldham East and Saddleworth,Oldham,Oldham,E05014658,E14001415,E08000004,E08000004
+2024,2024,Saddleworth South,Oldham East and Saddleworth,Oldham,Oldham,E05014659,E14001415,E08000004,E08000004
+2024,2024,Saddleworth West & Lees,Oldham East and Saddleworth,Oldham,Oldham,E05014660,E14001415,E08000004,E08000004
+2024,2024,Shaw,Oldham East and Saddleworth,Oldham,Oldham,E05014661,E14001415,E08000004,E08000004
+2024,2024,St James',Oldham East and Saddleworth,Oldham,Oldham,E05014662,E14001415,E08000004,E08000004
+2024,2024,St Mary's,Oldham East and Saddleworth,Oldham,Oldham,E05014663,E14001415,E08000004,E08000004
+2024,2024,Waterhead,Oldham East and Saddleworth,Oldham,Oldham,E05014664,E14001415,E08000004,E08000004
+2024,2024,Werneth,"Oldham West, Chadderton and Royton",Oldham,Oldham,E05014665,E14001416,E08000004,E08000004
+2024,2024,Balderstone & Kirkholt,Rochdale,Rochdale,Rochdale,E05014033,E14001446,E08000005,E08000005
+2024,2024,Bamford,Heywood and Middleton North,Rochdale,Rochdale,E05014034,E14001286,E08000005,E08000005
+2024,2024,Bamford,Rochdale,Rochdale,Rochdale,E05014034,E14001446,E08000005,E08000005
+2024,2024,Castleton,Heywood and Middleton North,Rochdale,Rochdale,E05014035,E14001286,E08000005,E08000005
+2024,2024,Central Rochdale,Heywood and Middleton North,Rochdale,Rochdale,E05014036,E14001286,E08000005,E08000005
+2024,2024,Central Rochdale,Rochdale,Rochdale,Rochdale,E05014036,E14001446,E08000005,E08000005
+2024,2024,East Middleton,Blackley and Middleton South,Rochdale,Rochdale,E05014037,E14001103,E08000005,E08000005
+2024,2024,East Middleton,Heywood and Middleton North,Rochdale,Rochdale,E05014037,E14001286,E08000005,E08000005
+2024,2024,Healey,Rochdale,Rochdale,Rochdale,E05014038,E14001446,E08000005,E08000005
+2024,2024,Hopwood Hall,Heywood and Middleton North,Rochdale,Rochdale,E05014039,E14001286,E08000005,E08000005
+2024,2024,Kingsway,Rochdale,Rochdale,Rochdale,E05014040,E14001446,E08000005,E08000005
+2024,2024,Littleborough Lakeside,Rochdale,Rochdale,Rochdale,E05014041,E14001446,E08000005,E08000005
+2024,2024,Milkstone & Deeplish,Heywood and Middleton North,Rochdale,Rochdale,E05014042,E14001286,E08000005,E08000005
+2024,2024,Milkstone & Deeplish,Rochdale,Rochdale,Rochdale,E05014042,E14001446,E08000005,E08000005
+2024,2024,Milnrow & Newhey,Rochdale,Rochdale,Rochdale,E05014043,E14001446,E08000005,E08000005
+2024,2024,Norden,Heywood and Middleton North,Rochdale,Rochdale,E05014044,E14001286,E08000005,E08000005
+2024,2024,North Heywood,Heywood and Middleton North,Rochdale,Rochdale,E05014045,E14001286,E08000005,E08000005
+2024,2024,North Middleton,Blackley and Middleton South,Rochdale,Rochdale,E05014046,E14001103,E08000005,E08000005
+2024,2024,North Middleton,Heywood and Middleton North,Rochdale,Rochdale,E05014046,E14001286,E08000005,E08000005
+2024,2024,Smallbridge & Firgrove,Rochdale,Rochdale,Rochdale,E05014047,E14001446,E08000005,E08000005
+2024,2024,South Middleton,Blackley and Middleton South,Rochdale,Rochdale,E05014048,E14001103,E08000005,E08000005
+2024,2024,South Middleton,Heywood and Middleton North,Rochdale,Rochdale,E05014048,E14001286,E08000005,E08000005
+2024,2024,Spotland & Falinge,Heywood and Middleton North,Rochdale,Rochdale,E05014049,E14001286,E08000005,E08000005
+2024,2024,Spotland & Falinge,Rochdale,Rochdale,Rochdale,E05014049,E14001446,E08000005,E08000005
+2024,2024,"Wardle, Shore & West Littleborough",Rochdale,Rochdale,Rochdale,E05014050,E14001446,E08000005,E08000005
+2024,2024,West Heywood,Heywood and Middleton North,Rochdale,Rochdale,E05014051,E14001286,E08000005,E08000005
+2024,2024,Bredon,West Worcestershire,Wychavon,Worcestershire,E05015442,E14001579,E07000238,E10000034
+2024,2024,Eastern Felixstowe,Suffolk Coastal,East Suffolk,Suffolk,E05012741,E14001530,E07000244,E10000029
+2024,2024,Pershore,West Worcestershire,Wychavon,Worcestershire,E05015463,E14001579,E07000238,E10000034
+2024,2024,West Middleton,Heywood and Middleton North,Rochdale,Rochdale,E05014052,E14001286,E08000005,E08000005
+2024,2024,Barton & Winton,Worsley and Eccles,Salford,Salford,E05013018,E14001598,E08000006,E08000006
+2024,2024,Blackfriars & Trinity,Salford,Salford,Salford,E05013019,E14001459,E08000006,E08000006
+2024,2024,Bredon Hill,West Worcestershire,Wychavon,Worcestershire,E05015443,E14001579,E07000238,E10000034
+2024,2024,Bretforton & Offenham,Droitwich and Evesham,Wychavon,Worcestershire,E05015444,E14001203,E07000238,E10000034
+2024,2024,"Broadway, Sedgeberrow & Childswickham",Droitwich and Evesham,Wychavon,Worcestershire,E05015445,E14001203,E07000238,E10000034
+2024,2024,"Broadway, Sedgeberrow & Childswickham",West Worcestershire,Wychavon,Worcestershire,E05015445,E14001579,E07000238,E10000034
+2024,2024,Dodderhill,Droitwich and Evesham,Wychavon,Worcestershire,E05015446,E14001203,E07000238,E10000034
+2024,2024,Dodderhill,Redditch,Wychavon,Worcestershire,E05015446,E14001441,E07000238,E10000034
+2024,2024,"Drakes Broughton, Norton & Whittington",Droitwich and Evesham,Wychavon,Worcestershire,E05015447,E14001203,E07000238,E10000034
+2024,2024,Droitwich East,Droitwich and Evesham,Wychavon,Worcestershire,E05015448,E14001203,E07000238,E10000034
+2024,2024,Droitwich South East,Droitwich and Evesham,Wychavon,Worcestershire,E05015449,E14001203,E07000238,E10000034
+2024,2024,Droitwich South West,Droitwich and Evesham,Wychavon,Worcestershire,E05015450,E14001203,E07000238,E10000034
+2024,2024,Droitwich West,Droitwich and Evesham,Wychavon,Worcestershire,E05015451,E14001203,E07000238,E10000034
+2024,2024,Eckington,West Worcestershire,Wychavon,Worcestershire,E05015452,E14001579,E07000238,E10000034
+2024,2024,Evesham North,Droitwich and Evesham,Wychavon,Worcestershire,E05015453,E14001203,E07000238,E10000034
+2024,2024,Evesham South,Droitwich and Evesham,Wychavon,Worcestershire,E05015454,E14001203,E07000238,E10000034
+2024,2024,Fladbury,Droitwich and Evesham,Wychavon,Worcestershire,E05015455,E14001203,E07000238,E10000034
+2024,2024,Hampton,Droitwich and Evesham,Wychavon,Worcestershire,E05015456,E14001203,E07000238,E10000034
+2024,2024,Hartlebury,Droitwich and Evesham,Wychavon,Worcestershire,E05015457,E14001203,E07000238,E10000034
+2024,2024,Framlingham,Central Suffolk and North Ipswich,East Suffolk,Suffolk,E05012742,E14001156,E07000244,E10000029
+2024,2024,Pinvin,Droitwich and Evesham,Wychavon,Worcestershire,E05015464,E14001203,E07000238,E10000034
+2024,2024,Harvington & Norton,Redditch,Wychavon,Worcestershire,E05015458,E14001441,E07000238,E10000034
+2024,2024,Broughton,Salford,Salford,Salford,E05013021,E14001459,E08000006,E08000006
+2024,2024,Cadishead & Lower Irlam,Worsley and Eccles,Salford,Salford,E05013022,E14001598,E08000006,E08000006
+2024,2024,Minden,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012789,E14001146,E07000245,E10000029
+2024,2024,Claremont,Salford,Salford,Salford,E05013023,E14001459,E08000006,E08000006
+2024,2024,Eccles,Worsley and Eccles,Salford,Salford,E05013024,E14001598,E08000006,E08000006
+2024,2024,North Manor,Bury North,Bury,Bury,E05014158,E14001144,E08000002,E08000002
+2024,2024,Newmarket East,West Suffolk,West Suffolk,Suffolk,E05012791,E14001578,E07000245,E10000029
+2024,2024,Panshanger,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011068,E14001573,E07000241,E10000015
+2024,2024,Higher Irlam & Peel Green,Worsley and Eccles,Salford,Salford,E05013025,E14001598,E08000006,E08000006
+2024,2024,Upton Snodsbury,Droitwich and Evesham,Wychavon,Worcestershire,E05015465,E14001203,E07000238,E10000034
+2024,2024,Pilkington Park,Bury South,Bury,Bury,E05014159,E14001145,E08000002,E08000002
+2024,2024,Gunton & St Margarets,Lowestoft,East Suffolk,Suffolk,E05012743,E14001344,E07000244,E10000029
+2024,2024,Newmarket North,West Suffolk,West Suffolk,Suffolk,E05012792,E14001578,E07000245,E10000029
+2024,2024,"Honeybourne, Pebworth & The Littletons",Droitwich and Evesham,Wychavon,Worcestershire,E05015459,E14001203,E07000238,E10000034
+2024,2024,Peartree,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011069,E14001573,E07000241,E10000015
+2024,2024,Kersal & Broughton Park,Bury South,Salford,Salford,E05013026,E14001145,E08000006,E08000006
+2024,2024,Radcliffe East,Bury South,Bury,Bury,E05014160,E14001145,E08000002,E08000002
+2024,2024,Newmarket West,West Suffolk,West Suffolk,Suffolk,E05012793,E14001578,E07000245,E10000029
+2024,2024,Inkberrow,Droitwich and Evesham,Wychavon,Worcestershire,E05015460,E14001203,E07000238,E10000034
+2024,2024,Little Hulton,Bolton South and Walkden,Salford,Salford,E05013027,E14001111,E08000006,E08000006
+2024,2024,Pakenham & Troston,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012794,E14001146,E07000245,E10000029
+2024,2024,Radcliffe North & Ainsworth,Bury North,Bury,Bury,E05014161,E14001144,E08000002,E08000002
+2024,2024,Sherrards,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011070,E14001573,E07000241,E10000015
+2024,2024,Halesworth & Blything,Waveney Valley,East Suffolk,Suffolk,E05012744,E14001569,E07000244,E10000029
+2024,2024,Aggborough & Spennells,Wyre Forest,Wyre Forest,Worcestershire,E05010502,E14001601,E07000239,E10000034
+2024,2024,Welham Green and Hatfield South,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011071,E14001573,E07000241,E10000015
+2024,2024,Areley Kings & Riverside,Wyre Forest,Wyre Forest,Worcestershire,E05010503,E14001601,E07000239,E10000034
+2024,2024,Harbour & Normanston,Lowestoft,East Suffolk,Suffolk,E05012745,E14001344,E07000244,E10000029
+2024,2024,Welwyn East,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011072,E14001573,E07000241,E10000015
+2024,2024,Radcliffe North & Ainsworth,Bury South,Bury,Bury,E05014161,E14001145,E08000002,E08000002
+2024,2024,Risby,West Suffolk,West Suffolk,Suffolk,E05012795,E14001578,E07000245,E10000029
+2024,2024,Inkberrow,Redditch,Wychavon,Worcestershire,E05015460,E14001441,E07000238,E10000034
+2024,2024,Bewdley & Rock,Wyre Forest,Wyre Forest,Worcestershire,E05010504,E14001601,E07000239,E10000034
+2024,2024,Kelsale & Yoxford,Suffolk Coastal,East Suffolk,Suffolk,E05012746,E14001530,E07000244,E10000029
+2024,2024,Ordsall,Salford,Salford,Salford,E05013028,E14001459,E08000006,E08000006
+2024,2024,Welwyn West,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011073,E14001573,E07000241,E10000015
+2024,2024,Radcliffe West,Bury South,Bury,Bury,E05014162,E14001145,E08000002,E08000002
+2024,2024,St Olaves,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012797,E14001146,E07000245,E10000029
+2024,2024,Blakebrook & Habberley South,Wyre Forest,Wyre Forest,Worcestershire,E05010505,E14001601,E07000239,E10000034
+2024,2024,Kesgrave,Central Suffolk and North Ipswich,East Suffolk,Suffolk,E05012747,E14001156,E07000244,E10000029
+2024,2024,Pendlebury & Clifton,Salford,Salford,Salford,E05013029,E14001459,E08000006,E08000006
+2024,2024,"Aston, Datchworth & Walkern",North East Hertfordshire,East Hertfordshire,Hertfordshire,E05015354,E14001393,E07000242,E10000015
+2024,2024,Ramsbottom,Bury North,Bury,Bury,E05014163,E14001144,E08000002,E08000002
+2024,2024,Southgate,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012798,E14001146,E07000245,E10000029
+2024,2024,Broadwaters,Wyre Forest,Wyre Forest,Worcestershire,E05010506,E14001601,E07000239,E10000034
+2024,2024,Kessingland,Lowestoft,East Suffolk,Suffolk,E05012748,E14001344,E07000244,E10000029
+2024,2024,Pendleton & Charlestown,Salford,Salford,Salford,E05013030,E14001459,E08000006,E08000006
+2024,2024,"Aston, Datchworth & Walkern",Stevenage,East Hertfordshire,Hertfordshire,E05015354,E14001516,E07000242,E10000015
+2024,2024,Redvales,Bury North,Bury,Bury,E05014164,E14001144,E08000002,E08000002
+2024,2024,Stanton,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012799,E14001146,E07000245,E10000029
+2024,2024,The Fornhams & Great Barton,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012800,E14001146,E07000245,E10000029
+2024,2024,The Rows,West Suffolk,West Suffolk,Suffolk,E05012801,E14001578,E07000245,E10000029
+2024,2024,Tollgate,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012802,E14001146,E07000245,E10000029
+2024,2024,Westgate,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012803,E14001146,E07000245,E10000029
+2024,2024,Whepstead & Wickhambrook,West Suffolk,West Suffolk,Suffolk,E05012804,E14001578,E07000245,E10000029
+2024,2024,Withersfield,West Suffolk,West Suffolk,Suffolk,E05012805,E14001578,E07000245,E10000029
+2024,2024,Iceni,West Suffolk,West Suffolk,Suffolk,E05015577,E14001578,E07000245,E10000029
+2024,2024,Manor,West Suffolk,West Suffolk,Suffolk,E05015578,E14001578,E07000245,E10000029
+2024,2024,Moreton Hall,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05015579,E14001146,E07000245,E10000029
+2024,2024,Rougham,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05015580,E14001146,E07000245,E10000029
+2024,2024,Astley Bridge,Bolton North East,Bolton,Bolton,E05014818,E14001110,E08000001,E08000001
+2024,2024,Bradshaw,Bolton North East,Bolton,Bolton,E05014819,E14001110,E08000001,E08000001
+2024,2024,Breightmet,Bolton North East,Bolton,Bolton,E05014820,E14001110,E08000001,E08000001
+2024,2024,Bromley Cross,Bolton North East,Bolton,Bolton,E05014821,E14001110,E08000001,E08000001
+2024,2024,Farnworth North,Bolton South and Walkden,Bolton,Bolton,E05014822,E14001111,E08000001,E08000001
+2024,2024,Farnworth South,Bolton South and Walkden,Bolton,Bolton,E05014823,E14001111,E08000001,E08000001
+2024,2024,Great Lever,Bolton South and Walkden,Bolton,Bolton,E05014824,E14001111,E08000001,E08000001
+2024,2024,Great Lever,Bolton West,Bolton,Bolton,E05014824,E14001112,E08000001,E08000001
+2024,2024,Halliwell,Bolton North East,Bolton,Bolton,E05014825,E14001110,E08000001,E08000001
+2024,2024,"Heaton, Lostock & Chew Moor",Bolton West,Bolton,Bolton,E05014826,E14001112,E08000001,E08000001
+2024,2024,Horwich North,Bolton West,Bolton,Bolton,E05014827,E14001112,E08000001,E08000001
+2024,2024,Horwich South & Blackrod,Bolton West,Bolton,Bolton,E05014828,E14001112,E08000001,E08000001
+2024,2024,Hulton,Bolton South and Walkden,Bolton,Bolton,E05014829,E14001111,E08000001,E08000001
+2024,2024,Hulton,Bolton West,Bolton,Bolton,E05014829,E14001112,E08000001,E08000001
+2024,2024,Kearsley,Bolton South and Walkden,Bolton,Bolton,E05014830,E14001111,E08000001,E08000001
+2024,2024,Little Lever & Darcy Lever,Bolton North East,Bolton,Bolton,E05014831,E14001110,E08000001,E08000001
+2024,2024,Queens Park & Central,Bolton North East,Bolton,Bolton,E05014832,E14001110,E08000001,E08000001
+2024,2024,Queens Park & Central,Bolton South and Walkden,Bolton,Bolton,E05014832,E14001111,E08000001,E08000001
+2024,2024,Rumworth,Bolton South and Walkden,Bolton,Bolton,E05014833,E14001111,E08000001,E08000001
+2024,2024,Rumworth,Bolton West,Bolton,Bolton,E05014833,E14001112,E08000001,E08000001
+2024,2024,Smithills,Bolton West,Bolton,Bolton,E05014834,E14001112,E08000001,E08000001
+2024,2024,Tonge with the Haulgh,Bolton North East,Bolton,Bolton,E05014835,E14001110,E08000001,E08000001
+2024,2024,Westhoughton North & Hunger Hill,Bolton West,Bolton,Bolton,E05014836,E14001112,E08000001,E08000001
+2024,2024,Westhoughton South,Bolton West,Bolton,Bolton,E05014837,E14001112,E08000001,E08000001
+2024,2024,Besses,Bury South,Bury,Bury,E05014152,E14001145,E08000002,E08000002
+2024,2024,Bury East,Bury North,Bury,Bury,E05014153,E14001144,E08000002,E08000002
+2024,2024,Bury West,Bury North,Bury,Bury,E05014154,E14001144,E08000002,E08000002
+2024,2024,Bury West,Bury South,Bury,Bury,E05014154,E14001145,E08000002,E08000002
+2024,2024,Elton,Bury North,Bury,Bury,E05014155,E14001144,E08000002,E08000002
+2024,2024,Holyrood,Bury South,Bury,Bury,E05014156,E14001145,E08000002,E08000002
+2024,2024,Quays,Salford,Salford,Salford,E05013031,E14001459,E08000006,E08000006
+2024,2024,Swinton & Wardley,Worsley and Eccles,Salford,Salford,E05013032,E14001598,E08000006,E08000006
+2024,2024,Swinton Park,Salford,Salford,Salford,E05013033,E14001459,E08000006,E08000006
+2024,2024,Walkden North,Bolton South and Walkden,Salford,Salford,E05013034,E14001111,E08000006,E08000006
+2024,2024,Walkden South,Bolton South and Walkden,Salford,Salford,E05013035,E14001111,E08000006,E08000006
+2024,2024,Weaste & Seedley,Salford,Salford,Salford,E05013036,E14001459,E08000006,E08000006
+2024,2024,Worsley & Westwood Park,Worsley and Eccles,Salford,Salford,E05013037,E14001598,E08000006,E08000006
+2024,2024,Bramhall North,Cheadle,Stockport,Stockport,E05015014,E14001158,E08000007,E08000007
+2024,2024,Bishop's Stortford All Saints,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015355,E14001283,E07000242,E10000015
+2024,2024,Bramhall South & Woodford,Cheadle,Stockport,Stockport,E05015015,E14001158,E08000007,E08000007
+2024,2024,Kirkley & Pakefield,Lowestoft,East Suffolk,Suffolk,E05012749,E14001344,E07000244,E10000029
+2024,2024,Lothingland,Lowestoft,East Suffolk,Suffolk,E05012750,E14001344,E07000244,E10000029
+2024,2024,Oulton Broad,Lowestoft,East Suffolk,Suffolk,E05012754,E14001344,E07000244,E10000029
+2024,2024,Rendlesham & Orford,Suffolk Coastal,East Suffolk,Suffolk,E05012755,E14001530,E07000244,E10000029
+2024,2024,Rushmere St Andrew,Central Suffolk and North Ipswich,East Suffolk,Suffolk,E05012756,E14001156,E07000244,E10000029
+2024,2024,Southwold,Suffolk Coastal,East Suffolk,Suffolk,E05012758,E14001530,E07000244,E10000029
+2024,2024,Western Felixstowe,Suffolk Coastal,East Suffolk,Suffolk,E05012759,E14001530,E07000244,E10000029
+2024,2024,Wickham Market,Central Suffolk and North Ipswich,East Suffolk,Suffolk,E05012760,E14001156,E07000244,E10000029
+2024,2024,"Wrentham, Wangford & Westleton",Suffolk Coastal,East Suffolk,Suffolk,E05012762,E14001530,E07000244,E10000029
+2024,2024,Bishop's Stortford Central,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015356,E14001283,E07000242,E10000015
+2024,2024,Bredbury & Woodley,Hazel Grove,Stockport,Stockport,E05015016,E14001277,E08000007,E08000007
+2024,2024,Sedgley,Bury South,Bury,Bury,E05014165,E14001145,E08000002,E08000002
+2024,2024,Bredbury Green & Romiley,Hazel Grove,Stockport,Stockport,E05015017,E14001277,E08000007,E08000007
+2024,2024,Bishop's Stortford North,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015357,E14001283,E07000242,E10000015
+2024,2024,Aldeburgh & Leiston,Suffolk Coastal,East Suffolk,Suffolk,E05015548,E14001530,E07000244,E10000029
+2024,2024,Foley Park & Hoobrook,Wyre Forest,Wyre Forest,Worcestershire,E05010507,E14001601,E07000239,E10000034
+2024,2024,Bishop's Stortford Parsonage,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015358,E14001283,E07000242,E10000015
+2024,2024,Franche & Habberley North,Wyre Forest,Wyre Forest,Worcestershire,E05010508,E14001601,E07000239,E10000034
+2024,2024,Bishop's Stortford South,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015359,E14001283,E07000242,E10000015
+2024,2024,Lickhill,Wyre Forest,Wyre Forest,Worcestershire,E05010509,E14001601,E07000239,E10000034
+2024,2024,Bishop's Stortford Thorley Manor,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015360,E14001283,E07000242,E10000015
+2024,2024,Mitton,Wyre Forest,Wyre Forest,Worcestershire,E05010510,E14001601,E07000239,E10000034
+2024,2024,Braughing & Standon,North East Hertfordshire,East Hertfordshire,Hertfordshire,E05015361,E14001393,E07000242,E10000015
+2024,2024,Offmore & Comberton,Wyre Forest,Wyre Forest,Worcestershire,E05010511,E14001601,E07000239,E10000034
+2024,2024,Buntingford,North East Hertfordshire,East Hertfordshire,Hertfordshire,E05015362,E14001393,E07000242,E10000015
+2024,2024,Wribbenhall & Arley,Wyre Forest,Wyre Forest,Worcestershire,E05010512,E14001601,E07000239,E10000034
+2024,2024,Wyre Forest Rural,Wyre Forest,Wyre Forest,Worcestershire,E05010513,E14001601,E07000239,E10000034
+2024,2024,Batchwood,St Albans,St Albans,Hertfordshire,E05013947,E14001507,E07000240,E10000015
+2024,2024,Bernards Heath,St Albans,St Albans,Hertfordshire,E05013948,E14001507,E07000240,E10000015
+2024,2024,Clarence,St Albans,St Albans,Hertfordshire,E05013949,E14001507,E07000240,E10000015
+2024,2024,Colney Heath,St Albans,St Albans,Hertfordshire,E05013950,E14001507,E07000240,E10000015
+2024,2024,Cunningham,St Albans,St Albans,Hertfordshire,E05013951,E14001507,E07000240,E10000015
+2024,2024,Harpenden East,Harpenden and Berkhamsted,St Albans,Hertfordshire,E05013952,E14001268,E07000240,E10000015
+2024,2024,Harpenden North & Rural,Harpenden and Berkhamsted,St Albans,Hertfordshire,E05013953,E14001268,E07000240,E10000015
+2024,2024,Harpenden South,Harpenden and Berkhamsted,St Albans,Hertfordshire,E05013954,E14001268,E07000240,E10000015
+2024,2024,Harpenden West,Harpenden and Berkhamsted,St Albans,Hertfordshire,E05013955,E14001268,E07000240,E10000015
+2024,2024,Hill End,St Albans,St Albans,Hertfordshire,E05013956,E14001507,E07000240,E10000015
+2024,2024,London Colney,St Albans,St Albans,Hertfordshire,E05013957,E14001507,E07000240,E10000015
+2024,2024,Park Street,St Albans,St Albans,Hertfordshire,E05013960,E14001507,E07000240,E10000015
+2024,2024,Redbourn,Harpenden and Berkhamsted,St Albans,Hertfordshire,E05013961,E14001268,E07000240,E10000015
+2024,2024,Sandridge & Wheathampstead,Harpenden and Berkhamsted,St Albans,Hertfordshire,E05013962,E14001268,E07000240,E10000015
+2024,2024,Sopwell,St Albans,St Albans,Hertfordshire,E05013963,E14001507,E07000240,E10000015
+2024,2024,St Peters,St Albans,St Albans,Hertfordshire,E05013964,E14001507,E07000240,E10000015
+2024,2024,St Stephen,Harpenden and Berkhamsted,St Albans,Hertfordshire,E05013965,E14001268,E07000240,E10000015
+2024,2024,St Stephen,St Albans,St Albans,Hertfordshire,E05013965,E14001507,E07000240,E10000015
+2024,2024,Verulam,Harpenden and Berkhamsted,St Albans,Hertfordshire,E05013966,E14001268,E07000240,E10000015
+2024,2024,Verulam,St Albans,St Albans,Hertfordshire,E05013966,E14001507,E07000240,E10000015
+2024,2024,Marshalswick East & Jersey Farm,Harpenden and Berkhamsted,St Albans,Hertfordshire,E05015801,E14001268,E07000240,E10000015
+2024,2024,Marshalswick East & Jersey Farm,St Albans,St Albans,Hertfordshire,E05015801,E14001507,E07000240,E10000015
+2024,2024,Marshalswick West,Harpenden and Berkhamsted,St Albans,Hertfordshire,E05015802,E14001268,E07000240,E10000015
+2024,2024,Marshalswick West,St Albans,St Albans,Hertfordshire,E05015802,E14001507,E07000240,E10000015
+2024,2024,Brookmans Park and Little Heath,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011058,E14001573,E07000241,E10000015
+2024,2024,Haldens,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011059,E14001573,E07000241,E10000015
+2024,2024,Handside,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011060,E14001573,E07000241,E10000015
+2024,2024,Hatfield Central,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011061,E14001573,E07000241,E10000015
+2024,2024,Hatfield East,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011062,E14001573,E07000241,E10000015
+2024,2024,Hatfield South West,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011063,E14001573,E07000241,E10000015
+2024,2024,Hatfield Villages,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011064,E14001573,E07000241,E10000015
+2024,2024,Hollybush,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011065,E14001573,E07000241,E10000015
+2024,2024,St. Mary's,Bury South,Bury,Bury,E05014166,E14001145,E08000002,E08000002
+2024,2024,Brinnington & Stockport Central,Stockport,Stockport,Stockport,E05015018,E14001517,E08000007,E08000007
+2024,2024,Martlesham & Purdis Farm,Suffolk Coastal,East Suffolk,Suffolk,E05015549,E14001530,E07000244,E10000029
+2024,2024,Howlands,Welwyn Hatfield,Welwyn Hatfield,Hertfordshire,E05011066,E14001573,E07000241,E10000015
+2024,2024,Tottington,Bury North,Bury,Bury,E05014167,E14001144,E08000002,E08000002
+2024,2024,Unsworth,Bury North,Bury,Bury,E05014168,E14001144,E08000002,E08000002
+2024,2024,Unsworth,Bury South,Bury,Bury,E05014168,E14001145,E08000002,E08000002
+2024,2024,Ancoats & Beswick,Manchester Central,Manchester,Manchester,E05011350,E14001352,E08000003,E08000003
+2024,2024,Ardwick,Manchester Rusholme,Manchester,Manchester,E05011351,E14001353,E08000003,E08000003
+2024,2024,Baguley,Wythenshawe and Sale East,Manchester,Manchester,E05011352,E14001602,E08000003,E08000003
+2024,2024,Brooklands,Wythenshawe and Sale East,Manchester,Manchester,E05011353,E14001602,E08000003,E08000003
+2024,2024,Burnage,Gorton and Denton,Manchester,Manchester,E05011354,E14001251,E08000003,E08000003
+2024,2024,Charlestown,Blackley and Middleton South,Manchester,Manchester,E05011355,E14001103,E08000003,E08000003
+2024,2024,Cheetham,Manchester Central,Manchester,Manchester,E05011356,E14001352,E08000003,E08000003
+2024,2024,Chorlton,Manchester Withington,Manchester,Manchester,E05011357,E14001354,E08000003,E08000003
+2024,2024,Chorlton Park,Manchester Withington,Manchester,Manchester,E05011358,E14001354,E08000003,E08000003
+2024,2024,Clayton & Openshaw,Manchester Central,Manchester,Manchester,E05011359,E14001352,E08000003,E08000003
+2024,2024,Crumpsall,Blackley and Middleton South,Manchester,Manchester,E05011360,E14001103,E08000003,E08000003
+2024,2024,Deansgate,Manchester Central,Manchester,Manchester,E05011361,E14001352,E08000003,E08000003
+2024,2024,Didsbury East,Manchester Withington,Manchester,Manchester,E05011362,E14001354,E08000003,E08000003
+2024,2024,Cheadle East & Cheadle Hulme North,Cheadle,Stockport,Stockport,E05015019,E14001158,E08000007,E08000007
+2024,2024,Didsbury West,Manchester Withington,Manchester,Manchester,E05011363,E14001354,E08000003,E08000003
+2024,2024,Cheadle East & Cheadle Hulme North,Stockport,Stockport,Stockport,E05015019,E14001517,E08000007,E08000007
+2024,2024,Fallowfield,Manchester Rusholme,Manchester,Manchester,E05011364,E14001353,E08000003,E08000003
+2024,2024,Cheadle Hulme South,Cheadle,Stockport,Stockport,E05015020,E14001158,E08000007,E08000007
+2024,2024,Great Amwell & Stansteads,Broxbourne,East Hertfordshire,Hertfordshire,E05015363,E14001139,E07000242,E10000015
+2024,2024,Melton,Suffolk Coastal,East Suffolk,Suffolk,E05015550,E14001530,E07000244,E10000029
+2024,2024,Hertford Bengeo,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015364,E14001283,E07000242,E10000015
+2024,2024,Hertford Castle,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015365,E14001283,E07000242,E10000015
+2024,2024,Orwell & Villages,Suffolk Coastal,East Suffolk,Suffolk,E05015551,E14001530,E07000244,E10000029
+2024,2024,Hertford Heath & Brickendon,Broxbourne,East Hertfordshire,Hertfordshire,E05015366,E14001139,E07000242,E10000015
+2024,2024,Saxmundham,Suffolk Coastal,East Suffolk,Suffolk,E05015552,E14001530,E07000244,E10000029
+2024,2024,Hertford Kingsmead,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015367,E14001283,E07000242,E10000015
+2024,2024,Woodbridge,Suffolk Coastal,East Suffolk,Suffolk,E05015553,E14001530,E07000244,E10000029
+2024,2024,Hertford Rural,North East Hertfordshire,East Hertfordshire,Hertfordshire,E05015368,E14001393,E07000242,E10000015
+2024,2024,Abbeygate,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012763,E14001146,E07000245,E10000029
+2024,2024,Hertford Sele,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015369,E14001283,E07000242,E10000015
+2024,2024,Bardwell,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012764,E14001146,E07000245,E10000029
+2024,2024,Hunsdon,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015370,E14001283,E07000242,E10000015
+2024,2024,Barningham,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012765,E14001146,E07000245,E10000029
+2024,2024,Little Hadham & The Pelhams,North East Hertfordshire,East Hertfordshire,Hertfordshire,E05015371,E14001393,E07000242,E10000015
+2024,2024,Barrow,West Suffolk,West Suffolk,Suffolk,E05012766,E14001578,E07000245,E10000029
+2024,2024,Much Hadham,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015372,E14001283,E07000242,E10000015
+2024,2024,Brandon Central,West Suffolk,West Suffolk,Suffolk,E05012767,E14001578,E07000245,E10000029
+2024,2024,Sawbridgeworth,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015373,E14001283,E07000242,E10000015
+2024,2024,Brandon East,West Suffolk,West Suffolk,Suffolk,E05012768,E14001578,E07000245,E10000029
+2024,2024,The Mundens,North East Hertfordshire,East Hertfordshire,Hertfordshire,E05015374,E14001393,E07000242,E10000015
+2024,2024,Brandon West,West Suffolk,West Suffolk,Suffolk,E05012769,E14001578,E07000245,E10000029
+2024,2024,Ware Priory,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015375,E14001283,E07000242,E10000015
+2024,2024,Chedburgh & Chevington,West Suffolk,West Suffolk,Suffolk,E05012770,E14001578,E07000245,E10000029
+2024,2024,Ware Rural,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015376,E14001283,E07000242,E10000015
+2024,2024,"Clare, Hundon & Kedington",West Suffolk,West Suffolk,Suffolk,E05012771,E14001578,E07000245,E10000029
+2024,2024,Ware Rural,North East Hertfordshire,East Hertfordshire,Hertfordshire,E05015376,E14001393,E07000242,E10000015
+2024,2024,Eastgate,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012772,E14001146,E07000245,E10000029
+2024,2024,Cheadle West & Gatley,Cheadle,Stockport,Stockport,E05015021,E14001158,E08000007,E08000007
+2024,2024,Exning,West Suffolk,West Suffolk,Suffolk,E05012773,E14001578,E07000245,E10000029
+2024,2024,Ware St Mary's,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015377,E14001283,E07000242,E10000015
+2024,2024,Gorton & Abbey Hey,Gorton and Denton,Manchester,Manchester,E05011365,E14001251,E08000003,E08000003
+2024,2024,Harpurhey,Blackley and Middleton South,Manchester,Manchester,E05011366,E14001103,E08000003,E08000003
+2024,2024,Haverhill Central,West Suffolk,West Suffolk,Suffolk,E05012774,E14001578,E07000245,E10000029
+2024,2024,Higher Blackley,Blackley and Middleton South,Manchester,Manchester,E05011367,E14001103,E08000003,E08000003
+2024,2024,Haverhill East,West Suffolk,West Suffolk,Suffolk,E05012775,E14001578,E07000245,E10000029
+2024,2024,Hulme,Manchester Rusholme,Manchester,Manchester,E05011368,E14001353,E08000003,E08000003
+2024,2024,Ware Trinity,Hertford and Stortford,East Hertfordshire,Hertfordshire,E05015378,E14001283,E07000242,E10000015
+2024,2024,Haverhill North,West Suffolk,West Suffolk,Suffolk,E05012776,E14001578,E07000245,E10000029
+2024,2024,Davenport & Cale Green,Cheadle,Stockport,Stockport,E05015022,E14001158,E08000007,E08000007
+2024,2024,Levenshulme,Gorton and Denton,Manchester,Manchester,E05011369,E14001251,E08000003,E08000003
+2024,2024,Watton-at-Stone,North East Hertfordshire,East Hertfordshire,Hertfordshire,E05015379,E14001393,E07000242,E10000015
+2024,2024,Haverhill South,West Suffolk,West Suffolk,Suffolk,E05012777,E14001578,E07000245,E10000029
+2024,2024,Davenport & Cale Green,Stockport,Stockport,Stockport,E05015022,E14001517,E08000007,E08000007
+2024,2024,Longsight,Gorton and Denton,Manchester,Manchester,E05011370,E14001251,E08000003,E08000003
+2024,2024,Almond Hill,Stevenage,Stevenage,Hertfordshire,E05015624,E14001516,E07000243,E10000015
+2024,2024,Haverhill South East,West Suffolk,West Suffolk,Suffolk,E05012778,E14001578,E07000245,E10000029
+2024,2024,Edgeley,Stockport,Stockport,Stockport,E05015023,E14001517,E08000007,E08000007
+2024,2024,Miles Platting & Newton Heath,Manchester Central,Manchester,Manchester,E05011371,E14001352,E08000003,E08000003
+2024,2024,Haverhill West,West Suffolk,West Suffolk,Suffolk,E05012779,E14001578,E07000245,E10000029
+2024,2024,Hazel Grove,Cheadle,Stockport,Stockport,E05015024,E14001158,E08000007,E08000007
+2024,2024,Moss Side,Manchester Rusholme,Manchester,Manchester,E05011372,E14001353,E08000003,E08000003
+2024,2024,Horringer,West Suffolk,West Suffolk,Suffolk,E05012780,E14001578,E07000245,E10000029
+2024,2024,Bandley Hill & Poplars,Stevenage,Stevenage,Hertfordshire,E05015625,E14001516,E07000243,E10000015
+2024,2024,Hazel Grove,Hazel Grove,Stockport,Stockport,E05015024,E14001277,E08000007,E08000007
+2024,2024,Ixworth,Bury St Edmunds and Stowmarket,West Suffolk,Suffolk,E05012782,E14001146,E07000245,E10000029
+2024,2024,Bedwell,Stevenage,Stevenage,Hertfordshire,E05015626,E14001516,E07000243,E10000015
+2024,2024,Moston,Blackley and Middleton South,Manchester,Manchester,E05011373,E14001103,E08000003,E08000003
+2024,2024,Heald Green,Cheadle,Stockport,Stockport,E05015025,E14001158,E08000007,E08000007
+2024,2024,Kentford & Moulton,West Suffolk,West Suffolk,Suffolk,E05012783,E14001578,E07000245,E10000029
+2024,2024,Chells,Stevenage,Stevenage,Hertfordshire,E05015627,E14001516,E07000243,E10000015
+2024,2024,Northenden,Wythenshawe and Sale East,Manchester,Manchester,E05011374,E14001602,E08000003,E08000003
+2024,2024,Heatons North,Stockport,Stockport,Stockport,E05015026,E14001517,E08000007,E08000007
+2024,2024,Lakenheath,West Suffolk,West Suffolk,Suffolk,E05012784,E14001578,E07000245,E10000029
+2024,2024,Longmeadow,Stevenage,Stevenage,Hertfordshire,E05015628,E14001516,E07000243,E10000015
+2024,2024,Old Moat,Manchester Withington,Manchester,Manchester,E05011375,E14001354,E08000003,E08000003
+2024,2024,Heatons South,Stockport,Stockport,Stockport,E05015027,E14001517,E08000007,E08000007
+2024,2024,Mildenhall Great Heath,West Suffolk,West Suffolk,Suffolk,E05012786,E14001578,E07000245,E10000029
+2024,2024,Manor,Stevenage,Stevenage,Hertfordshire,E05015629,E14001516,E07000243,E10000015
+2024,2024,Piccadilly,Manchester Central,Manchester,Manchester,E05011376,E14001352,E08000003,E08000003
+2024,2024,Manor,Hazel Grove,Stockport,Stockport,E05015028,E14001277,E08000007,E08000007
+2024,2024,Mildenhall Kingsway & Market,West Suffolk,West Suffolk,Suffolk,E05012787,E14001578,E07000245,E10000029
+2024,2024,Martins Wood,Stevenage,Stevenage,Hertfordshire,E05015630,E14001516,E07000243,E10000015
+2024,2024,Rusholme,Manchester Rusholme,Manchester,Manchester,E05011377,E14001353,E08000003,E08000003
+2024,2024,Marple North,Hazel Grove,Stockport,Stockport,E05015029,E14001277,E08000007,E08000007
+2024,2024,Old Town,Stevenage,Stevenage,Hertfordshire,E05015631,E14001516,E07000243,E10000015
+2024,2024,Sharston,Wythenshawe and Sale East,Manchester,Manchester,E05011378,E14001602,E08000003,E08000003
+2024,2024,Marple South & High Lane,Hazel Grove,Stockport,Stockport,E05015030,E14001277,E08000007,E08000007
+2024,2024,Roebuck,Stevenage,Stevenage,Hertfordshire,E05015632,E14001516,E07000243,E10000015
+2024,2024,Whalley Range,Manchester Rusholme,Manchester,Manchester,E05011379,E14001353,E08000003,E08000003
+2024,2024,Norbury & Woodsmoor,Cheadle,Stockport,Stockport,E05015031,E14001158,E08000007,E08000007
+2024,2024,Shephall,Stevenage,Stevenage,Hertfordshire,E05015633,E14001516,E07000243,E10000015
+2024,2024,Withington,Manchester Withington,Manchester,Manchester,E05011380,E14001354,E08000003,E08000003
+2024,2024,Norbury & Woodsmoor,Hazel Grove,Stockport,Stockport,E05015031,E14001277,E08000007,E08000007
+2024,2024,St Nicholas,Stevenage,Stevenage,Hertfordshire,E05015634,E14001516,E07000243,E10000015
+2024,2024,Offerton,Cheadle,Stockport,Stockport,E05015032,E14001158,E08000007,E08000007
+2024,2024,Symonds Green,Stevenage,Stevenage,Hertfordshire,E05015635,E14001516,E07000243,E10000015
+2024,2024,Woodhouse Park,Wythenshawe and Sale East,Manchester,Manchester,E05011381,E14001602,E08000003,E08000003
+2024,2024,Offerton,Hazel Grove,Stockport,Stockport,E05015032,E14001277,E08000007,E08000007
+2024,2024,Alexandra,Oldham East and Saddleworth,Oldham,Oldham,E05014646,E14001415,E08000004,E08000004
+2024,2024,Reddish North,Stockport,Stockport,Stockport,E05015033,E14001517,E08000007,E08000007
+2024,2024,Chadderton Central,"Oldham West, Chadderton and Royton",Oldham,Oldham,E05014647,E14001416,E08000004,E08000004
+2024,2024,Reddish South,Stockport,Stockport,Stockport,E05015034,E14001517,E08000007,E08000007
+2024,2024,Chadderton North,"Oldham West, Chadderton and Royton",Oldham,Oldham,E05014648,E14001416,E08000004,E08000004
+2024,2024,Ashton Hurst,Ashton-under-Lyne,Tameside,Tameside,E05014519,E14001070,E08000008,E08000008
+2024,2024,Chadderton South,"Oldham West, Chadderton and Royton",Oldham,Oldham,E05014649,E14001416,E08000004,E08000004
+2024,2024,Ashton Hurst,Stalybridge and Hyde,Tameside,Tameside,E05014519,E14001515,E08000008,E08000008
+2024,2024,Ashton St Michael's,Ashton-under-Lyne,Tameside,Tameside,E05014520,E14001070,E08000008,E08000008
+2024,2024,Ashton Waterloo,Ashton-under-Lyne,Tameside,Tameside,E05014521,E14001070,E08000008,E08000008
+2024,2024,Audenshaw,Ashton-under-Lyne,Tameside,Tameside,E05014522,E14001070,E08000008,E08000008
+2024,2024,Audenshaw,Gorton and Denton,Tameside,Tameside,E05014522,E14001251,E08000008,E08000008
+2024,2024,Woodfield,Stevenage,Stevenage,Hertfordshire,E05015636,E14001516,E07000243,E10000015
+2024,2024,Beccles & Worlingham,Lowestoft,East Suffolk,Suffolk,E05012735,E14001344,E07000244,E10000029
+2024,2024,Bungay & Wainford,Waveney Valley,East Suffolk,Suffolk,E05012736,E14001569,E07000244,E10000029
+2024,2024,Childwall,Liverpool Garston,Liverpool,Liverpool,E05015286,E14001337,E08000012,E08000012
+2024,2024,Childwall,Liverpool Wavertree,Liverpool,Liverpool,E05015286,E14001340,E08000012,E08000012
+2024,2024,Church,Liverpool Garston,Liverpool,Liverpool,E05015287,E14001337,E08000012,E08000012
+2024,2024,Church,Liverpool Wavertree,Liverpool,Liverpool,E05015287,E14001340,E08000012,E08000012
+2024,2024,City Centre North,Liverpool Riverside,Liverpool,Liverpool,E05015288,E14001338,E08000012,E08000012
+2024,2024,City Centre South,Liverpool Riverside,Liverpool,Liverpool,E05015289,E14001338,E08000012,E08000012
+2024,2024,Clubmoor East,Liverpool Walton,Liverpool,Liverpool,E05015290,E14001339,E08000012,E08000012
+2024,2024,Clubmoor West,Liverpool Walton,Liverpool,Liverpool,E05015291,E14001339,E08000012,E08000012
+2024,2024,County,Liverpool Walton,Liverpool,Liverpool,E05015292,E14001339,E08000012,E08000012
+2024,2024,Croxteth,Liverpool Walton,Liverpool,Liverpool,E05015293,E14001339,E08000012,E08000012
+2024,2024,Croxteth Country Park,Liverpool Walton,Liverpool,Liverpool,E05015294,E14001339,E08000012,E08000012
+2024,2024,Dingle,Liverpool Riverside,Liverpool,Liverpool,E05015295,E14001338,E08000012,E08000012
+2024,2024,Edge Hill,Liverpool Riverside,Liverpool,Liverpool,E05015296,E14001338,E08000012,E08000012
+2024,2024,Edge Hill,Liverpool Wavertree,Liverpool,Liverpool,E05015296,E14001340,E08000012,E08000012
+2024,2024,Everton East,Liverpool Riverside,Liverpool,Liverpool,E05015297,E14001338,E08000012,E08000012
+2024,2024,Everton East,Liverpool Wavertree,Liverpool,Liverpool,E05015297,E14001340,E08000012,E08000012
+2024,2024,Everton North,Liverpool Riverside,Liverpool,Liverpool,E05015298,E14001338,E08000012,E08000012
+2024,2024,Everton West,Liverpool Riverside,Liverpool,Liverpool,E05015299,E14001338,E08000012,E08000012
+2024,2024,Fazakerley East,Liverpool Walton,Liverpool,Liverpool,E05015300,E14001339,E08000012,E08000012
+2024,2024,Fazakerley North,Liverpool Walton,Liverpool,Liverpool,E05015301,E14001339,E08000012,E08000012
+2024,2024,Fazakerley West,Liverpool Walton,Liverpool,Liverpool,E05015302,E14001339,E08000012,E08000012
+2024,2024,Festival Gardens,Liverpool Riverside,Liverpool,Liverpool,E05015303,E14001338,E08000012,E08000012
+2024,2024,Festival Gardens,Liverpool Wavertree,Liverpool,Liverpool,E05015303,E14001340,E08000012,E08000012
+2024,2024,Garston,Liverpool Garston,Liverpool,Liverpool,E05015304,E14001337,E08000012,E08000012
+2024,2024,Gateacre,Liverpool Garston,Liverpool,Liverpool,E05015305,E14001337,E08000012,E08000012
+2024,2024,Gateacre,Liverpool Wavertree,Liverpool,Liverpool,E05015305,E14001340,E08000012,E08000012
+2024,2024,Grassendale & Cressington,Liverpool Garston,Liverpool,Liverpool,E05015306,E14001337,E08000012,E08000012
+2024,2024,Greenbank Park,Liverpool Wavertree,Liverpool,Liverpool,E05015307,E14001340,E08000012,E08000012
+2024,2024,Kensington & Fairfield,Liverpool Riverside,Liverpool,Liverpool,E05015308,E14001338,E08000012,E08000012
+2024,2024,Kensington & Fairfield,Liverpool Wavertree,Liverpool,Liverpool,E05015308,E14001340,E08000012,E08000012
+2024,2024,Kensington & Fairfield,Liverpool West Derby,Liverpool,Liverpool,E05015308,E14001341,E08000012,E08000012
+2024,2024,Kirkdale East,Liverpool Riverside,Liverpool,Liverpool,E05015309,E14001338,E08000012,E08000012
+2024,2024,Kirkdale West,Liverpool Riverside,Liverpool,Liverpool,E05015310,E14001338,E08000012,E08000012
+2024,2024,Knotty Ash & Dovecot Park,Liverpool West Derby,Liverpool,Liverpool,E05015311,E14001341,E08000012,E08000012
+2024,2024,Mossley Hill,Liverpool Garston,Liverpool,Liverpool,E05015312,E14001337,E08000012,E08000012
+2024,2024,Mossley Hill,Liverpool Wavertree,Liverpool,Liverpool,E05015312,E14001340,E08000012,E08000012
+2024,2024,Much Woolton & Hunts Cross,Liverpool Garston,Liverpool,Liverpool,E05015313,E14001337,E08000012,E08000012
+2024,2024,Norris Green,Liverpool Walton,Liverpool,Liverpool,E05015314,E14001339,E08000012,E08000012
+2024,2024,Old Swan East,Liverpool West Derby,Liverpool,Liverpool,E05015315,E14001341,E08000012,E08000012
+2024,2024,Old Swan West,Liverpool Wavertree,Liverpool,Liverpool,E05015316,E14001340,E08000012,E08000012
+2024,2024,Old Swan West,Liverpool West Derby,Liverpool,Liverpool,E05015316,E14001341,E08000012,E08000012
+2024,2024,Orrell Park,Liverpool Walton,Liverpool,Liverpool,E05015317,E14001339,E08000012,E08000012
+2024,2024,Penny Lane,Liverpool Garston,Liverpool,Liverpool,E05015318,E14001337,E08000012,E08000012
+2024,2024,Penny Lane,Liverpool Wavertree,Liverpool,Liverpool,E05015318,E14001340,E08000012,E08000012
+2024,2024,Princes Park,Liverpool Riverside,Liverpool,Liverpool,E05015319,E14001338,E08000012,E08000012
+2024,2024,Princes Park,Liverpool Wavertree,Liverpool,Liverpool,E05015319,E14001340,E08000012,E08000012
+2024,2024,Sandfield Park,Liverpool West Derby,Liverpool,Liverpool,E05015320,E14001341,E08000012,E08000012
+2024,2024,Sefton Park,Liverpool Riverside,Liverpool,Liverpool,E05015321,E14001338,E08000012,E08000012
+2024,2024,Sefton Park,Liverpool Wavertree,Liverpool,Liverpool,E05015321,E14001340,E08000012,E08000012
+2024,2024,Smithdown,Liverpool Wavertree,Liverpool,Liverpool,E05015322,E14001340,E08000012,E08000012
+2024,2024,Hindley,Makerfield,Wigan,Wigan,E05014998,E14001350,E08000010,E08000010
+2024,2024,Denton North East,Ashton-under-Lyne,Tameside,Tameside,E05014523,E14001070,E08000008,E08000008
+2024,2024,Linacre,Bootle,Sefton,Sefton,E05000942,E14001113,E08000014,E08000014
+2024,2024,Penistone West,Penistone and Stocksbridge,Barnsley,Barnsley,E05000990,E14001423,E08000016,E08000016
+2024,2024,Wales,Rother Valley,Rotherham,Rotherham,E05013015,E14001451,E08000018,E08000018
+2024,2024,Rockingham,Barnsley South,Barnsley,Barnsley,E05000991,E14001075,E08000016,E08000016
+2024,2024,Royston,Barnsley North,Barnsley,Barnsley,E05000992,E14001074,E08000016,E08000016
+2024,2024,St Helens,Barnsley North,Barnsley,Barnsley,E05000993,E14001074,E08000016,E08000016
+2024,2024,Stairfoot,Barnsley South,Barnsley,Barnsley,E05000994,E14001075,E08000016,E08000016
+2024,2024,Wombwell,Barnsley South,Barnsley,Barnsley,E05000995,E14001075,E08000016,E08000016
+2024,2024,Worsbrough,Barnsley South,Barnsley,Barnsley,E05000996,E14001075,E08000016,E08000016
+2024,2024,Adwick le Street & Carcroft,Doncaster North,Doncaster,Doncaster,E05010728,E14001200,E08000017,E08000017
+2024,2024,Armthorpe,Doncaster Central,Doncaster,Doncaster,E05010729,E14001198,E08000017,E08000017
+2024,2024,Balby South,Doncaster Central,Doncaster,Doncaster,E05010730,E14001198,E08000017,E08000017
+2024,2024,Bentley,Doncaster North,Doncaster,Doncaster,E05010731,E14001200,E08000017,E08000017
+2024,2024,Bessacarr,Doncaster Central,Doncaster,Doncaster,E05010732,E14001198,E08000017,E08000017
+2024,2024,Conisbrough,Rawmarsh and Conisbrough,Doncaster,Doncaster,E05010733,E14001436,E08000017,E08000017
+2024,2024,Edenthorpe & Kirk Sandall,Doncaster Central,Doncaster,Doncaster,E05010734,E14001198,E08000017,E08000017
+2024,2024,Edlington & Warmsworth,Rawmarsh and Conisbrough,Doncaster,Doncaster,E05010735,E14001436,E08000017,E08000017
+2024,2024,Finningley,Doncaster East and the Isle of Axholme,Doncaster,Doncaster,E05010736,E14001199,E08000017,E08000017
+2024,2024,Hatfield,Doncaster East and the Isle of Axholme,Doncaster,Doncaster,E05010737,E14001199,E08000017,E08000017
+2024,2024,Hexthorpe & Balby North,Doncaster Central,Doncaster,Doncaster,E05010738,E14001198,E08000017,E08000017
+2024,2024,Mexborough,Doncaster North,Doncaster,Doncaster,E05010739,E14001200,E08000017,E08000017
+2024,2024,Wath,Rawmarsh and Conisbrough,Rotherham,Rotherham,E05013016,E14001436,E08000018,E08000018
+2024,2024,Speke,Liverpool Garston,Liverpool,Liverpool,E05015323,E14001337,E08000012,E08000012
+2024,2024,Norton & Askern,Doncaster North,Doncaster,Doncaster,E05010740,E14001200,E08000017,E08000017
+2024,2024,Manor Park,Newcastle upon Tyne East and Wallsend,Newcastle upon Tyne,Newcastle upon Tyne,E05011452,E14001378,E08000021,E08000021
+2024,2024,Wickersley North,Rotherham,Rotherham,Rotherham,E05013017,E14001452,E08000018,E08000018
+2024,2024,Litherland,Bootle,Sefton,Sefton,E05000943,E14001113,E08000014,E08000014
+2024,2024,Springwood,Liverpool Garston,Liverpool,Liverpool,E05015324,E14001337,E08000012,E08000012
+2024,2024,Roman Ridge,Doncaster North,Doncaster,Doncaster,E05010741,E14001200,E08000017,E08000017
+2024,2024,Denton North East,Gorton and Denton,Tameside,Tameside,E05014523,E14001251,E08000008,E08000008
+2024,2024,Hindley,Wigan,Wigan,Wigan,E05014998,E14001585,E08000010,E08000010
+2024,2024,Monument,Newcastle upon Tyne Central and West,Newcastle upon Tyne,Newcastle upon Tyne,E05011453,E14001377,E08000021,E08000021
+2024,2024,Beauchief and Greenhill,Sheffield Heeley,Sheffield,Sheffield,E05010857,E14001469,E08000019,E08000019
+2024,2024,Manor,Sefton Central,Sefton,Sefton,E05000944,E14001463,E08000014,E08000014
+2024,2024,St Michaels,Liverpool Wavertree,Liverpool,Liverpool,E05015325,E14001340,E08000012,E08000012
+2024,2024,Rossington & Bawtry,Doncaster East and the Isle of Axholme,Doncaster,Doncaster,E05010742,E14001199,E08000017,E08000017
+2024,2024,Denton South,Gorton and Denton,Tameside,Tameside,E05014524,E14001251,E08000008,E08000008
+2024,2024,Hindley Green,Leigh and Atherton,Wigan,Wigan,E05014999,E14001329,E08000010,E08000010
+2024,2024,North Jesmond,Newcastle upon Tyne North,Newcastle upon Tyne,Newcastle upon Tyne,E05011454,E14001379,E08000021,E08000021
+2024,2024,Meols,Southport,Sefton,Sefton,E05000945,E14001504,E08000014,E08000014
+2024,2024,Beighton,Sheffield South East,Sheffield,Sheffield,E05010858,E14001470,E08000019,E08000019
+2024,2024,Molyneux,Liverpool Walton,Sefton,Sefton,E05000946,E14001339,E08000014,E08000014
+2024,2024,Birley,Sheffield South East,Sheffield,Sheffield,E05010859,E14001470,E08000019,E08000019
+2024,2024,Molyneux,Sefton Central,Sefton,Sefton,E05000946,E14001463,E08000014,E08000014
+2024,2024,Broomhill and Sharrow Vale,Sheffield Central,Sheffield,Sheffield,E05010860,E14001467,E08000019,E08000019
+2024,2024,Netherton and Orrell,Bootle,Sefton,Sefton,E05000947,E14001113,E08000014,E08000014
+2024,2024,Burngreave,Sheffield Brightside and Hillsborough,Sheffield,Sheffield,E05010861,E14001466,E08000019,E08000019
+2024,2024,Norwood,Southport,Sefton,Sefton,E05000948,E14001504,E08000014,E08000014
+2024,2024,City,Sheffield Central,Sheffield,Sheffield,E05010862,E14001467,E08000019,E08000019
+2024,2024,Park,Sefton Central,Sefton,Sefton,E05000949,E14001463,E08000014,E08000014
+2024,2024,Crookes and Crosspool,Sheffield Hallam,Sheffield,Sheffield,E05010863,E14001468,E08000019,E08000019
+2024,2024,Ravenmeols,Sefton Central,Sefton,Sefton,E05000950,E14001463,E08000014,E08000014
+2024,2024,Darnall,Sheffield South East,Sheffield,Sheffield,E05010864,E14001470,E08000019,E08000019
+2024,2024,St Oswald,Bootle,Sefton,Sefton,E05000951,E14001113,E08000014,E08000014
+2024,2024,Sprotbrough,Doncaster North,Doncaster,Doncaster,E05010743,E14001200,E08000017,E08000017
+2024,2024,Dore and Totley,Sheffield Hallam,Sheffield,Sheffield,E05010865,E14001468,E08000019,E08000019
+2024,2024,Sudell,Sefton Central,Sefton,Sefton,E05000952,E14001463,E08000014,E08000014
+2024,2024,Ouseburn,Newcastle upon Tyne East and Wallsend,Newcastle upon Tyne,Newcastle upon Tyne,E05011455,E14001378,E08000021,E08000021
+2024,2024,Stoneycroft,Liverpool West Derby,Liverpool,Liverpool,E05015326,E14001341,E08000012,E08000012
+2024,2024,Denton West,Gorton and Denton,Tameside,Tameside,E05014525,E14001251,E08000008,E08000008
+2024,2024,Hindley Green,Makerfield,Wigan,Wigan,E05014999,E14001350,E08000010,E08000010
+2024,2024,Ince,Makerfield,Wigan,Wigan,E05015000,E14001350,E08000010,E08000010
+2024,2024,Ince,Wigan,Wigan,Wigan,E05015000,E14001585,E08000010,E08000010
+2024,2024,Leigh Central & Higher Folds,Leigh and Atherton,Wigan,Wigan,E05015001,E14001329,E08000010,E08000010
+2024,2024,Leigh South,Leigh and Atherton,Wigan,Wigan,E05015002,E14001329,E08000010,E08000010
+2024,2024,Leigh South,Worsley and Eccles,Wigan,Wigan,E05015002,E14001598,E08000010,E08000010
+2024,2024,Leigh West,Leigh and Atherton,Wigan,Wigan,E05015003,E14001329,E08000010,E08000010
+2024,2024,Leigh West,Makerfield,Wigan,Wigan,E05015003,E14001350,E08000010,E08000010
+2024,2024,Toxteth,Liverpool Riverside,Liverpool,Liverpool,E05015327,E14001338,E08000012,E08000012
+2024,2024,Tuebrook Breckside Park,Liverpool Riverside,Liverpool,Liverpool,E05015328,E14001338,E08000012,E08000012
+2024,2024,Tuebrook Breckside Park,Liverpool West Derby,Liverpool,Liverpool,E05015328,E14001341,E08000012,E08000012
+2024,2024,Tuebrook Larkhill,Liverpool Walton,Liverpool,Liverpool,E05015329,E14001339,E08000012,E08000012
+2024,2024,Lowton East,Leigh and Atherton,Wigan,Wigan,E05015004,E14001329,E08000010,E08000010
+2024,2024,Tuebrook Larkhill,Liverpool West Derby,Liverpool,Liverpool,E05015329,E14001341,E08000012,E08000012
+2024,2024,Orrell,Makerfield,Wigan,Wigan,E05015005,E14001350,E08000010,E08000010
+2024,2024,Parklands,Newcastle upon Tyne North,Newcastle upon Tyne,Newcastle upon Tyne,E05011456,E14001379,E08000021,E08000021
+2024,2024,South Jesmond,Newcastle upon Tyne North,Newcastle upon Tyne,Newcastle upon Tyne,E05011457,E14001379,E08000021,E08000021
+2024,2024,Walker,Newcastle upon Tyne East and Wallsend,Newcastle upon Tyne,Newcastle upon Tyne,E05011458,E14001378,E08000021,E08000021
+2024,2024,Walkergate,Newcastle upon Tyne East and Wallsend,Newcastle upon Tyne,Newcastle upon Tyne,E05011459,E14001378,E08000021,E08000021
+2024,2024,West Fenham,Newcastle upon Tyne Central and West,Newcastle upon Tyne,Newcastle upon Tyne,E05011460,E14001377,E08000021,E08000021
+2024,2024,Wingrove,Newcastle upon Tyne Central and West,Newcastle upon Tyne,Newcastle upon Tyne,E05011461,E14001377,E08000021,E08000021
+2024,2024,Backworth & Holystone,Cramlington and Killingworth,North Tyneside,North Tyneside,E05015865,E14001183,E08000022,E08000022
+2024,2024,Battle Hill,Cramlington and Killingworth,North Tyneside,North Tyneside,E05015866,E14001183,E08000022,E08000022
+2024,2024,Battle Hill,Newcastle upon Tyne East and Wallsend,North Tyneside,North Tyneside,E05015866,E14001378,E08000022,E08000022
+2024,2024,Camperdown,Cramlington and Killingworth,North Tyneside,North Tyneside,E05015867,E14001183,E08000022,E08000022
+2024,2024,Camperdown,Newcastle upon Tyne North,North Tyneside,North Tyneside,E05015867,E14001379,E08000022,E08000022
+2024,2024,Chirton & Percy Main,Tynemouth,North Tyneside,North Tyneside,E05015868,E14001557,E08000022,E08000022
+2024,2024,Cullercoats & Whitley Bay South,Tynemouth,North Tyneside,North Tyneside,E05015869,E14001557,E08000022,E08000022
+2024,2024,Forest Hall,Cramlington and Killingworth,North Tyneside,North Tyneside,E05015870,E14001183,E08000022,E08000022
+2024,2024,Pemberton,Wigan,Wigan,Wigan,E05015006,E14001585,E08000010,E08000010
+2024,2024,Forest Hall,Newcastle upon Tyne North,North Tyneside,North Tyneside,E05015870,E14001379,E08000022,E08000022
+2024,2024,East Ecclesfield,Penistone and Stocksbridge,Sheffield,Sheffield,E05010866,E14001423,E08000019,E08000019
+2024,2024,Shevington with Lower Ground & Moor,Wigan,Wigan,Wigan,E05015007,E14001585,E08000010,E08000010
+2024,2024,Howdon,Newcastle upon Tyne East and Wallsend,North Tyneside,North Tyneside,E05015871,E14001378,E08000022,E08000022
+2024,2024,Droylsden East,Ashton-under-Lyne,Tameside,Tameside,E05014526,E14001070,E08000008,E08000008
+2024,2024,Victoria,Bootle,Sefton,Sefton,E05000953,E14001113,E08000014,E08000014
+2024,2024,Stainforth & Barnby Dun,Doncaster North,Doncaster,Doncaster,E05010744,E14001200,E08000017,E08000017
+2024,2024,Thorne & Moorends,Doncaster East and the Isle of Axholme,Doncaster,Doncaster,E05010745,E14001199,E08000017,E08000017
+2024,2024,Tickhill & Wadsworth,Doncaster Central,Doncaster,Doncaster,E05010746,E14001198,E08000017,E08000017
+2024,2024,Vauxhall,Liverpool Riverside,Liverpool,Liverpool,E05015330,E14001338,E08000012,E08000012
+2024,2024,Town,Doncaster Central,Doncaster,Doncaster,E05010747,E14001198,E08000017,E08000017
+2024,2024,Walton,Liverpool Walton,Liverpool,Liverpool,E05015331,E14001339,E08000012,E08000012
+2024,2024,Wheatley Hills & Intake,Doncaster Central,Doncaster,Doncaster,E05010748,E14001198,E08000017,E08000017
+2024,2024,Waterfront North,Liverpool Riverside,Liverpool,Liverpool,E05015332,E14001338,E08000012,E08000012
+2024,2024,Anston & Woodsetts,Rother Valley,Rotherham,Rotherham,E05012993,E14001451,E08000018,E08000018
+2024,2024,Waterfront South,Liverpool Riverside,Liverpool,Liverpool,E05015333,E14001338,E08000012,E08000012
+2024,2024,Aston & Todwick,Rother Valley,Rotherham,Rotherham,E05012994,E14001451,E08000018,E08000018
+2024,2024,Wavertree Garden Suburb,Liverpool Wavertree,Liverpool,Liverpool,E05015334,E14001340,E08000012,E08000012
+2024,2024,Aughton & Swallownest,Rother Valley,Rotherham,Rotherham,E05012995,E14001451,E08000018,E08000018
+2024,2024,Wavertree Village,Liverpool Wavertree,Liverpool,Liverpool,E05015335,E14001340,E08000012,E08000012
+2024,2024,Boston Castle,Rotherham,Rotherham,Rotherham,E05012996,E14001452,E08000018,E08000018
+2024,2024,West Derby Deysbrook,Liverpool West Derby,Liverpool,Liverpool,E05015336,E14001341,E08000012,E08000012
+2024,2024,Bramley & Ravenfield,Rawmarsh and Conisbrough,Rotherham,Rotherham,E05012997,E14001436,E08000018,E08000018
+2024,2024,Brinsworth,Rotherham,Rotherham,Rotherham,E05012998,E14001452,E08000018,E08000018
+2024,2024,Dalton & Thrybergh,Rotherham,Rotherham,Rotherham,E05012999,E14001452,E08000018,E08000018
+2024,2024,Dinnington,Rother Valley,Rotherham,Rotherham,E05013000,E14001451,E08000018,E08000018
+2024,2024,Greasbrough,Rotherham,Rotherham,Rotherham,E05013001,E14001452,E08000018,E08000018
+2024,2024,Hellaby & Maltby West,Rother Valley,Rotherham,Rotherham,E05013002,E14001451,E08000018,E08000018
+2024,2024,Hoober,Rawmarsh and Conisbrough,Rotherham,Rotherham,E05013003,E14001436,E08000018,E08000018
+2024,2024,Keppel,Rotherham,Rotherham,Rotherham,E05013004,E14001452,E08000018,E08000018
+2024,2024,Kilnhurst & Swinton East,Rawmarsh and Conisbrough,Rotherham,Rotherham,E05013005,E14001436,E08000018,E08000018
+2024,2024,Maltby East,Rother Valley,Rotherham,Rotherham,E05013006,E14001451,E08000018,E08000018
+2024,2024,Rawmarsh East,Rawmarsh and Conisbrough,Rotherham,Rotherham,E05013007,E14001436,E08000018,E08000018
+2024,2024,Rawmarsh West,Rawmarsh and Conisbrough,Rotherham,Rotherham,E05013008,E14001436,E08000018,E08000018
+2024,2024,Rother Vale,Rotherham,Rotherham,Rotherham,E05013009,E14001452,E08000018,E08000018
+2024,2024,Rotherham East,Rotherham,Rotherham,Rotherham,E05013010,E14001452,E08000018,E08000018
+2024,2024,Rotherham West,Rotherham,Rotherham,Rotherham,E05013011,E14001452,E08000018,E08000018
+2024,2024,Sitwell,Rother Valley,Rotherham,Rotherham,E05013012,E14001451,E08000018,E08000018
+2024,2024,Swinton Rockingham,Rawmarsh and Conisbrough,Rotherham,Rotherham,E05013013,E14001436,E08000018,E08000018
+2024,2024,Thurcroft & Wickersley South,Rother Valley,Rotherham,Rotherham,E05013014,E14001451,E08000018,E08000018
+2024,2024,Killingworth,Cramlington and Killingworth,North Tyneside,North Tyneside,E05015872,E14001183,E08000022,E08000022
+2024,2024,Ecclesall,Sheffield Hallam,Sheffield,Sheffield,E05010867,E14001468,E08000019,E08000019
+2024,2024,Standish with Langtree,Wigan,Wigan,Wigan,E05015008,E14001585,E08000010,E08000010
+2024,2024,Droylsden West,Ashton-under-Lyne,Tameside,Tameside,E05014527,E14001070,E08000008,E08000008
+2024,2024,Bebington,Birkenhead,Wirral,Wirral,E05000954,E14001091,E08000015,E08000015
+2024,2024,Longbenton & Benton,Newcastle upon Tyne North,North Tyneside,North Tyneside,E05015873,E14001379,E08000022,E08000022
+2024,2024,Monkseaton,Tynemouth,North Tyneside,North Tyneside,E05015874,E14001557,E08000022,E08000022
+2024,2024,New York & Murton,Cramlington and Killingworth,North Tyneside,North Tyneside,E05015875,E14001183,E08000022,E08000022
+2024,2024,New York & Murton,Tynemouth,North Tyneside,North Tyneside,E05015875,E14001557,E08000022,E08000022
+2024,2024,North Shields,Tynemouth,North Tyneside,North Tyneside,E05015876,E14001557,E08000022,E08000022
+2024,2024,Preston with Preston Grange,Tynemouth,North Tyneside,North Tyneside,E05015877,E14001557,E08000022,E08000022
+2024,2024,Shiremoor,Cramlington and Killingworth,North Tyneside,North Tyneside,E05015878,E14001183,E08000022,E08000022
+2024,2024,Shiremoor,Tynemouth,North Tyneside,North Tyneside,E05015878,E14001557,E08000022,E08000022
+2024,2024,St Mary's,Tynemouth,North Tyneside,North Tyneside,E05015879,E14001557,E08000022,E08000022
+2024,2024,Tynemouth,Tynemouth,North Tyneside,North Tyneside,E05015880,E14001557,E08000022,E08000022
+2024,2024,Wallsend Central,Newcastle upon Tyne East and Wallsend,North Tyneside,North Tyneside,E05015881,E14001378,E08000022,E08000022
+2024,2024,Wallsend North,Newcastle upon Tyne East and Wallsend,North Tyneside,North Tyneside,E05015882,E14001378,E08000022,E08000022
+2024,2024,Weetslade,Cramlington and Killingworth,North Tyneside,North Tyneside,E05015883,E14001183,E08000022,E08000022
+2024,2024,Whitley Bay North,Tynemouth,North Tyneside,North Tyneside,E05015884,E14001557,E08000022,E08000022
+2024,2024,Beacon and Bents,South Shields,South Tyneside,South Tyneside,E05001135,E14001492,E08000023,E08000023
+2024,2024,Bede,Jarrow and Gateshead East,South Tyneside,South Tyneside,E05001136,E14001307,E08000023,E08000023
+2024,2024,Bidston and St James,Birkenhead,Wirral,Wirral,E05000955,E14001091,E08000015,E08000015
+2024,2024,Biddick and All Saints,South Shields,South Tyneside,South Tyneside,E05001137,E14001492,E08000023,E08000023
+2024,2024,Boldon Colliery,Jarrow and Gateshead East,South Tyneside,South Tyneside,E05001138,E14001307,E08000023,E08000023
+2024,2024,Birkenhead and Tranmere,Birkenhead,Wirral,Wirral,E05000956,E14001091,E08000015,E08000015
+2024,2024,Cleadon and East Boldon,South Shields,South Tyneside,South Tyneside,E05001139,E14001492,E08000023,E08000023
+2024,2024,Bromborough,Ellesmere Port and Bromborough,Wirral,Wirral,E05000957,E14001222,E08000015,E08000015
+2024,2024,Cleadon Park,South Shields,South Tyneside,South Tyneside,E05001140,E14001492,E08000023,E08000023
+2024,2024,Clatterbridge,Wirral West,Wirral,Wirral,E05000958,E14001589,E08000015,E08000015
+2024,2024,Fellgate and Hedworth,Jarrow and Gateshead East,South Tyneside,South Tyneside,E05001141,E14001307,E08000023,E08000023
+2024,2024,Claughton,Birkenhead,Wirral,Wirral,E05000959,E14001091,E08000015,E08000015
+2024,2024,Harton,South Shields,South Tyneside,South Tyneside,E05001142,E14001492,E08000023,E08000023
+2024,2024,Eastham,Ellesmere Port and Bromborough,Wirral,Wirral,E05000960,E14001222,E08000015,E08000015
+2024,2024,Hebburn North,Jarrow and Gateshead East,South Tyneside,South Tyneside,E05001143,E14001307,E08000023,E08000023
+2024,2024,"Greasby, Frankby and Irby",Wirral West,Wirral,Wirral,E05000961,E14001589,E08000015,E08000015
+2024,2024,Hebburn South,Jarrow and Gateshead East,South Tyneside,South Tyneside,E05001144,E14001307,E08000023,E08000023
+2024,2024,Heswall,Wirral West,Wirral,Wirral,E05000962,E14001589,E08000015,E08000015
+2024,2024,Horsley Hill,South Shields,South Tyneside,South Tyneside,E05001145,E14001492,E08000023,E08000023
+2024,2024,Hoylake and Meols,Wirral West,Wirral,Wirral,E05000963,E14001589,E08000015,E08000015
+2024,2024,Monkton,Jarrow and Gateshead East,South Tyneside,South Tyneside,E05001146,E14001307,E08000023,E08000023
+2024,2024,Leasowe and Moreton East,Wallasey,Wirral,Wirral,E05000964,E14001561,E08000015,E08000015
+2024,2024,Primrose,Jarrow and Gateshead East,South Tyneside,South Tyneside,E05001147,E14001307,E08000023,E08000023
+2024,2024,Liscard,Wallasey,Wirral,Wirral,E05000965,E14001561,E08000015,E08000015
+2024,2024,Simonside and Rekendyke,South Shields,South Tyneside,South Tyneside,E05001148,E14001492,E08000023,E08000023
+2024,2024,Moreton West and Saughall Massie,Wallasey,Wirral,Wirral,E05000966,E14001561,E08000015,E08000015
+2024,2024,Westoe,South Shields,South Tyneside,South Tyneside,E05001149,E14001492,E08000023,E08000023
+2024,2024,New Brighton,Wallasey,Wirral,Wirral,E05000967,E14001561,E08000015,E08000015
+2024,2024,Oxton,Birkenhead,Wirral,Wirral,E05000968,E14001091,E08000015,E08000015
+2024,2024,Pensby and Thingwall,Wirral West,Wirral,Wirral,E05000969,E14001589,E08000015,E08000015
+2024,2024,Prenton,Birkenhead,Wirral,Wirral,E05000970,E14001091,E08000015,E08000015
+2024,2024,Rock Ferry,Birkenhead,Wirral,Wirral,E05000971,E14001091,E08000015,E08000015
+2024,2024,Seacombe,Wallasey,Wirral,Wirral,E05000972,E14001561,E08000015,E08000015
+2024,2024,Upton,Wallasey,Wirral,Wirral,E05000973,E14001561,E08000015,E08000015
+2024,2024,Upton,Wirral West,Wirral,Wirral,E05000973,E14001589,E08000015,E08000015
+2024,2024,Wallasey,Wallasey,Wirral,Wirral,E05000974,E14001561,E08000015,E08000015
+2024,2024,West Kirby and Thurstaston,Wirral West,Wirral,Wirral,E05000975,E14001589,E08000015,E08000015
+2024,2024,Central,Barnsley North,Barnsley,Barnsley,E05000976,E14001074,E08000016,E08000016
+2024,2024,Cudworth,Barnsley North,Barnsley,Barnsley,E05000977,E14001074,E08000016,E08000016
+2024,2024,Darfield,Barnsley South,Barnsley,Barnsley,E05000978,E14001075,E08000016,E08000016
+2024,2024,Darton East,Barnsley North,Barnsley,Barnsley,E05000979,E14001074,E08000016,E08000016
+2024,2024,Darton West,Barnsley North,Barnsley,Barnsley,E05000980,E14001074,E08000016,E08000016
+2024,2024,Dearne North,Barnsley South,Barnsley,Barnsley,E05000981,E14001075,E08000016,E08000016
+2024,2024,Dearne South,Barnsley South,Barnsley,Barnsley,E05000982,E14001075,E08000016,E08000016
+2024,2024,Dodworth,Penistone and Stocksbridge,Barnsley,Barnsley,E05000983,E14001423,E08000016,E08000016
+2024,2024,Hoyland Milton,Barnsley South,Barnsley,Barnsley,E05000984,E14001075,E08000016,E08000016
+2024,2024,Kingstone,Barnsley South,Barnsley,Barnsley,E05000985,E14001075,E08000016,E08000016
+2024,2024,Monk Bretton,Barnsley North,Barnsley,Barnsley,E05000986,E14001074,E08000016,E08000016
+2024,2024,North East,Barnsley North,Barnsley,Barnsley,E05000987,E14001074,E08000016,E08000016
+2024,2024,Old Town,Barnsley North,Barnsley,Barnsley,E05000988,E14001074,E08000016,E08000016
+2024,2024,Penistone East,Penistone and Stocksbridge,Barnsley,Barnsley,E05000989,E14001423,E08000016,E08000016
+2024,2024,West Derby Leyfield,Liverpool West Derby,Liverpool,Liverpool,E05015337,E14001341,E08000012,E08000012
+2024,2024,Dukinfield,Ashton-under-Lyne,Tameside,Tameside,E05014528,E14001070,E08000008,E08000008
+2024,2024,Tyldesley & Mosley Common,Leigh and Atherton,Wigan,Wigan,E05015009,E14001329,E08000010,E08000010
+2024,2024,Firth Park,Sheffield Brightside and Hillsborough,Sheffield,Sheffield,E05010868,E14001466,E08000019,E08000019
+2024,2024,Fulwood,Sheffield Hallam,Sheffield,Sheffield,E05010869,E14001468,E08000019,E08000019
+2024,2024,Gleadless Valley,Sheffield Heeley,Sheffield,Sheffield,E05010870,E14001469,E08000019,E08000019
+2024,2024,Graves Park,Sheffield Heeley,Sheffield,Sheffield,E05010871,E14001469,E08000019,E08000019
+2024,2024,Hillsborough,Sheffield Brightside and Hillsborough,Sheffield,Sheffield,E05010872,E14001466,E08000019,E08000019
+2024,2024,Manor Castle,Sheffield Heeley,Sheffield,Sheffield,E05010873,E14001469,E08000019,E08000019
+2024,2024,Mosborough,Sheffield South East,Sheffield,Sheffield,E05010874,E14001470,E08000019,E08000019
+2024,2024,Nether Edge and Sharrow,Sheffield Central,Sheffield,Sheffield,E05010875,E14001467,E08000019,E08000019
+2024,2024,Park and Arbourthorne,Sheffield Heeley,Sheffield,Sheffield,E05010876,E14001469,E08000019,E08000019
+2024,2024,Richmond,Sheffield Heeley,Sheffield,Sheffield,E05010877,E14001469,E08000019,E08000019
+2024,2024,Richmond,Sheffield South East,Sheffield,Sheffield,E05010877,E14001470,E08000019,E08000019
+2024,2024,Shiregreen and Brightside,Sheffield Brightside and Hillsborough,Sheffield,Sheffield,E05010878,E14001466,E08000019,E08000019
+2024,2024,Southey,Sheffield Brightside and Hillsborough,Sheffield,Sheffield,E05010879,E14001466,E08000019,E08000019
+2024,2024,Stannington,Sheffield Hallam,Sheffield,Sheffield,E05010880,E14001468,E08000019,E08000019
+2024,2024,Stocksbridge and Upper Don,Penistone and Stocksbridge,Sheffield,Sheffield,E05010881,E14001423,E08000019,E08000019
+2024,2024,Walkley,Sheffield Central,Sheffield,Sheffield,E05010882,E14001467,E08000019,E08000019
+2024,2024,West Ecclesfield,Penistone and Stocksbridge,Sheffield,Sheffield,E05010883,E14001423,E08000019,E08000019
+2024,2024,Woodhouse,Sheffield South East,Sheffield,Sheffield,E05010884,E14001470,E08000019,E08000019
+2024,2024,Arthur's Hill,Newcastle upon Tyne Central and West,Newcastle upon Tyne,Newcastle upon Tyne,E05011436,E14001377,E08000021,E08000021
+2024,2024,Benwell & Scotswood,Newcastle upon Tyne Central and West,Newcastle upon Tyne,Newcastle upon Tyne,E05011437,E14001377,E08000021,E08000021
+2024,2024,Tyldesley & Mosley Common,Worsley and Eccles,Wigan,Wigan,E05015009,E14001598,E08000010,E08000010
+2024,2024,Blakelaw,Newcastle upon Tyne Central and West,Newcastle upon Tyne,Newcastle upon Tyne,E05011438,E14001377,E08000021,E08000021
+2024,2024,Wigan Central,Wigan,Wigan,Wigan,E05015010,E14001585,E08000010,E08000010
+2024,2024,Wigan West,Wigan,Wigan,Wigan,E05015011,E14001585,E08000010,E08000010
+2024,2024,Winstanley,Makerfield,Wigan,Wigan,E05015012,E14001350,E08000010,E08000010
+2024,2024,Worsley Mesnes,Makerfield,Wigan,Wigan,E05015013,E14001350,E08000010,E08000010
+2024,2024,Cherryfield,Knowsley,Knowsley,Knowsley,E05010935,E14001317,E08000011,E08000011
+2024,2024,Halewood North,Widnes and Halewood,Knowsley,Knowsley,E05010936,E14001584,E08000011,E08000011
+2024,2024,Halewood South,Widnes and Halewood,Knowsley,Knowsley,E05010937,E14001584,E08000011,E08000011
+2024,2024,Northwood,Knowsley,Knowsley,Knowsley,E05010938,E14001317,E08000011,E08000011
+2024,2024,Page Moss,Liverpool West Derby,Knowsley,Knowsley,E05010939,E14001341,E08000011,E08000011
+2024,2024,Prescot North,Knowsley,Knowsley,Knowsley,E05010940,E14001317,E08000011,E08000011
+2024,2024,Prescot South,St Helens South and Whiston,Knowsley,Knowsley,E05010941,E14001510,E08000011,E08000011
+2024,2024,Roby,Knowsley,Knowsley,Knowsley,E05010942,E14001317,E08000011,E08000011
+2024,2024,Shevington,Knowsley,Knowsley,Knowsley,E05010943,E14001317,E08000011,E08000011
+2024,2024,St Gabriels,Knowsley,Knowsley,Knowsley,E05010944,E14001317,E08000011,E08000011
+2024,2024,St Michaels,Knowsley,Knowsley,Knowsley,E05010945,E14001317,E08000011,E08000011
+2024,2024,Stockbridge,Knowsley,Knowsley,Knowsley,E05010946,E14001317,E08000011,E08000011
+2024,2024,Swanside,Liverpool West Derby,Knowsley,Knowsley,E05010947,E14001341,E08000011,E08000011
+2024,2024,Whiston and Cronton,St Helens South and Whiston,Knowsley,Knowsley,E05010948,E14001510,E08000011,E08000011
+2024,2024,Whiston and Cronton,Widnes and Halewood,Knowsley,Knowsley,E05010948,E14001584,E08000011,E08000011
+2024,2024,Whitefield,Knowsley,Knowsley,Knowsley,E05010949,E14001317,E08000011,E08000011
+2024,2024,Aigburth,Liverpool Garston,Liverpool,Liverpool,E05015277,E14001337,E08000012,E08000012
+2024,2024,Aigburth,Liverpool Wavertree,Liverpool,Liverpool,E05015277,E14001340,E08000012,E08000012
+2024,2024,Allerton,Liverpool Garston,Liverpool,Liverpool,E05015278,E14001337,E08000012,E08000012
+2024,2024,Anfield,Liverpool Riverside,Liverpool,Liverpool,E05015279,E14001338,E08000012,E08000012
+2024,2024,Anfield,Liverpool West Derby,Liverpool,Liverpool,E05015279,E14001341,E08000012,E08000012
+2024,2024,Arundel,Liverpool Wavertree,Liverpool,Liverpool,E05015280,E14001340,E08000012,E08000012
+2024,2024,Belle Vale,Liverpool Garston,Liverpool,Liverpool,E05015281,E14001337,E08000012,E08000012
+2024,2024,Broadgreen,Liverpool West Derby,Liverpool,Liverpool,E05015282,E14001341,E08000012,E08000012
+2024,2024,Brownlow Hill,Liverpool Riverside,Liverpool,Liverpool,E05015283,E14001338,E08000012,E08000012
+2024,2024,Calderstones,Liverpool Garston,Liverpool,Liverpool,E05015284,E14001337,E08000012,E08000012
+2024,2024,Canning,Liverpool Riverside,Liverpool,Liverpool,E05015285,E14001338,E08000012,E08000012
+2024,2024,Canning,Liverpool Wavertree,Liverpool,Liverpool,E05015285,E14001340,E08000012,E08000012
+2024,2024,West Derby Muirhead,Liverpool Walton,Liverpool,Liverpool,E05015338,E14001339,E08000012,E08000012
+2024,2024,Dukinfield,Stalybridge and Hyde,Tameside,Tameside,E05014528,E14001515,E08000008,E08000008
+2024,2024,West Derby Muirhead,Liverpool West Derby,Liverpool,Liverpool,E05015338,E14001341,E08000012,E08000012
+2024,2024,Woolton Village,Liverpool Garston,Liverpool,Liverpool,E05015339,E14001337,E08000012,E08000012
+2024,2024,Yew Tree,Liverpool West Derby,Liverpool,Liverpool,E05015340,E14001341,E08000012,E08000012
+2024,2024,Billinge & Seneley Green,St Helens North,St. Helens,St. Helens,E05014120,E14001509,E08000013,E08000013
+2024,2024,Blackbrook,St Helens North,St. Helens,St. Helens,E05014121,E14001509,E08000013,E08000013
+2024,2024,Bold & Lea Green,St Helens South and Whiston,St. Helens,St. Helens,E05014122,E14001510,E08000013,E08000013
+2024,2024,Eccleston,St Helens South and Whiston,St. Helens,St. Helens,E05014123,E14001510,E08000013,E08000013
+2024,2024,Haydock,St Helens North,St. Helens,St. Helens,E05014124,E14001509,E08000013,E08000013
+2024,2024,Moss Bank,St Helens North,St. Helens,St. Helens,E05014125,E14001509,E08000013,E08000013
+2024,2024,Newton-le-Willows East,St Helens North,St. Helens,St. Helens,E05014126,E14001509,E08000013,E08000013
+2024,2024,Newton-le-Willows West,St Helens North,St. Helens,St. Helens,E05014127,E14001509,E08000013,E08000013
+2024,2024,Dukinfield Stalybridge,Ashton-under-Lyne,Tameside,Tameside,E05014529,E14001070,E08000008,E08000008
+2024,2024,Parr,St Helens North,St. Helens,St. Helens,E05014128,E14001509,E08000013,E08000013
+2024,2024,Dukinfield Stalybridge,Stalybridge and Hyde,Tameside,Tameside,E05014529,E14001515,E08000008,E08000008
+2024,2024,Peasley Cross & Fingerpost,St Helens South and Whiston,St. Helens,St. Helens,E05014129,E14001510,E08000013,E08000013
+2024,2024,Hyde Godley,Stalybridge and Hyde,Tameside,Tameside,E05014530,E14001515,E08000008,E08000008
+2024,2024,Rainford,St Helens North,St. Helens,St. Helens,E05014130,E14001509,E08000013,E08000013
+2024,2024,Hyde Newton,Stalybridge and Hyde,Tameside,Tameside,E05014531,E14001515,E08000008,E08000008
+2024,2024,Rainhill,St Helens South and Whiston,St. Helens,St. Helens,E05014131,E14001510,E08000013,E08000013
+2024,2024,Hyde Werneth,Stalybridge and Hyde,Tameside,Tameside,E05014532,E14001515,E08000008,E08000008
+2024,2024,St Helens Town Centre,St Helens South and Whiston,St. Helens,St. Helens,E05014132,E14001510,E08000013,E08000013
+2024,2024,Longdendale,Stalybridge and Hyde,Tameside,Tameside,E05014533,E14001515,E08000008,E08000008
+2024,2024,Sutton North West,St Helens South and Whiston,St. Helens,St. Helens,E05014133,E14001510,E08000013,E08000013
+2024,2024,Mossley,Stalybridge and Hyde,Tameside,Tameside,E05014534,E14001515,E08000008,E08000008
+2024,2024,Sutton South East,St Helens North,St. Helens,St. Helens,E05014134,E14001509,E08000013,E08000013
+2024,2024,St Peter's,Ashton-under-Lyne,Tameside,Tameside,E05014535,E14001070,E08000008,E08000008
+2024,2024,Sutton South East,St Helens South and Whiston,St. Helens,St. Helens,E05014134,E14001510,E08000013,E08000013
+2024,2024,Stalybridge North,Stalybridge and Hyde,Tameside,Tameside,E05014536,E14001515,E08000008,E08000008
+2024,2024,Thatto Heath,St Helens South and Whiston,St. Helens,St. Helens,E05014135,E14001510,E08000013,E08000013
+2024,2024,Stalybridge South,Stalybridge and Hyde,Tameside,Tameside,E05014537,E14001515,E08000008,E08000008
+2024,2024,West Park,St Helens South and Whiston,St. Helens,St. Helens,E05014136,E14001510,E08000013,E08000013
+2024,2024,Altrincham,Altrincham and Sale West,Trafford,Trafford,E05015239,E14001065,E08000009,E08000009
+2024,2024,Windle,St Helens North,St. Helens,St. Helens,E05014137,E14001509,E08000013,E08000013
+2024,2024,Ainsdale,Sefton Central,Sefton,Sefton,E05000932,E14001463,E08000014,E08000014
+2024,2024,Birkdale,Southport,Sefton,Sefton,E05000933,E14001504,E08000014,E08000014
+2024,2024,Blundellsands,Sefton Central,Sefton,Sefton,E05000934,E14001463,E08000014,E08000014
+2024,2024,Ashton upon Mersey,Altrincham and Sale West,Trafford,Trafford,E05015240,E14001065,E08000009,E08000009
+2024,2024,Cambridge,Southport,Sefton,Sefton,E05000935,E14001504,E08000014,E08000014
+2024,2024,Bowdon,Altrincham and Sale West,Trafford,Trafford,E05015241,E14001065,E08000009,E08000009
+2024,2024,Church,Bootle,Sefton,Sefton,E05000936,E14001113,E08000014,E08000014
+2024,2024,Broadheath,Altrincham and Sale West,Trafford,Trafford,E05015242,E14001065,E08000009,E08000009
+2024,2024,Brooklands,Wythenshawe and Sale East,Trafford,Trafford,E05015243,E14001602,E08000009,E08000009
+2024,2024,Bucklow-St Martins,Stretford and Urmston,Trafford,Trafford,E05015244,E14001528,E08000009,E08000009
+2024,2024,Davyhulme,Stretford and Urmston,Trafford,Trafford,E05015245,E14001528,E08000009,E08000009
+2024,2024,Flixton,Stretford and Urmston,Trafford,Trafford,E05015246,E14001528,E08000009,E08000009
+2024,2024,Gorse Hill & Cornbrook,Stretford and Urmston,Trafford,Trafford,E05015247,E14001528,E08000009,E08000009
+2024,2024,Hale,Altrincham and Sale West,Trafford,Trafford,E05015248,E14001065,E08000009,E08000009
+2024,2024,Hale Barns & Timperley South,Altrincham and Sale West,Trafford,Trafford,E05015249,E14001065,E08000009,E08000009
+2024,2024,Longford,Stretford and Urmston,Trafford,Trafford,E05015250,E14001528,E08000009,E08000009
+2024,2024,Lostock & Barton,Stretford and Urmston,Trafford,Trafford,E05015251,E14001528,E08000009,E08000009
+2024,2024,Manor,Altrincham and Sale West,Trafford,Trafford,E05015252,E14001065,E08000009,E08000009
+2024,2024,Old Trafford,Stretford and Urmston,Trafford,Trafford,E05015253,E14001528,E08000009,E08000009
+2024,2024,Sale Central,Wythenshawe and Sale East,Trafford,Trafford,E05015254,E14001602,E08000009,E08000009
+2024,2024,Sale Moor,Wythenshawe and Sale East,Trafford,Trafford,E05015255,E14001602,E08000009,E08000009
+2024,2024,Stretford & Humphrey Park,Stretford and Urmston,Trafford,Trafford,E05015256,E14001528,E08000009,E08000009
+2024,2024,Timperley Central,Altrincham and Sale West,Trafford,Trafford,E05015257,E14001065,E08000009,E08000009
+2024,2024,Timperley North,Altrincham and Sale West,Trafford,Trafford,E05015258,E14001065,E08000009,E08000009
+2024,2024,Urmston,Stretford and Urmston,Trafford,Trafford,E05015259,E14001528,E08000009,E08000009
+2024,2024,Abram,Makerfield,Wigan,Wigan,E05014989,E14001350,E08000010,E08000010
+2024,2024,Ashton-in-Makerfield South,Makerfield,Wigan,Wigan,E05014990,E14001350,E08000010,E08000010
+2024,2024,"Aspull, New Springs & Whelley",Wigan,Wigan,Wigan,E05014991,E14001585,E08000010,E08000010
+2024,2024,Astley,Leigh and Atherton,Wigan,Wigan,E05014992,E14001329,E08000010,E08000010
+2024,2024,Astley,Worsley and Eccles,Wigan,Wigan,E05014992,E14001598,E08000010,E08000010
+2024,2024,Atherton North,Leigh and Atherton,Wigan,Wigan,E05014993,E14001329,E08000010,E08000010
+2024,2024,Atherton South & Lilford,Leigh and Atherton,Wigan,Wigan,E05014994,E14001329,E08000010,E08000010
+2024,2024,Bryn with Ashton-in-Makerfield North,Makerfield,Wigan,Wigan,E05014995,E14001350,E08000010,E08000010
+2024,2024,Douglas,Wigan,Wigan,Wigan,E05014996,E14001585,E08000010,E08000010
+2024,2024,Golborne & Lowton West,Leigh and Atherton,Wigan,Wigan,E05014997,E14001329,E08000010,E08000010
+2024,2024,Golborne & Lowton West,Makerfield,Wigan,Wigan,E05014997,E14001350,E08000010,E08000010
+2024,2024,Byker,Newcastle upon Tyne East and Wallsend,Newcastle upon Tyne,Newcastle upon Tyne,E05011439,E14001378,E08000021,E08000021
+2024,2024,Callerton & Throckley,Hexham,Newcastle upon Tyne,Newcastle upon Tyne,E05011440,E14001285,E08000021,E08000021
+2024,2024,Castle,Cramlington and Killingworth,Newcastle upon Tyne,Newcastle upon Tyne,E05011441,E14001183,E08000021,E08000021
+2024,2024,Castle,Newcastle upon Tyne North,Newcastle upon Tyne,Newcastle upon Tyne,E05011441,E14001379,E08000021,E08000021
+2024,2024,Chapel,Newcastle upon Tyne Central and West,Newcastle upon Tyne,Newcastle upon Tyne,E05011442,E14001377,E08000021,E08000021
+2024,2024,Dene & South Gosforth,Newcastle upon Tyne North,Newcastle upon Tyne,Newcastle upon Tyne,E05011443,E14001379,E08000021,E08000021
+2024,2024,Denton & Westerhope,Newcastle upon Tyne Central and West,Newcastle upon Tyne,Newcastle upon Tyne,E05011444,E14001377,E08000021,E08000021
+2024,2024,Elswick,Newcastle upon Tyne Central and West,Newcastle upon Tyne,Newcastle upon Tyne,E05011445,E14001377,E08000021,E08000021
+2024,2024,Fawdon & West Gosforth,Newcastle upon Tyne North,Newcastle upon Tyne,Newcastle upon Tyne,E05011446,E14001379,E08000021,E08000021
+2024,2024,Gosforth,Newcastle upon Tyne North,Newcastle upon Tyne,Newcastle upon Tyne,E05011447,E14001379,E08000021,E08000021
+2024,2024,Heaton,Newcastle upon Tyne East and Wallsend,Newcastle upon Tyne,Newcastle upon Tyne,E05011448,E14001378,E08000021,E08000021
+2024,2024,Kenton,Newcastle upon Tyne North,Newcastle upon Tyne,Newcastle upon Tyne,E05011449,E14001379,E08000021,E08000021
+2024,2024,Kingston Park South & Newbiggin Hall,Newcastle upon Tyne Central and West,Newcastle upon Tyne,Newcastle upon Tyne,E05011450,E14001377,E08000021,E08000021
+2024,2024,Kingston Park South & Newbiggin Hall,Newcastle upon Tyne North,Newcastle upon Tyne,Newcastle upon Tyne,E05011450,E14001379,E08000021,E08000021
+2024,2024,Lemington,Newcastle upon Tyne Central and West,Newcastle upon Tyne,Newcastle upon Tyne,E05011451,E14001377,E08000021,E08000021
+2024,2024,Derby,Bootle,Sefton,Sefton,E05000937,E14001113,E08000014,E08000014
+2024,2024,Duke's,Southport,Sefton,Sefton,E05000938,E14001504,E08000014,E08000014
+2024,2024,Ford,Bootle,Sefton,Sefton,E05000939,E14001113,E08000014,E08000014
+2024,2024,Harington,Sefton Central,Sefton,Sefton,E05000940,E14001463,E08000014,E08000014
+2024,2024,Kew,Southport,Sefton,Sefton,E05000941,E14001504,E08000014,E08000014
+2024,2024,West Park,South Shields,South Tyneside,South Tyneside,E05001150,E14001492,E08000023,E08000023
+2024,2024,Whitburn and Marsden,South Shields,South Tyneside,South Tyneside,E05001151,E14001492,E08000023,E08000023
+2024,2024,Whiteleas,South Shields,South Tyneside,South Tyneside,E05001152,E14001492,E08000023,E08000023
+2024,2024,Barnes,Sunderland Central,Sunderland,Sunderland,E05001153,E14001531,E08000024,E08000024
+2024,2024,Castle,Washington and Gateshead South,Sunderland,Sunderland,E05001154,E14001567,E08000024,E08000024
+2024,2024,Copt Hill,Houghton and Sunderland South,Sunderland,Sunderland,E05001155,E14001295,E08000024,E08000024
+2024,2024,Doxford,Houghton and Sunderland South,Sunderland,Sunderland,E05001156,E14001295,E08000024,E08000024
+2024,2024,Fulwell,Sunderland Central,Sunderland,Sunderland,E05001157,E14001531,E08000024,E08000024
+2024,2024,Hendon,Sunderland Central,Sunderland,Sunderland,E05001158,E14001531,E08000024,E08000024
+2024,2024,Hetton,Houghton and Sunderland South,Sunderland,Sunderland,E05001159,E14001295,E08000024,E08000024
+2024,2024,Houghton,Houghton and Sunderland South,Sunderland,Sunderland,E05001160,E14001295,E08000024,E08000024
+2024,2024,Millfield,Sunderland Central,Sunderland,Sunderland,E05001161,E14001531,E08000024,E08000024
+2024,2024,Pallion,Sunderland Central,Sunderland,Sunderland,E05001162,E14001531,E08000024,E08000024
+2024,2024,Redhill,Washington and Gateshead South,Sunderland,Sunderland,E05001163,E14001567,E08000024,E08000024
+2024,2024,Ryhope,Sunderland Central,Sunderland,Sunderland,E05001164,E14001531,E08000024,E08000024
+2024,2024,St Anne's,Houghton and Sunderland South,Sunderland,Sunderland,E05001165,E14001295,E08000024,E08000024
+2024,2024,St Chad's,Houghton and Sunderland South,Sunderland,Sunderland,E05001166,E14001295,E08000024,E08000024
+2024,2024,St Michael's,Sunderland Central,Sunderland,Sunderland,E05001167,E14001531,E08000024,E08000024
+2024,2024,St Peter's,Sunderland Central,Sunderland,Sunderland,E05001168,E14001531,E08000024,E08000024
+2024,2024,Sandhill,Houghton and Sunderland South,Sunderland,Sunderland,E05001169,E14001295,E08000024,E08000024
+2024,2024,Shiney Row,Houghton and Sunderland South,Sunderland,Sunderland,E05001170,E14001295,E08000024,E08000024
+2024,2024,Silksworth,Houghton and Sunderland South,Sunderland,Sunderland,E05001171,E14001295,E08000024,E08000024
+2024,2024,Southwick,Sunderland Central,Sunderland,Sunderland,E05001172,E14001531,E08000024,E08000024
+2024,2024,Washington Central,Washington and Gateshead South,Sunderland,Sunderland,E05001173,E14001567,E08000024,E08000024
+2024,2024,Washington East,Washington and Gateshead South,Sunderland,Sunderland,E05001174,E14001567,E08000024,E08000024
+2024,2024,Washington North,Washington and Gateshead South,Sunderland,Sunderland,E05001175,E14001567,E08000024,E08000024
+2024,2024,Washington South,Washington and Gateshead South,Sunderland,Sunderland,E05001176,E14001567,E08000024,E08000024
+2024,2024,Washington West,Washington and Gateshead South,Sunderland,Sunderland,E05001177,E14001567,E08000024,E08000024
+2024,2024,Acocks Green,Birmingham Yardley,Birmingham,Birmingham,E05011118,E14001100,E08000025,E08000025
+2024,2024,Allens Cross,Birmingham Northfield,Birmingham,Birmingham,E05011119,E14001097,E08000025,E08000025
+2024,2024,Alum Rock,Birmingham Ladywood,Birmingham,Birmingham,E05011120,E14001096,E08000025,E08000025
+2024,2024,Aston,Birmingham Perry Barr,Birmingham,Birmingham,E05011121,E14001098,E08000025,E08000025
+2024,2024,Balsall Heath West,Birmingham Ladywood,Birmingham,Birmingham,E05011122,E14001096,E08000025,E08000025
+2024,2024,Bartley Green,Birmingham Edgbaston,Birmingham,Birmingham,E05011123,E14001092,E08000025,E08000025
+2024,2024,Billesley,Birmingham Selly Oak,Birmingham,Birmingham,E05011124,E14001099,E08000025,E08000025
+2024,2024,Birchfield,Birmingham Perry Barr,Birmingham,Birmingham,E05011125,E14001098,E08000025,E08000025
+2024,2024,Bordesley & Highgate,Birmingham Ladywood,Birmingham,Birmingham,E05011126,E14001096,E08000025,E08000025
+2024,2024,Bordesley Green,Birmingham Ladywood,Birmingham,Birmingham,E05011127,E14001096,E08000025,E08000025
+2024,2024,Bournbrook & Selly Park,Birmingham Selly Oak,Birmingham,Birmingham,E05011128,E14001099,E08000025,E08000025
+2024,2024,Bournville & Cotteridge,Birmingham Selly Oak,Birmingham,Birmingham,E05011129,E14001099,E08000025,E08000025
+2024,2024,Brandwood & King's Heath,Birmingham Hall Green and Moseley,Birmingham,Birmingham,E05011130,E14001094,E08000025,E08000025
+2024,2024,Brandwood & King's Heath,Birmingham Selly Oak,Birmingham,Birmingham,E05011130,E14001099,E08000025,E08000025
+2024,2024,Bromford & Hodge Hill,Birmingham Hodge Hill and Solihull North,Birmingham,Birmingham,E05011131,E14001095,E08000025,E08000025
+2024,2024,Castle Vale,Birmingham Erdington,Birmingham,Birmingham,E05011132,E14001093,E08000025,E08000025
+2024,2024,Druids Heath & Monyhull,Birmingham Selly Oak,Birmingham,Birmingham,E05011133,E14001099,E08000025,E08000025
+2024,2024,Edgbaston,Birmingham Edgbaston,Birmingham,Birmingham,E05011134,E14001092,E08000025,E08000025
+2024,2024,Erdington,Birmingham Erdington,Birmingham,Birmingham,E05011135,E14001093,E08000025,E08000025
+2024,2024,Frankley Great Park,Birmingham Northfield,Birmingham,Birmingham,E05011136,E14001097,E08000025,E08000025
+2024,2024,Garretts Green,Birmingham Hodge Hill and Solihull North,Birmingham,Birmingham,E05011137,E14001095,E08000025,E08000025
+2024,2024,Glebe Farm & Tile Cross,Birmingham Hodge Hill and Solihull North,Birmingham,Birmingham,E05011138,E14001095,E08000025,E08000025
+2024,2024,Pleck,Walsall and Bloxwich,Walsall,Walsall,E05001314,E14001562,E08000030,E08000030
+2024,2024,Colne Valley,Colne Valley,Kirklees,Kirklees,E05008559,E14001177,E08000034,E08000034
+2024,2024,Gravelly Hill,Birmingham Erdington,Birmingham,Birmingham,E05011139,E14001093,E08000025,E08000025
+2024,2024,Manningham,Bradford West,Bradford,Bradford,E05001359,E14001120,E08000032,E08000032
+2024,2024,Bablake,Coventry North West,Coventry,Coventry,E05001218,E14001181,E08000026,E08000026
+2024,2024,Friar Park,Tipton and Wednesbury,Sandwell,Sandwell,E05001265,E14001547,E08000028,E08000028
+2024,2024,Queensbury,Bradford South,Bradford,Bradford,E05001360,E14001119,E08000032,E08000032
+2024,2024,Pontefract North,"Pontefract, Castleford and Knottingley",Wakefield,Wakefield,E05001455,E14001428,E08000036,E08000036
+2024,2024,Royds,Bradford South,Bradford,Bradford,E05001361,E14001119,E08000032,E08000032
+2024,2024,Shipley,Shipley,Bradford,Bradford,E05001362,E14001472,E08000032,E08000032
+2024,2024,Thornton and Allerton,Bradford West,Bradford,Bradford,E05001363,E14001120,E08000032,E08000032
+2024,2024,Toller,Bradford West,Bradford,Bradford,E05001364,E14001120,E08000032,E08000032
+2024,2024,Tong,Bradford South,Bradford,Bradford,E05001365,E14001119,E08000032,E08000032
+2024,2024,Wharfedale,Shipley,Bradford,Bradford,E05001366,E14001472,E08000032,E08000032
+2024,2024,Wibsey,Bradford South,Bradford,Bradford,E05001367,E14001119,E08000032,E08000032
+2024,2024,Windhill and Wrose,Shipley,Bradford,Bradford,E05001368,E14001472,E08000032,E08000032
+2024,2024,Worth Valley,Keighley and Ilkley,Bradford,Bradford,E05001369,E14001308,E08000032,E08000032
+2024,2024,Wyke,Bradford South,Bradford,Bradford,E05001370,E14001119,E08000032,E08000032
+2024,2024,Brighouse,Calder Valley,Calderdale,Calderdale,E05001371,E14001147,E08000033,E08000033
+2024,2024,Calder,Calder Valley,Calderdale,Calderdale,E05001372,E14001147,E08000033,E08000033
+2024,2024,Elland,Calder Valley,Calderdale,Calderdale,E05001373,E14001147,E08000033,E08000033
+2024,2024,Greetland and Stainland,Calder Valley,Calderdale,Calderdale,E05001374,E14001147,E08000033,E08000033
+2024,2024,Hipperholme and Lightcliffe,Calder Valley,Calderdale,Calderdale,E05001375,E14001147,E08000033,E08000033
+2024,2024,Illingworth and Mixenden,Halifax,Calderdale,Calderdale,E05001376,E14001262,E08000033,E08000033
+2024,2024,Luddendenfoot,Calder Valley,Calderdale,Calderdale,E05001377,E14001147,E08000033,E08000033
+2024,2024,Northowram and Shelf,Halifax,Calderdale,Calderdale,E05001378,E14001262,E08000033,E08000033
+2024,2024,Ovenden,Halifax,Calderdale,Calderdale,E05001379,E14001262,E08000033,E08000033
+2024,2024,Park,Halifax,Calderdale,Calderdale,E05001380,E14001262,E08000033,E08000033
+2024,2024,Rastrick,Calder Valley,Calderdale,Calderdale,E05001381,E14001147,E08000033,E08000033
+2024,2024,Ryburn,Calder Valley,Calderdale,Calderdale,E05001382,E14001147,E08000033,E08000033
+2024,2024,Ryburn,Halifax,Calderdale,Calderdale,E05001382,E14001262,E08000033,E08000033
+2024,2024,Skircoat,Halifax,Calderdale,Calderdale,E05001383,E14001262,E08000033,E08000033
+2024,2024,Sowerby Bridge,Halifax,Calderdale,Calderdale,E05001384,E14001262,E08000033,E08000033
+2024,2024,Todmorden,Calder Valley,Calderdale,Calderdale,E05001385,E14001147,E08000033,E08000033
+2024,2024,Town,Halifax,Calderdale,Calderdale,E05001386,E14001262,E08000033,E08000033
+2024,2024,Warley,Halifax,Calderdale,Calderdale,E05001387,E14001262,E08000033,E08000033
+2024,2024,Ashbrow,Huddersfield,Kirklees,Kirklees,E05001389,E14001297,E08000034,E08000034
+2024,2024,Batley East,Dewsbury and Batley,Kirklees,Kirklees,E05001390,E14001196,E08000034,E08000034
+2024,2024,Batley West,Dewsbury and Batley,Kirklees,Kirklees,E05001391,E14001196,E08000034,E08000034
+2024,2024,Birstall and Birkenshaw,Spen Valley,Kirklees,Kirklees,E05001392,E14001506,E08000034,E08000034
+2024,2024,Cleckheaton,Spen Valley,Kirklees,Kirklees,E05001393,E14001506,E08000034,E08000034
+2024,2024,Dalton,Huddersfield,Kirklees,Kirklees,E05001396,E14001297,E08000034,E08000034
+2024,2024,Dalton,Spen Valley,Kirklees,Kirklees,E05001396,E14001506,E08000034,E08000034
+2024,2024,Denby Dale,Ossett and Denby Dale,Kirklees,Kirklees,E05001397,E14001418,E08000034,E08000034
+2024,2024,Dewsbury East,Dewsbury and Batley,Kirklees,Kirklees,E05001398,E14001196,E08000034,E08000034
+2024,2024,Dewsbury South,Dewsbury and Batley,Kirklees,Kirklees,E05001399,E14001196,E08000034,E08000034
+2024,2024,Dewsbury West,Dewsbury and Batley,Kirklees,Kirklees,E05001400,E14001196,E08000034,E08000034
+2024,2024,Binley and Willenhall,Coventry East,Coventry,Coventry,E05001219,E14001180,E08000026,E08000026
+2024,2024,Hall Green North,Birmingham Hall Green and Moseley,Birmingham,Birmingham,E05011140,E14001094,E08000025,E08000025
+2024,2024,Crosland Moor and Netherton,Huddersfield,Kirklees,Kirklees,E05008560,E14001297,E08000034,E08000034
+2024,2024,Rushall-Shelfield,Aldridge-Brownhills,Walsall,Walsall,E05001315,E14001064,E08000030,E08000030
+2024,2024,Golcar,Colne Valley,Kirklees,Kirklees,E05001401,E14001177,E08000034,E08000034
+2024,2024,Greenhead,Huddersfield,Kirklees,Kirklees,E05001402,E14001297,E08000034,E08000034
+2024,2024,Heckmondwike,Spen Valley,Kirklees,Kirklees,E05001403,E14001506,E08000034,E08000034
+2024,2024,Holme Valley South,Colne Valley,Kirklees,Kirklees,E05001405,E14001177,E08000034,E08000034
+2024,2024,Lindley,Colne Valley,Kirklees,Kirklees,E05001407,E14001177,E08000034,E08000034
+2024,2024,Liversedge and Gomersal,Spen Valley,Kirklees,Kirklees,E05001408,E14001506,E08000034,E08000034
+2024,2024,Mirfield,Spen Valley,Kirklees,Kirklees,E05001409,E14001506,E08000034,E08000034
+2024,2024,Newsome,Huddersfield,Kirklees,Kirklees,E05001410,E14001297,E08000034,E08000034
+2024,2024,Almondbury,Huddersfield,Kirklees,Kirklees,E05008558,E14001297,E08000034,E08000034
+2024,2024,Great Barr with Yew Tree,West Bromwich,Sandwell,Sandwell,E05001266,E14001574,E08000028,E08000028
+2024,2024,Great Bridge,Tipton and Wednesbury,Sandwell,Sandwell,E05001267,E14001547,E08000028,E08000028
+2024,2024,Greets Green and Lyng,West Bromwich,Sandwell,Sandwell,E05001268,E14001574,E08000028,E08000028
+2024,2024,Hateley Heath,Tipton and Wednesbury,Sandwell,Sandwell,E05001269,E14001547,E08000028,E08000028
+2024,2024,Langley,Smethwick,Sandwell,Sandwell,E05001270,E14001478,E08000028,E08000028
+2024,2024,Newton,West Bromwich,Sandwell,Sandwell,E05001271,E14001574,E08000028,E08000028
+2024,2024,Old Warley,Smethwick,Sandwell,Sandwell,E05001272,E14001478,E08000028,E08000028
+2024,2024,Oldbury,West Bromwich,Sandwell,Sandwell,E05001273,E14001574,E08000028,E08000028
+2024,2024,Princes End,Tipton and Wednesbury,Sandwell,Sandwell,E05001274,E14001547,E08000028,E08000028
+2024,2024,Rowley,West Bromwich,Sandwell,Sandwell,E05001275,E14001574,E08000028,E08000028
+2024,2024,St Pauls,Smethwick,Sandwell,Sandwell,E05001276,E14001478,E08000028,E08000028
+2024,2024,Smethwick,Smethwick,Sandwell,Sandwell,E05001277,E14001478,E08000028,E08000028
+2024,2024,Soho and Victoria,Smethwick,Sandwell,Sandwell,E05001278,E14001478,E08000028,E08000028
+2024,2024,Tipton Green,Tipton and Wednesbury,Sandwell,Sandwell,E05001279,E14001547,E08000028,E08000028
+2024,2024,Tividale,West Bromwich,Sandwell,Sandwell,E05001280,E14001574,E08000028,E08000028
+2024,2024,Wednesbury North,Tipton and Wednesbury,Sandwell,Sandwell,E05001281,E14001547,E08000028,E08000028
+2024,2024,Wednesbury South,Tipton and Wednesbury,Sandwell,Sandwell,E05001282,E14001547,E08000028,E08000028
+2024,2024,West Bromwich Central,West Bromwich,Sandwell,Sandwell,E05001283,E14001574,E08000028,E08000028
+2024,2024,Hall Green South,Birmingham Hall Green and Moseley,Birmingham,Birmingham,E05011141,E14001094,E08000025,E08000025
+2024,2024,Bickenhill,Meriden and Solihull East,Solihull,Solihull,E05001284,E14001358,E08000029,E08000029
+2024,2024,Blythe,Solihull West and Shirley,Solihull,Solihull,E05001285,E14001479,E08000029,E08000029
+2024,2024,Handsworth,Birmingham Perry Barr,Birmingham,Birmingham,E05011142,E14001098,E08000025,E08000025
+2024,2024,Castle Bromwich,Birmingham Hodge Hill and Solihull North,Solihull,Solihull,E05001286,E14001095,E08000029,E08000029
+2024,2024,Cheylesmore,Coventry South,Coventry,Coventry,E05001220,E14001182,E08000026,E08000026
+2024,2024,Holme Valley North,Colne Valley,Kirklees,Kirklees,E05008561,E14001177,E08000034,E08000034
+2024,2024,Pontefract South,"Pontefract, Castleford and Knottingley",Wakefield,Wakefield,E05001456,E14001428,E08000036,E08000036
+2024,2024,Handsworth Wood,Birmingham Perry Barr,Birmingham,Birmingham,E05011143,E14001098,E08000025,E08000025
+2024,2024,Harborne,Birmingham Edgbaston,Birmingham,Birmingham,E05011144,E14001092,E08000025,E08000025
+2024,2024,South Elmsall and South Kirkby,Normanton and Hemsworth,Wakefield,Wakefield,E05001457,E14001383,E08000036,E08000036
+2024,2024,Heartlands,Birmingham Hodge Hill and Solihull North,Birmingham,Birmingham,E05011145,E14001095,E08000025,E08000025
+2024,2024,Stanley and Outwood East,Wakefield and Rothwell,Wakefield,Wakefield,E05001458,E14001560,E08000036,E08000036
+2024,2024,Highter's Heath,Birmingham Selly Oak,Birmingham,Birmingham,E05011146,E14001099,E08000025,E08000025
+2024,2024,Holyhead,Birmingham Perry Barr,Birmingham,Birmingham,E05011147,E14001098,E08000025,E08000025
+2024,2024,Wakefield East,Wakefield and Rothwell,Wakefield,Wakefield,E05001459,E14001560,E08000036,E08000036
+2024,2024,King's Norton North,Birmingham Northfield,Birmingham,Birmingham,E05011148,E14001097,E08000025,E08000025
+2024,2024,Wakefield North,Wakefield and Rothwell,Wakefield,Wakefield,E05001460,E14001560,E08000036,E08000036
+2024,2024,King's Norton South,Birmingham Northfield,Birmingham,Birmingham,E05011149,E14001097,E08000025,E08000025
+2024,2024,Wakefield Rural,Ossett and Denby Dale,Wakefield,Wakefield,E05001461,E14001418,E08000036,E08000036
+2024,2024,Kingstanding,Birmingham Erdington,Birmingham,Birmingham,E05011150,E14001093,E08000025,E08000025
+2024,2024,Wakefield South,Ossett and Denby Dale,Wakefield,Wakefield,E05001462,E14001418,E08000036,E08000036
+2024,2024,Ladywood,Birmingham Ladywood,Birmingham,Birmingham,E05011151,E14001096,E08000025,E08000025
+2024,2024,Wakefield West,Wakefield and Rothwell,Wakefield,Wakefield,E05001463,E14001560,E08000036,E08000036
+2024,2024,Longbridge & West Heath,Birmingham Northfield,Birmingham,Birmingham,E05011152,E14001097,E08000025,E08000025
+2024,2024,Wrenthorpe and Outwood West,Wakefield and Rothwell,Wakefield,Wakefield,E05001464,E14001560,E08000036,E08000036
+2024,2024,Lozells,Birmingham Perry Barr,Birmingham,Birmingham,E05011153,E14001098,E08000025,E08000025
+2024,2024,Birtley,Washington and Gateshead South,Gateshead,Gateshead,E05001067,E14001567,E08000037,E08000037
+2024,2024,Blaydon,Blaydon and Consett,Gateshead,Gateshead,E05001068,E14001106,E08000037,E08000037
+2024,2024,Earlsdon,Coventry South,Coventry,Coventry,E05001221,E14001182,E08000026,E08000026
+2024,2024,Kirkburton,Dewsbury and Batley,Kirklees,Kirklees,E05008562,E14001196,E08000034,E08000034
+2024,2024,Chelmsley Wood,Meriden and Solihull East,Solihull,Solihull,E05001287,E14001358,E08000029,E08000029
+2024,2024,Dorridge and Hockley Heath,Meriden and Solihull East,Solihull,Solihull,E05001288,E14001358,E08000029,E08000029
+2024,2024,St Matthew's,Walsall and Bloxwich,Walsall,Walsall,E05001316,E14001562,E08000030,E08000030
+2024,2024,Elmdon,Meriden and Solihull East,Solihull,Solihull,E05001289,E14001358,E08000029,E08000029
+2024,2024,Short Heath,Wolverhampton North East,Walsall,Walsall,E05001317,E14001594,E08000030,E08000030
+2024,2024,Kingshurst and Fordbridge,Meriden and Solihull East,Solihull,Solihull,E05001290,E14001358,E08000029,E08000029
+2024,2024,Streetly,Aldridge-Brownhills,Walsall,Walsall,E05001318,E14001064,E08000030,E08000030
+2024,2024,Knowle,Meriden and Solihull East,Solihull,Solihull,E05001291,E14001358,E08000029,E08000029
+2024,2024,Willenhall North,Wolverhampton North East,Walsall,Walsall,E05001319,E14001594,E08000030,E08000030
+2024,2024,Lyndon,Solihull West and Shirley,Solihull,Solihull,E05001292,E14001479,E08000029,E08000029
+2024,2024,Willenhall South,Wolverhampton South East,Walsall,Walsall,E05001320,E14001595,E08000030,E08000030
+2024,2024,Meriden,Meriden and Solihull East,Solihull,Solihull,E05001293,E14001358,E08000029,E08000029
+2024,2024,Bilston North,Wolverhampton South East,Wolverhampton,Wolverhampton,E05014838,E14001595,E08000031,E08000031
+2024,2024,Olton,Solihull West and Shirley,Solihull,Solihull,E05001294,E14001479,E08000029,E08000029
+2024,2024,Bilston South,Wolverhampton South East,Wolverhampton,Wolverhampton,E05014839,E14001595,E08000031,E08000031
+2024,2024,St Alphege,Solihull West and Shirley,Solihull,Solihull,E05001295,E14001479,E08000029,E08000029
+2024,2024,Blakenhall,Wolverhampton West,Wolverhampton,Wolverhampton,E05014840,E14001596,E08000031,E08000031
+2024,2024,Shirley East,Solihull West and Shirley,Solihull,Solihull,E05001296,E14001479,E08000029,E08000029
+2024,2024,Bushbury North,Wolverhampton North East,Wolverhampton,Wolverhampton,E05014841,E14001594,E08000031,E08000031
+2024,2024,Shirley South,Solihull West and Shirley,Solihull,Solihull,E05001297,E14001479,E08000029,E08000029
+2024,2024,Foleshill,Coventry East,Coventry,Coventry,E05001222,E14001180,E08000026,E08000026
+2024,2024,Bushbury North,Wolverhampton West,Wolverhampton,Wolverhampton,E05014841,E14001596,E08000031,E08000031
+2024,2024,Kirkburton,Ossett and Denby Dale,Kirklees,Kirklees,E05008562,E14001418,E08000034,E08000034
+2024,2024,Bridges,Gateshead Central and Whickham,Gateshead,Gateshead,E05001069,E14001244,E08000037,E08000037
+2024,2024,Moseley,Birmingham Hall Green and Moseley,Birmingham,Birmingham,E05011154,E14001094,E08000025,E08000025
+2024,2024,Shirley West,Solihull West and Shirley,Solihull,Solihull,E05001298,E14001479,E08000029,E08000029
+2024,2024,Henley,Coventry East,Coventry,Coventry,E05001223,E14001180,E08000026,E08000026
+2024,2024,Bushbury South & Low Hill,Wolverhampton North East,Wolverhampton,Wolverhampton,E05014842,E14001594,E08000031,E08000031
+2024,2024,Ardsley & Robin Hood,Leeds South West and Morley,Leeds,Leeds,E05011384,E14001324,E08000035,E08000035
+2024,2024,Chowdene,Gateshead Central and Whickham,Gateshead,Gateshead,E05001071,E14001244,E08000037,E08000037
+2024,2024,Nechells,Birmingham Ladywood,Birmingham,Birmingham,E05011155,E14001096,E08000025,E08000025
+2024,2024,Silhill,Meriden and Solihull East,Solihull,Solihull,E05001299,E14001358,E08000029,E08000029
+2024,2024,Holbrook,Coventry North West,Coventry,Coventry,E05001224,E14001181,E08000026,E08000026
+2024,2024,East Park,Wolverhampton South East,Wolverhampton,Wolverhampton,E05014843,E14001595,E08000031,E08000031
+2024,2024,Armley,Leeds West and Pudsey,Leeds,Leeds,E05011385,E14001325,E08000035,E08000035
+2024,2024,Crawcrook and Greenside,Blaydon and Consett,Gateshead,Gateshead,E05001072,E14001106,E08000037,E08000037
+2024,2024,Newtown,Birmingham Ladywood,Birmingham,Birmingham,E05011156,E14001096,E08000025,E08000025
+2024,2024,North Edgbaston,Birmingham Edgbaston,Birmingham,Birmingham,E05011157,E14001092,E08000025,E08000025
+2024,2024,Northfield,Birmingham Northfield,Birmingham,Birmingham,E05011158,E14001097,E08000025,E08000025
+2024,2024,Smith's Wood,Birmingham Hodge Hill and Solihull North,Solihull,Solihull,E05001300,E14001095,E08000029,E08000029
+2024,2024,Oscott,Birmingham Erdington,Birmingham,Birmingham,E05011159,E14001093,E08000025,E08000025
+2024,2024,Longford,Coventry East,Coventry,Coventry,E05001225,E14001180,E08000026,E08000026
+2024,2024,Deckham,Gateshead Central and Whickham,Gateshead,Gateshead,E05001073,E14001244,E08000037,E08000037
+2024,2024,Bramley & Stanningley,Leeds West and Pudsey,Leeds,Leeds,E05011387,E14001325,E08000035,E08000035
+2024,2024,Ettingshall North,Wolverhampton South East,Wolverhampton,Wolverhampton,E05014844,E14001595,E08000031,E08000031
+2024,2024,Ettingshall South & Spring Vale,Wolverhampton South East,Wolverhampton,Wolverhampton,E05014845,E14001595,E08000031,E08000031
+2024,2024,Fallings Park,Wolverhampton North East,Wolverhampton,Wolverhampton,E05014846,E14001594,E08000031,E08000031
+2024,2024,Graiseley,Wolverhampton West,Wolverhampton,Wolverhampton,E05014847,E14001596,E08000031,E08000031
+2024,2024,Heath Town,Wolverhampton North East,Wolverhampton,Wolverhampton,E05014848,E14001594,E08000031,E08000031
+2024,2024,Merry Hill,Wolverhampton West,Wolverhampton,Wolverhampton,E05014849,E14001596,E08000031,E08000031
+2024,2024,Oxley,Wolverhampton North East,Wolverhampton,Wolverhampton,E05014850,E14001594,E08000031,E08000031
+2024,2024,Oxley,Wolverhampton West,Wolverhampton,Wolverhampton,E05014850,E14001596,E08000031,E08000031
+2024,2024,Park,Wolverhampton West,Wolverhampton,Wolverhampton,E05014851,E14001596,E08000031,E08000031
+2024,2024,Penn,Wolverhampton West,Wolverhampton,Wolverhampton,E05014852,E14001596,E08000031,E08000031
+2024,2024,St Peters,Wolverhampton North East,Wolverhampton,Wolverhampton,E05014853,E14001594,E08000031,E08000031
+2024,2024,St Peters,Wolverhampton South East,Wolverhampton,Wolverhampton,E05014853,E14001595,E08000031,E08000031
+2024,2024,St Peters,Wolverhampton West,Wolverhampton,Wolverhampton,E05014853,E14001596,E08000031,E08000031
+2024,2024,Tettenhall Regis,Wolverhampton West,Wolverhampton,Wolverhampton,E05014854,E14001596,E08000031,E08000031
+2024,2024,Tettenhall Wightwick,Wolverhampton West,Wolverhampton,Wolverhampton,E05014855,E14001596,E08000031,E08000031
+2024,2024,Wednesfield North,Wolverhampton North East,Wolverhampton,Wolverhampton,E05014856,E14001594,E08000031,E08000031
+2024,2024,Wednesfield South,Wolverhampton North East,Wolverhampton,Wolverhampton,E05014857,E14001594,E08000031,E08000031
+2024,2024,Baildon,Shipley,Bradford,Bradford,E05001341,E14001472,E08000032,E08000032
+2024,2024,Bingley,Shipley,Bradford,Bradford,E05001342,E14001472,E08000032,E08000032
+2024,2024,Bingley Rural,Shipley,Bradford,Bradford,E05001343,E14001472,E08000032,E08000032
+2024,2024,Bolton and Undercliffe,Bradford East,Bradford,Bradford,E05001344,E14001118,E08000032,E08000032
+2024,2024,Bowling and Barkerend,Bradford East,Bradford,Bradford,E05001345,E14001118,E08000032,E08000032
+2024,2024,Bowling and Barkerend,Bradford South,Bradford,Bradford,E05001345,E14001119,E08000032,E08000032
+2024,2024,Bradford Moor,Bradford East,Bradford,Bradford,E05001346,E14001118,E08000032,E08000032
+2024,2024,Dunston and Teams,Gateshead Central and Whickham,Gateshead,Gateshead,E05001074,E14001244,E08000037,E08000037
+2024,2024,Lower Stoke,Coventry South,Coventry,Coventry,E05001226,E14001182,E08000026,E08000026
+2024,2024,City,Bradford West,Bradford,Bradford,E05001347,E14001120,E08000032,E08000032
+2024,2024,Burmantofts & Richmond Hill,Leeds South,Leeds,Leeds,E05011388,E14001323,E08000035,E08000035
+2024,2024,Dunston Hill and Whickham East,Gateshead Central and Whickham,Gateshead,Gateshead,E05001075,E14001244,E08000037,E08000037
+2024,2024,Radford,Coventry North West,Coventry,Coventry,E05001227,E14001181,E08000026,E08000026
+2024,2024,Aldridge Central and South,Aldridge-Brownhills,Walsall,Walsall,E05001301,E14001064,E08000030,E08000030
+2024,2024,Calverley & Farsley,Leeds West and Pudsey,Leeds,Leeds,E05011389,E14001325,E08000035,E08000035
+2024,2024,St Michael's,Coventry South,Coventry,Coventry,E05001228,E14001182,E08000026,E08000026
+2024,2024,Felling,Jarrow and Gateshead East,Gateshead,Gateshead,E05001076,E14001307,E08000037,E08000037
+2024,2024,Clayton and Fairweather Green,Bradford West,Bradford,Bradford,E05001348,E14001120,E08000032,E08000032
+2024,2024,Oscott,Birmingham Perry Barr,Birmingham,Birmingham,E05011159,E14001098,E08000025,E08000025
+2024,2024,High Fell,Gateshead Central and Whickham,Gateshead,Gateshead,E05001077,E14001244,E08000037,E08000037
+2024,2024,Perry Barr,Birmingham Perry Barr,Birmingham,Birmingham,E05011160,E14001098,E08000025,E08000025
+2024,2024,Craven,Keighley and Ilkley,Bradford,Bradford,E05001349,E14001308,E08000032,E08000032
+2024,2024,Lamesley,Washington and Gateshead South,Gateshead,Gateshead,E05001078,E14001567,E08000037,E08000037
+2024,2024,Sherbourne,Coventry North West,Coventry,Coventry,E05001229,E14001181,E08000026,E08000026
+2024,2024,Perry Common,Birmingham Erdington,Birmingham,Birmingham,E05011161,E14001093,E08000025,E08000025
+2024,2024,Aldridge North and Walsall Wood,Aldridge-Brownhills,Walsall,Walsall,E05001302,E14001064,E08000030,E08000030
+2024,2024,Eccleshill,Bradford East,Bradford,Bradford,E05001350,E14001118,E08000032,E08000032
+2024,2024,Chapel Allerton,Leeds North East,Leeds,Leeds,E05011390,E14001321,E08000035,E08000035
+2024,2024,Lobley Hill and Bensham,Gateshead Central and Whickham,Gateshead,Gateshead,E05001079,E14001244,E08000037,E08000037
+2024,2024,Upper Stoke,Coventry East,Coventry,Coventry,E05001230,E14001180,E08000026,E08000026
+2024,2024,Pype Hayes,Birmingham Erdington,Birmingham,Birmingham,E05011162,E14001093,E08000025,E08000025
+2024,2024,Great Horton,Bradford South,Bradford,Bradford,E05001351,E14001119,E08000032,E08000032
+2024,2024,Cross Gates & Whinmoor,Leeds East,Leeds,Leeds,E05011391,E14001320,E08000035,E08000035
+2024,2024,Wainbody,Coventry South,Coventry,Coventry,E05001231,E14001182,E08000026,E08000026
+2024,2024,Heaton,Bradford West,Bradford,Bradford,E05001352,E14001120,E08000032,E08000032
+2024,2024,Quinton,Birmingham Edgbaston,Birmingham,Birmingham,E05011163,E14001092,E08000025,E08000025
+2024,2024,Low Fell,Gateshead Central and Whickham,Gateshead,Gateshead,E05001080,E14001244,E08000037,E08000037
+2024,2024,Bentley and Darlaston North,Wolverhampton South East,Walsall,Walsall,E05001303,E14001595,E08000030,E08000030
+2024,2024,Rubery & Rednal,Birmingham Northfield,Birmingham,Birmingham,E05011164,E14001097,E08000025,E08000025
+2024,2024,Birchills Leamore,Walsall and Bloxwich,Walsall,Walsall,E05001304,E14001562,E08000030,E08000030
+2024,2024,Shard End,Birmingham Hodge Hill and Solihull North,Birmingham,Birmingham,E05011165,E14001095,E08000025,E08000025
+2024,2024,Blakenall,Walsall and Bloxwich,Walsall,Walsall,E05001305,E14001562,E08000030,E08000030
+2024,2024,Sheldon,Birmingham Yardley,Birmingham,Birmingham,E05011166,E14001100,E08000025,E08000025
+2024,2024,Bloxwich East,Walsall and Bloxwich,Walsall,Walsall,E05001306,E14001562,E08000030,E08000030
+2024,2024,Pelaw and Heworth,Jarrow and Gateshead East,Gateshead,Gateshead,E05001081,E14001307,E08000037,E08000037
+2024,2024,Small Heath,Birmingham Yardley,Birmingham,Birmingham,E05011167,E14001100,E08000025,E08000025
+2024,2024,Bloxwich West,Walsall and Bloxwich,Walsall,Walsall,E05001307,E14001562,E08000030,E08000030
+2024,2024,Idle and Thackley,Bradford East,Bradford,Bradford,E05001353,E14001118,E08000032,E08000032
+2024,2024,"Ryton, Crookhill and Stella",Blaydon and Consett,Gateshead,Gateshead,E05001082,E14001106,E08000037,E08000037
+2024,2024,Westwood,Coventry South,Coventry,Coventry,E05001232,E14001182,E08000026,E08000026
+2024,2024,Gipton & Harehills,Leeds East,Leeds,Leeds,E05011394,E14001320,E08000035,E08000035
+2024,2024,Soho & Jewellery Quarter,Birmingham Ladywood,Birmingham,Birmingham,E05011168,E14001096,E08000025,E08000025
+2024,2024,Brownhills,Aldridge-Brownhills,Walsall,Walsall,E05001308,E14001064,E08000030,E08000030
+2024,2024,Ilkley,Keighley and Ilkley,Bradford,Bradford,E05001354,E14001308,E08000032,E08000032
+2024,2024,Saltwell,Gateshead Central and Whickham,Gateshead,Gateshead,E05001083,E14001244,E08000037,E08000037
+2024,2024,Whoberley,Coventry North West,Coventry,Coventry,E05001233,E14001181,E08000026,E08000026
+2024,2024,Guiseley & Rawdon,Leeds North West,Leeds,Leeds,E05011395,E14001322,E08000035,E08000035
+2024,2024,South Yardley,Birmingham Yardley,Birmingham,Birmingham,E05011169,E14001100,E08000025,E08000025
+2024,2024,Darlaston South,Wolverhampton South East,Walsall,Walsall,E05001309,E14001595,E08000030,E08000030
+2024,2024,Keighley Central,Keighley and Ilkley,Bradford,Bradford,E05001355,E14001308,E08000032,E08000032
+2024,2024,Wardley and Leam Lane,Jarrow and Gateshead East,Gateshead,Gateshead,E05001084,E14001307,E08000037,E08000037
+2024,2024,Woodlands,Coventry North West,Coventry,Coventry,E05001234,E14001181,E08000026,E08000026
+2024,2024,Harewood,Wetherby and Easingwold,Leeds,Leeds,E05011396,E14001582,E08000035,E08000035
+2024,2024,Sparkbrook & Balsall Heath East,Birmingham Hall Green and Moseley,Birmingham,Birmingham,E05011170,E14001094,E08000025,E08000025
+2024,2024,Paddock,Aldridge-Brownhills,Walsall,Walsall,E05001310,E14001064,E08000030,E08000030
+2024,2024,Keighley East,Keighley and Ilkley,Bradford,Bradford,E05001356,E14001308,E08000032,E08000032
+2024,2024,Keighley West,Keighley and Ilkley,Bradford,Bradford,E05001357,E14001308,E08000032,E08000032
+2024,2024,Little Horton,Bradford East,Bradford,Bradford,E05001358,E14001118,E08000032,E08000032
+2024,2024,Paddock,Walsall and Bloxwich,Walsall,Walsall,E05001310,E14001562,E08000030,E08000030
+2024,2024,Palfrey,Walsall and Bloxwich,Walsall,Walsall,E05001311,E14001562,E08000030,E08000030
+2024,2024,Pelsall,Aldridge-Brownhills,Walsall,Walsall,E05001312,E14001064,E08000030,E08000030
+2024,2024,Pheasey Park Farm,Aldridge-Brownhills,Walsall,Walsall,E05001313,E14001064,E08000030,E08000030
+2024,2024,Wyken,Coventry East,Coventry,Coventry,E05001235,E14001180,E08000026,E08000026
+2024,2024,Amblecote,Stourbridge,Dudley,Dudley,E05015903,E14001524,E08000027,E08000027
+2024,2024,Headingley & Hyde Park,Leeds Central and Headingley,Leeds,Leeds,E05011397,E14001319,E08000035,E08000035
+2024,2024,Belle Vale,Halesowen,Dudley,Dudley,E05015904,E14001261,E08000027,E08000027
+2024,2024,Whickham North,Gateshead Central and Whickham,Gateshead,Gateshead,E05001085,E14001244,E08000037,E08000037
+2024,2024,Hunslet & Riverside,Leeds South,Leeds,Leeds,E05011399,E14001323,E08000035,E08000035
+2024,2024,Brierley Hill & Wordsley South,Stourbridge,Dudley,Dudley,E05015905,E14001524,E08000027,E08000027
+2024,2024,Whickham South and Sunniside,Gateshead Central and Whickham,Gateshead,Gateshead,E05001086,E14001244,E08000037,E08000037
+2024,2024,Sparkhill,Birmingham Hall Green and Moseley,Birmingham,Birmingham,E05011171,E14001094,E08000025,E08000025
+2024,2024,Killingbeck & Seacroft,Leeds East,Leeds,Leeds,E05011400,E14001320,E08000035,E08000035
+2024,2024,Brockmoor & Pensnett,Dudley,Dudley,Dudley,E05015906,E14001204,E08000027,E08000027
+2024,2024,Windy Nook and Whitehills,Jarrow and Gateshead East,Gateshead,Gateshead,E05001087,E14001307,E08000037,E08000037
+2024,2024,Stirchley,Birmingham Selly Oak,Birmingham,Birmingham,E05011172,E14001099,E08000025,E08000025
+2024,2024,Kippax & Methley,Selby,Leeds,Leeds,E05011401,E14001464,E08000035,E08000035
+2024,2024,Castle & Priory,Dudley,Dudley,Dudley,E05015907,E14001204,E08000027,E08000027
+2024,2024,Winlaton and High Spen,Blaydon and Consett,Gateshead,Gateshead,E05001088,E14001106,E08000037,E08000037
+2024,2024,Stockland Green,Birmingham Erdington,Birmingham,Birmingham,E05011173,E14001093,E08000025,E08000025
+2024,2024,Kirkstall,Leeds Central and Headingley,Leeds,Leeds,E05011402,E14001319,E08000035,E08000035
+2024,2024,Coseley,Dudley,Dudley,Dudley,E05015908,E14001204,E08000027,E08000027
+2024,2024,Chopwell and Rowlands Gill,Blaydon and Consett,Gateshead,Gateshead,E05009313,E14001106,E08000037,E08000037
+2024,2024,Sutton Four Oaks,Sutton Coldfield,Birmingham,Birmingham,E05011174,E14001535,E08000025,E08000025
+2024,2024,Little London & Woodhouse,Leeds Central and Headingley,Leeds,Leeds,E05011403,E14001319,E08000035,E08000035
+2024,2024,Coseley,Tipton and Wednesbury,Dudley,Dudley,E05015908,E14001547,E08000027,E08000027
+2024,2024,Aldersgate,Cities of London and Westminster,City of London,City of London,E05009288,E14001172,E09000001,E09000001
+2024,2024,Sutton Mere Green,Sutton Coldfield,Birmingham,Birmingham,E05011175,E14001535,E08000025,E08000025
+2024,2024,Middleton Park,Leeds South,Leeds,Leeds,E05011404,E14001323,E08000035,E08000035
+2024,2024,Cradley North & Wollescote,Halesowen,Dudley,Dudley,E05015909,E14001261,E08000027,E08000027
+2024,2024,Aldgate,Cities of London and Westminster,City of London,City of London,E05009289,E14001172,E09000001,E09000001
+2024,2024,Sutton Reddicap,Sutton Coldfield,Birmingham,Birmingham,E05011176,E14001535,E08000025,E08000025
+2024,2024,Moortown,Leeds North East,Leeds,Leeds,E05011405,E14001321,E08000035,E08000035
+2024,2024,Sutton Roughley,Sutton Coldfield,Birmingham,Birmingham,E05011177,E14001535,E08000025,E08000025
+2024,2024,Bassishaw,Cities of London and Westminster,City of London,City of London,E05009290,E14001172,E09000001,E09000001
+2024,2024,Gornal,Dudley,Dudley,Dudley,E05015910,E14001204,E08000027,E08000027
+2024,2024,Sutton Trinity,Sutton Coldfield,Birmingham,Birmingham,E05011178,E14001535,E08000025,E08000025
+2024,2024,Halesowen North,Halesowen,Dudley,Dudley,E05015911,E14001261,E08000027,E08000027
+2024,2024,Billingsgate,Cities of London and Westminster,City of London,City of London,E05009291,E14001172,E09000001,E09000001
+2024,2024,Sutton Vesey,Sutton Coldfield,Birmingham,Birmingham,E05011179,E14001535,E08000025,E08000025
+2024,2024,Morley North,Leeds South West and Morley,Leeds,Leeds,E05011406,E14001324,E08000035,E08000035
+2024,2024,Halesowen South,Halesowen,Dudley,Dudley,E05015912,E14001261,E08000027,E08000027
+2024,2024,Bishopsgate,Cities of London and Westminster,City of London,City of London,E05009292,E14001172,E09000001,E09000001
+2024,2024,Sutton Walmley & Minworth,Sutton Coldfield,Birmingham,Birmingham,E05011180,E14001535,E08000025,E08000025
+2024,2024,Morley South,Leeds South West and Morley,Leeds,Leeds,E05011407,E14001324,E08000035,E08000035
+2024,2024,Hayley Green & Cradley South,Halesowen,Dudley,Dudley,E05015913,E14001261,E08000027,E08000027
+2024,2024,Bread Street,Cities of London and Westminster,City of London,City of London,E05009293,E14001172,E09000001,E09000001
+2024,2024,Sutton Wylde Green,Sutton Coldfield,Birmingham,Birmingham,E05011181,E14001535,E08000025,E08000025
+2024,2024,Pudsey,Leeds West and Pudsey,Leeds,Leeds,E05011409,E14001325,E08000035,E08000035
+2024,2024,Kingswinford North & Wall Heath,Kingswinford and South Staffordshire,Dudley,Dudley,E05015914,E14001316,E08000027,E08000027
+2024,2024,Bridge,Cities of London and Westminster,City of London,City of London,E05009294,E14001172,E09000001,E09000001
+2024,2024,Tyseley & Hay Mills,Birmingham Yardley,Birmingham,Birmingham,E05011182,E14001100,E08000025,E08000025
+2024,2024,Rothwell,Wakefield and Rothwell,Leeds,Leeds,E05011410,E14001560,E08000035,E08000035
+2024,2024,Kingswinford South,Kingswinford and South Staffordshire,Dudley,Dudley,E05015915,E14001316,E08000027,E08000027
+2024,2024,Broad Street,Cities of London and Westminster,City of London,City of London,E05009295,E14001172,E09000001,E09000001
+2024,2024,Ward End,Birmingham Hodge Hill and Solihull North,Birmingham,Birmingham,E05011183,E14001095,E08000025,E08000025
+2024,2024,Roundhay,Leeds North East,Leeds,Leeds,E05011411,E14001321,E08000035,E08000035
+2024,2024,Lye & Stourbridge North,Halesowen,Dudley,Dudley,E05015916,E14001261,E08000027,E08000027
+2024,2024,Candlewick,Cities of London and Westminster,City of London,City of London,E05009296,E14001172,E09000001,E09000001
+2024,2024,Weoley & Selly Oak,Birmingham Northfield,Birmingham,Birmingham,E05011184,E14001097,E08000025,E08000025
+2024,2024,Weetwood,Leeds Central and Headingley,Leeds,Leeds,E05011413,E14001319,E08000035,E08000035
+2024,2024,Lye & Stourbridge North,Stourbridge,Dudley,Dudley,E05015916,E14001524,E08000027,E08000027
+2024,2024,Castle Baynard,Cities of London and Westminster,City of London,City of London,E05009297,E14001172,E09000001,E09000001
+2024,2024,Weoley & Selly Oak,Birmingham Selly Oak,Birmingham,Birmingham,E05011184,E14001099,E08000025,E08000025
+2024,2024,Wetherby,Wetherby and Easingwold,Leeds,Leeds,E05011414,E14001582,E08000035,E08000035
+2024,2024,Netherton & Holly Hall,Stourbridge,Dudley,Dudley,E05015917,E14001524,E08000027,E08000027
+2024,2024,Cheap,Cities of London and Westminster,City of London,City of London,E05009298,E14001172,E09000001,E09000001
+2024,2024,Horsforth,Leeds North West,Leeds,Leeds,E05011547,E14001322,E08000035,E08000035
+2024,2024,Norton,Stourbridge,Dudley,Dudley,E05015918,E14001524,E08000027,E08000027
+2024,2024,Yardley East,Birmingham Yardley,Birmingham,Birmingham,E05011185,E14001100,E08000025,E08000025
+2024,2024,Coleman Street,Cities of London and Westminster,City of London,City of London,E05009299,E14001172,E09000001,E09000001
+2024,2024,Pedmore & Stourbridge East,Stourbridge,Dudley,Dudley,E05015919,E14001524,E08000027,E08000027
+2024,2024,Yardley West & Stechford,Birmingham Yardley,Birmingham,Birmingham,E05011186,E14001100,E08000025,E08000025
+2024,2024,Otley & Yeadon,Leeds North West,Leeds,Leeds,E05011549,E14001322,E08000035,E08000035
+2024,2024,Cordwainer,Cities of London and Westminster,City of London,City of London,E05009300,E14001172,E09000001,E09000001
+2024,2024,Quarry Bank & Dudley Wood,Halesowen,Dudley,Dudley,E05015920,E14001261,E08000027,E08000027
+2024,2024,Beeston & Holbeck,Leeds South,Leeds,Leeds,E05012647,E14001323,E08000035,E08000035
+2024,2024,Cornhill,Cities of London and Westminster,City of London,City of London,E05009301,E14001172,E09000001,E09000001
+2024,2024,Sedgley,Dudley,Dudley,Dudley,E05015921,E14001204,E08000027,E08000027
+2024,2024,Farnley & Wortley,Leeds South West and Morley,Leeds,Leeds,E05012648,E14001324,E08000035,E08000035
+2024,2024,Cripplegate,Cities of London and Westminster,City of London,City of London,E05009302,E14001172,E09000001,E09000001
+2024,2024,St. James's,Dudley,Dudley,Dudley,E05015922,E14001204,E08000027,E08000027
+2024,2024,Adel & Wharfedale,Leeds North West,Leeds,Leeds,E05012841,E14001322,E08000035,E08000035
+2024,2024,Dowgate,Cities of London and Westminster,City of London,City of London,E05009303,E14001172,E09000001,E09000001
+2024,2024,St. Thomas's,Dudley,Dudley,Dudley,E05015923,E14001204,E08000027,E08000027
+2024,2024,Alwoodley,Leeds North East,Leeds,Leeds,E05012842,E14001321,E08000035,E08000035
+2024,2024,Farringdon Within,Cities of London and Westminster,City of London,City of London,E05009304,E14001172,E09000001,E09000001
+2024,2024,Upper Gornal & Woodsetton,Dudley,Dudley,Dudley,E05015924,E14001204,E08000027,E08000027
+2024,2024,Garforth & Swillington,Leeds East,Leeds,Leeds,E05013830,E14001320,E08000035,E08000035
+2024,2024,Farringdon Without,Cities of London and Westminster,City of London,City of London,E05009305,E14001172,E09000001,E09000001
+2024,2024,Wollaston & Stourbridge Town,Stourbridge,Dudley,Dudley,E05015925,E14001524,E08000027,E08000027
+2024,2024,Temple Newsam,Leeds East,Leeds,Leeds,E05013831,E14001320,E08000035,E08000035
+2024,2024,Wordsley North,Kingswinford and South Staffordshire,Dudley,Dudley,E05015926,E14001316,E08000027,E08000027
+2024,2024,Temple Newsam,Leeds South,Leeds,Leeds,E05013831,E14001323,E08000035,E08000035
+2024,2024,Abbey,Smethwick,Sandwell,Sandwell,E05001260,E14001478,E08000028,E08000028
+2024,2024,"Ackworth, North Elmsall and Upton",Normanton and Hemsworth,Wakefield,Wakefield,E05001444,E14001383,E08000036,E08000036
+2024,2024,Blackheath,Halesowen,Sandwell,Sandwell,E05001261,E14001261,E08000028,E08000028
+2024,2024,Blackheath,Smethwick,Sandwell,Sandwell,E05001261,E14001478,E08000028,E08000028
+2024,2024,Airedale and Ferry Fryston,"Pontefract, Castleford and Knottingley",Wakefield,Wakefield,E05001445,E14001428,E08000036,E08000036
+2024,2024,Altofts and Whitwood,"Pontefract, Castleford and Knottingley",Wakefield,Wakefield,E05001446,E14001428,E08000036,E08000036
+2024,2024,Castleford Central and Glasshoughton,"Pontefract, Castleford and Knottingley",Wakefield,Wakefield,E05001447,E14001428,E08000036,E08000036
+2024,2024,"Crofton, Ryhill and Walton",Normanton and Hemsworth,Wakefield,Wakefield,E05001448,E14001383,E08000036,E08000036
+2024,2024,Bristnall,Smethwick,Sandwell,Sandwell,E05001262,E14001478,E08000028,E08000028
+2024,2024,Featherstone,Normanton and Hemsworth,Wakefield,Wakefield,E05001449,E14001383,E08000036,E08000036
+2024,2024,Hemsworth,Normanton and Hemsworth,Wakefield,Wakefield,E05001450,E14001383,E08000036,E08000036
+2024,2024,Charlemont with Grove Vale,West Bromwich,Sandwell,Sandwell,E05001263,E14001574,E08000028,E08000028
+2024,2024,Horbury and South Ossett,Ossett and Denby Dale,Wakefield,Wakefield,E05001451,E14001418,E08000036,E08000036
+2024,2024,Cradley Heath and Old Hill,Halesowen,Sandwell,Sandwell,E05001264,E14001261,E08000028,E08000028
+2024,2024,Knottingley,"Pontefract, Castleford and Knottingley",Wakefield,Wakefield,E05001452,E14001428,E08000036,E08000036
+2024,2024,Normanton,Normanton and Hemsworth,Wakefield,Wakefield,E05001453,E14001383,E08000036,E08000036
+2024,2024,Ossett,Ossett and Denby Dale,Wakefield,Wakefield,E05001454,E14001418,E08000036,E08000036
+2024,2024,Brownswood,Tottenham,Hackney,Hackney,E05009367,E14001553,E09000012,E09000012
+2024,2024,Cazenove,Hackney North and Stoke Newington,Hackney,Hackney,E05009368,E14001259,E09000012,E09000012
+2024,2024,Clissold,Hackney North and Stoke Newington,Hackney,Hackney,E05009369,E14001259,E09000012,E09000012
+2024,2024,Dalston,Hackney South and Shoreditch,Hackney,Hackney,E05009370,E14001260,E09000012,E09000012
+2024,2024,De Beauvoir,Islington South and Finsbury,Hackney,Hackney,E05009371,E14001306,E09000012,E09000012
+2024,2024,Hackney Central,Hackney South and Shoreditch,Hackney,Hackney,E05009372,E14001260,E09000012,E09000012
+2024,2024,Hackney Downs,Hackney North and Stoke Newington,Hackney,Hackney,E05009373,E14001259,E09000012,E09000012
+2024,2024,Hackney Wick,Hackney South and Shoreditch,Hackney,Hackney,E05009374,E14001260,E09000012,E09000012
+2024,2024,Haggerston,Hackney South and Shoreditch,Hackney,Hackney,E05009375,E14001260,E09000012,E09000012
+2024,2024,Homerton,Hackney South and Shoreditch,Hackney,Hackney,E05009376,E14001260,E09000012,E09000012
+2024,2024,Hoxton East & Shoreditch,Hackney South and Shoreditch,Hackney,Hackney,E05009377,E14001260,E09000012,E09000012
+2024,2024,Hoxton West,Hackney South and Shoreditch,Hackney,Hackney,E05009378,E14001260,E09000012,E09000012
+2024,2024,King's Park,Hackney North and Stoke Newington,Hackney,Hackney,E05009379,E14001259,E09000012,E09000012
+2024,2024,Lea Bridge,Hackney North and Stoke Newington,Hackney,Hackney,E05009380,E14001259,E09000012,E09000012
+2024,2024,London Fields,Hackney South and Shoreditch,Hackney,Hackney,E05009381,E14001260,E09000012,E09000012
+2024,2024,Shacklewell,Hackney North and Stoke Newington,Hackney,Hackney,E05009382,E14001259,E09000012,E09000012
+2024,2024,Springfield,Hackney North and Stoke Newington,Hackney,Hackney,E05009383,E14001259,E09000012,E09000012
+2024,2024,Stamford Hill West,Hackney North and Stoke Newington,Hackney,Hackney,E05009384,E14001259,E09000012,E09000012
+2024,2024,Stoke Newington,Hackney North and Stoke Newington,Hackney,Hackney,E05009385,E14001259,E09000012,E09000012
+2024,2024,Victoria,Hackney South and Shoreditch,Hackney,Hackney,E05009386,E14001260,E09000012,E09000012
+2024,2024,Woodberry Down,Tottenham,Hackney,Hackney,E05009387,E14001553,E09000012,E09000012
+2024,2024,Addison,Hammersmith and Chiswick,Hammersmith and Fulham,Hammersmith and Fulham,E05013733,E14001264,E09000013,E09000013
+2024,2024,Avonmore,Hammersmith and Chiswick,Hammersmith and Fulham,Hammersmith and Fulham,E05013734,E14001264,E09000013,E09000013
+2024,2024,Brook Green,Hammersmith and Chiswick,Hammersmith and Fulham,Hammersmith and Fulham,E05013735,E14001264,E09000013,E09000013
+2024,2024,College Park & Old Oak,Ealing Central and Acton,Hammersmith and Fulham,Hammersmith and Fulham,E05013736,E14001207,E09000013,E09000013
+2024,2024,Coningham,Hammersmith and Chiswick,Hammersmith and Fulham,Hammersmith and Fulham,E05013737,E14001264,E09000013,E09000013
+2024,2024,Fulham Reach,Chelsea and Fulham,Hammersmith and Fulham,Hammersmith and Fulham,E05013738,E14001160,E09000013,E09000013
+2024,2024,Fulham Town,Chelsea and Fulham,Hammersmith and Fulham,Hammersmith and Fulham,E05013739,E14001160,E09000013,E09000013
+2024,2024,Grove,Hammersmith and Chiswick,Hammersmith and Fulham,Hammersmith and Fulham,E05013740,E14001264,E09000013,E09000013
+2024,2024,Hammersmith Broadway,Hammersmith and Chiswick,Hammersmith and Fulham,Hammersmith and Fulham,E05013741,E14001264,E09000013,E09000013
+2024,2024,Lillie,Chelsea and Fulham,Hammersmith and Fulham,Hammersmith and Fulham,E05013742,E14001160,E09000013,E09000013
+2024,2024,Munster,Chelsea and Fulham,Hammersmith and Fulham,Hammersmith and Fulham,E05013743,E14001160,E09000013,E09000013
+2024,2024,Palace & Hurlingham,Chelsea and Fulham,Hammersmith and Fulham,Hammersmith and Fulham,E05013744,E14001160,E09000013,E09000013
+2024,2024,Parsons Green & Sandford,Chelsea and Fulham,Hammersmith and Fulham,Hammersmith and Fulham,E05013745,E14001160,E09000013,E09000013
+2024,2024,Ravenscourt,Hammersmith and Chiswick,Hammersmith and Fulham,Hammersmith and Fulham,E05013746,E14001264,E09000013,E09000013
+2024,2024,Sands End,Chelsea and Fulham,Hammersmith and Fulham,Hammersmith and Fulham,E05013747,E14001160,E09000013,E09000013
+2024,2024,Shepherd's Bush Green,Hammersmith and Chiswick,Hammersmith and Fulham,Hammersmith and Fulham,E05013748,E14001264,E09000013,E09000013
+2024,2024,Walham Green,Chelsea and Fulham,Hammersmith and Fulham,Hammersmith and Fulham,E05013749,E14001160,E09000013,E09000013
+2024,2024,Wendell Park,Hammersmith and Chiswick,Hammersmith and Fulham,Hammersmith and Fulham,E05013750,E14001264,E09000013,E09000013
+2024,2024,West Kensington,Chelsea and Fulham,Hammersmith and Fulham,Hammersmith and Fulham,E05013751,E14001160,E09000013,E09000013
+2024,2024,White City,Hammersmith and Chiswick,Hammersmith and Fulham,Hammersmith and Fulham,E05013752,E14001264,E09000013,E09000013
+2024,2024,Wormholt,Ealing Central and Acton,Hammersmith and Fulham,Hammersmith and Fulham,E05013753,E14001207,E09000013,E09000013
+2024,2024,Alexandra Park,Hornsey and Friern Barnet,Haringey,Haringey,E05013585,E14001293,E09000014,E09000014
+2024,2024,Bounds Green,Southgate and Wood Green,Haringey,Haringey,E05013586,E14001503,E09000014,E09000014
+2024,2024,Bruce Castle,Tottenham,Haringey,Haringey,E05013587,E14001553,E09000014,E09000014
+2024,2024,Crouch End,Hornsey and Friern Barnet,Haringey,Haringey,E05013588,E14001293,E09000014,E09000014
+2024,2024,Fortis Green,Hornsey and Friern Barnet,Haringey,Haringey,E05013589,E14001293,E09000014,E09000014
+2024,2024,Harringay,Hornsey and Friern Barnet,Haringey,Haringey,E05013590,E14001293,E09000014,E09000014
+2024,2024,Hermitage & Gardens,Tottenham,Haringey,Haringey,E05013591,E14001553,E09000014,E09000014
+2024,2024,Highgate,Hampstead and Highgate,Haringey,Haringey,E05013592,E14001265,E09000014,E09000014
+2024,2024,Langbourn,Cities of London and Westminster,City of London,City of London,E05009306,E14001172,E09000001,E09000001
+2024,2024,Rush Green & Crowlands,Romford,Havering,Havering,E05013980,E14001448,E09000016,E09000016
+2024,2024,New Addington North,Croydon East,Croydon,Croydon,E05011470,E14001186,E09000008,E09000008
+2024,2024,Underhill,Chipping Barnet,Barnet,Barnet,E05013647,E14001169,E09000003,E09000003
+2024,2024,Carterhatch,Enfield North,Enfield,Enfield,E05013677,E14001225,E09000010,E09000010
+2024,2024,Cockfosters,Southgate and Wood Green,Enfield,Enfield,E05013678,E14001503,E09000010,E09000010
+2024,2024,Edmonton Green,Edmonton and Winchmore Hill,Enfield,Enfield,E05013679,E14001221,E09000010,E09000010
+2024,2024,Enfield Lock,Enfield North,Enfield,Enfield,E05013680,E14001225,E09000010,E09000010
+2024,2024,Grange Park,Edmonton and Winchmore Hill,Enfield,Enfield,E05013681,E14001221,E09000010,E09000010
+2024,2024,Haselbury,Edmonton and Winchmore Hill,Enfield,Enfield,E05013682,E14001221,E09000010,E09000010
+2024,2024,Highfield,Edmonton and Winchmore Hill,Enfield,Enfield,E05013683,E14001221,E09000010,E09000010
+2024,2024,Jubilee,Edmonton and Winchmore Hill,Enfield,Enfield,E05013684,E14001221,E09000010,E09000010
+2024,2024,Lower Edmonton,Edmonton and Winchmore Hill,Enfield,Enfield,E05013685,E14001221,E09000010,E09000010
+2024,2024,New Southgate,Southgate and Wood Green,Enfield,Enfield,E05013686,E14001503,E09000010,E09000010
+2024,2024,Oakwood,Southgate and Wood Green,Enfield,Enfield,E05013687,E14001503,E09000010,E09000010
+2024,2024,Palmers Green,Southgate and Wood Green,Enfield,Enfield,E05013688,E14001503,E09000010,E09000010
+2024,2024,Ponders End,Enfield North,Enfield,Enfield,E05013689,E14001225,E09000010,E09000010
+2024,2024,Ridgeway,Enfield North,Enfield,Enfield,E05013690,E14001225,E09000010,E09000010
+2024,2024,Southbury,Enfield North,Enfield,Enfield,E05013691,E14001225,E09000010,E09000010
+2024,2024,Southgate,Southgate and Wood Green,Enfield,Enfield,E05013692,E14001503,E09000010,E09000010
+2024,2024,Town,Enfield North,Enfield,Enfield,E05013693,E14001225,E09000010,E09000010
+2024,2024,Upper Edmonton,Edmonton and Winchmore Hill,Enfield,Enfield,E05013694,E14001221,E09000010,E09000010
+2024,2024,Whitewebbs,Enfield North,Enfield,Enfield,E05013695,E14001225,E09000010,E09000010
+2024,2024,New Addington South,Croydon East,Croydon,Croydon,E05011471,E14001186,E09000008,E09000008
+2024,2024,Winchmore Hill,Edmonton and Winchmore Hill,Enfield,Enfield,E05013696,E14001221,E09000010,E09000010
+2024,2024,West Finchley,Finchley and Golders Green,Barnet,Barnet,E05013648,E14001238,E09000003,E09000003
+2024,2024,Chelsfield,Orpington,Bromley,Bromley,E05013992,E14001417,E09000006,E09000006
+2024,2024,Norbury & Pollards Hill,Streatham and Croydon North,Croydon,Croydon,E05011472,E14001527,E09000008,E09000008
+2024,2024,Abbey Wood,Erith and Thamesmead,Greenwich,Greenwich,E05014072,E14001229,E09000011,E09000011
+2024,2024,West Hendon,Hendon,Barnet,Barnet,E05013649,E14001279,E09000003,E09000003
+2024,2024,Hornsey,Hornsey and Friern Barnet,Haringey,Haringey,E05013593,E14001293,E09000014,E09000014
+2024,2024,St Alban's,Romford,Havering,Havering,E05013981,E14001448,E09000016,E09000016
+2024,2024,Lime Street,Cities of London and Westminster,City of London,City of London,E05009307,E14001172,E09000001,E09000001
+2024,2024,Chislehurst,Eltham and Chislehurst,Bromley,Bromley,E05013993,E14001223,E09000006,E09000006
+2024,2024,Norbury Park,Streatham and Croydon North,Croydon,Croydon,E05011473,E14001527,E09000008,E09000008
+2024,2024,Blackheath Westcombe,Eltham and Chislehurst,Greenwich,Greenwich,E05014073,E14001223,E09000011,E09000011
+2024,2024,Whetstone,Chipping Barnet,Barnet,Barnet,E05013650,E14001169,E09000003,E09000003
+2024,2024,Muswell Hill,Hornsey and Friern Barnet,Haringey,Haringey,E05013594,E14001293,E09000014,E09000014
+2024,2024,St Andrew's,Hornchurch and Upminster,Havering,Havering,E05013982,E14001292,E09000016,E09000016
+2024,2024,Portsoken,Cities of London and Westminster,City of London,City of London,E05009308,E14001172,E09000001,E09000001
+2024,2024,Chislehurst,Orpington,Bromley,Bromley,E05013993,E14001417,E09000006,E09000006
+2024,2024,Old Coulsdon,Croydon South,Croydon,Croydon,E05011474,E14001187,E09000008,E09000008
+2024,2024,Park Hill & Whitgift,Croydon South,Croydon,Croydon,E05011475,E14001187,E09000008,E09000008
+2024,2024,Purley & Woodcote,Croydon South,Croydon,Croydon,E05011476,E14001187,E09000008,E09000008
+2024,2024,Purley Oaks & Riddlesdown,Croydon South,Croydon,Croydon,E05011477,E14001187,E09000008,E09000008
+2024,2024,Sanderstead,Croydon South,Croydon,Croydon,E05011478,E14001187,E09000008,E09000008
+2024,2024,Selhurst,Croydon West,Croydon,Croydon,E05011479,E14001188,E09000008,E09000008
+2024,2024,Selsdon & Addington Village,Croydon East,Croydon,Croydon,E05011480,E14001186,E09000008,E09000008
+2024,2024,Selsdon Vale & Forestdale,Croydon East,Croydon,Croydon,E05011481,E14001186,E09000008,E09000008
+2024,2024,Shirley North,Croydon East,Croydon,Croydon,E05011482,E14001186,E09000008,E09000008
+2024,2024,Shirley South,Croydon East,Croydon,Croydon,E05011483,E14001186,E09000008,E09000008
+2024,2024,South Croydon,Croydon South,Croydon,Croydon,E05011484,E14001187,E09000008,E09000008
+2024,2024,South Norwood,Croydon West,Croydon,Croydon,E05011485,E14001188,E09000008,E09000008
+2024,2024,Thornton Heath,Streatham and Croydon North,Croydon,Croydon,E05011486,E14001527,E09000008,E09000008
+2024,2024,Waddon,Croydon West,Croydon,Croydon,E05011487,E14001188,E09000008,E09000008
+2024,2024,West Thornton,Croydon West,Croydon,Croydon,E05011488,E14001188,E09000008,E09000008
+2024,2024,Woodside,Croydon East,Croydon,Croydon,E05011489,E14001186,E09000008,E09000008
+2024,2024,Woodside,Croydon West,Croydon,Croydon,E05011489,E14001188,E09000008,E09000008
+2024,2024,Central Greenford,Ealing North,Ealing,Ealing,E05013518,E14001208,E09000009,E09000009
+2024,2024,Dormers Wells,Ealing Southall,Ealing,Ealing,E05013519,E14001209,E09000009,E09000009
+2024,2024,Ealing Broadway,Ealing Central and Acton,Ealing,Ealing,E05013520,E14001207,E09000009,E09000009
+2024,2024,Ealing Common,Ealing Central and Acton,Ealing,Ealing,E05013521,E14001207,E09000009,E09000009
+2024,2024,East Acton,Ealing Central and Acton,Ealing,Ealing,E05013522,E14001207,E09000009,E09000009
+2024,2024,Greenford Broadway,Ealing North,Ealing,Ealing,E05013523,E14001208,E09000009,E09000009
+2024,2024,Hanger Hill,Ealing Central and Acton,Ealing,Ealing,E05013524,E14001207,E09000009,E09000009
+2024,2024,Hanwell Broadway,Ealing Southall,Ealing,Ealing,E05013525,E14001209,E09000009,E09000009
+2024,2024,Lady Margaret,Ealing Southall,Ealing,Ealing,E05013526,E14001209,E09000009,E09000009
+2024,2024,North Acton,Ealing Central and Acton,Ealing,Ealing,E05013527,E14001207,E09000009,E09000009
+2024,2024,North Greenford,Ealing North,Ealing,Ealing,E05013528,E14001208,E09000009,E09000009
+2024,2024,North Hanwell,Ealing North,Ealing,Ealing,E05013529,E14001208,E09000009,E09000009
+2024,2024,Northfield,Ealing Southall,Ealing,Ealing,E05013530,E14001209,E09000009,E09000009
+2024,2024,Northolt Mandeville,Ealing North,Ealing,Ealing,E05013531,E14001208,E09000009,E09000009
+2024,2024,Northolt West End,Ealing North,Ealing,Ealing,E05013532,E14001208,E09000009,E09000009
+2024,2024,Norwood Green,Ealing Southall,Ealing,Ealing,E05013533,E14001209,E09000009,E09000009
+2024,2024,Perivale,Ealing North,Ealing,Ealing,E05013534,E14001208,E09000009,E09000009
+2024,2024,Pitshanger,Ealing North,Ealing,Ealing,E05013535,E14001208,E09000009,E09000009
+2024,2024,South Acton,Ealing Central and Acton,Ealing,Ealing,E05013536,E14001207,E09000009,E09000009
+2024,2024,Southall Broadway,Ealing Southall,Ealing,Ealing,E05013537,E14001209,E09000009,E09000009
+2024,2024,Southall Green,Ealing Southall,Ealing,Ealing,E05013538,E14001209,E09000009,E09000009
+2024,2024,Southall West,Ealing Southall,Ealing,Ealing,E05013539,E14001209,E09000009,E09000009
+2024,2024,Southfield,Ealing Central and Acton,Ealing,Ealing,E05013540,E14001207,E09000009,E09000009
+2024,2024,Walpole,Ealing Southall,Ealing,Ealing,E05013541,E14001209,E09000009,E09000009
+2024,2024,Arnos Grove,Southgate and Wood Green,Enfield,Enfield,E05013672,E14001503,E09000010,E09000010
+2024,2024,Bowes,Southgate and Wood Green,Enfield,Enfield,E05013673,E14001503,E09000010,E09000010
+2024,2024,Brimsdown,Enfield North,Enfield,Enfield,E05013674,E14001225,E09000010,E09000010
+2024,2024,Bullsmoor,Enfield North,Enfield,Enfield,E05013675,E14001225,E09000010,E09000010
+2024,2024,Bush Hill Park,Edmonton and Winchmore Hill,Enfield,Enfield,E05013676,E14001221,E09000010,E09000010
+2024,2024,Queenhithe,Cities of London and Westminster,City of London,City of London,E05009309,E14001172,E09000001,E09000001
+2024,2024,Tower,Cities of London and Westminster,City of London,City of London,E05009310,E14001172,E09000001,E09000001
+2024,2024,Vintry,Cities of London and Westminster,City of London,City of London,E05009311,E14001172,E09000001,E09000001
+2024,2024,Walbrook,Cities of London and Westminster,City of London,City of London,E05009312,E14001172,E09000001,E09000001
+2024,2024,Abbey,Barking,Barking and Dagenham,Barking and Dagenham,E05014053,E14001073,E09000002,E09000002
+2024,2024,Alibon,Barking,Barking and Dagenham,Barking and Dagenham,E05014054,E14001073,E09000002,E09000002
+2024,2024,Clock House,Beckenham and Penge,Bromley,Bromley,E05013994,E14001083,E09000006,E09000006
+2024,2024,Noel Park,Southgate and Wood Green,Haringey,Haringey,E05013595,E14001503,E09000014,E09000014
+2024,2024,Crystal Palace & Anerley,Beckenham and Penge,Bromley,Bromley,E05013995,E14001083,E09000006,E09000006
+2024,2024,Alibon,Dagenham and Rainham,Barking and Dagenham,Barking and Dagenham,E05014054,E14001189,E09000002,E09000002
+2024,2024,Woodhouse,Finchley and Golders Green,Barnet,Barnet,E05013651,E14001238,E09000003,E09000003
+2024,2024,Darwin,Bromley and Biggin Hill,Bromley,Bromley,E05013996,E14001137,E09000006,E09000006
+2024,2024,Barking Riverside,Barking,Barking and Dagenham,Barking and Dagenham,E05014055,E14001073,E09000002,E09000002
+2024,2024,Northumberland Park,Tottenham,Haringey,Haringey,E05013596,E14001553,E09000014,E09000014
+2024,2024,St Edward's,Romford,Havering,Havering,E05013983,E14001448,E09000016,E09000016
+2024,2024,Darwin,Orpington,Bromley,Bromley,E05013996,E14001417,E09000006,E09000006
+2024,2024,South Hornchurch,Dagenham and Rainham,Havering,Havering,E05013984,E14001189,E09000016,E09000016
+2024,2024,Farnborough & Crofton,Orpington,Bromley,Bromley,E05013997,E14001417,E09000006,E09000006
+2024,2024,Squirrels Heath,Romford,Havering,Havering,E05013985,E14001448,E09000016,E09000016
+2024,2024,Hayes & Coney Hall,Bromley and Biggin Hill,Bromley,Bromley,E05013998,E14001137,E09000006,E09000006
+2024,2024,Upminster,Hornchurch and Upminster,Havering,Havering,E05013986,E14001292,E09000016,E09000016
+2024,2024,Kelsey & Eden Park,Beckenham and Penge,Bromley,Bromley,E05013999,E14001083,E09000006,E09000006
+2024,2024,Belmore,Hayes and Harlington,Hillingdon,Hillingdon,E05013564,E14001276,E09000017,E09000017
+2024,2024,Mottingham,Eltham and Chislehurst,Bromley,Bromley,E05014000,E14001223,E09000006,E09000006
+2024,2024,St Ann's,Tottenham,Haringey,Haringey,E05013597,E14001553,E09000014,E09000014
+2024,2024,Charville,Hayes and Harlington,Hillingdon,Hillingdon,E05013565,E14001276,E09000017,E09000017
+2024,2024,Beam,Dagenham and Rainham,Barking and Dagenham,Barking and Dagenham,E05014056,E14001189,E09000002,E09000002
+2024,2024,Barnehurst,Bexleyheath and Crayford,Bexley,Bexley,E05011217,E14001089,E09000004,E09000004
+2024,2024,Blackheath Westcombe,Greenwich and Woolwich,Greenwich,Greenwich,E05014073,E14001257,E09000011,E09000011
+2024,2024,Seven Sisters,Tottenham,Haringey,Haringey,E05013598,E14001553,E09000014,E09000014
+2024,2024,Charlton Hornfair,Eltham and Chislehurst,Greenwich,Greenwich,E05014074,E14001223,E09000011,E09000011
+2024,2024,Belvedere,Erith and Thamesmead,Bexley,Bexley,E05011218,E14001229,E09000004,E09000004
+2024,2024,South Tottenham,Tottenham,Haringey,Haringey,E05013599,E14001553,E09000014,E09000014
+2024,2024,Charlton Hornfair,Greenwich and Woolwich,Greenwich,Greenwich,E05014074,E14001257,E09000011,E09000011
+2024,2024,Charlton Village & Riverside,Greenwich and Woolwich,Greenwich,Greenwich,E05014075,E14001257,E09000011,E09000011
+2024,2024,East Greenwich,Greenwich and Woolwich,Greenwich,Greenwich,E05014076,E14001257,E09000011,E09000011
+2024,2024,Eltham Page,Eltham and Chislehurst,Greenwich,Greenwich,E05014077,E14001223,E09000011,E09000011
+2024,2024,Eltham Park & Progress,Eltham and Chislehurst,Greenwich,Greenwich,E05014078,E14001223,E09000011,E09000011
+2024,2024,Eltham Park & Progress,Erith and Thamesmead,Greenwich,Greenwich,E05014078,E14001229,E09000011,E09000011
+2024,2024,Eltham Town & Avery Hill,Eltham and Chislehurst,Greenwich,Greenwich,E05014079,E14001223,E09000011,E09000011
+2024,2024,Greenwich Creekside,Greenwich and Woolwich,Greenwich,Greenwich,E05014080,E14001257,E09000011,E09000011
+2024,2024,Greenwich Park,Greenwich and Woolwich,Greenwich,Greenwich,E05014081,E14001257,E09000011,E09000011
+2024,2024,Greenwich Peninsula,Greenwich and Woolwich,Greenwich,Greenwich,E05014082,E14001257,E09000011,E09000011
+2024,2024,Kidbrooke Park,Eltham and Chislehurst,Greenwich,Greenwich,E05014083,E14001223,E09000011,E09000011
+2024,2024,Kidbrooke Village & Sutcliffe,Eltham and Chislehurst,Greenwich,Greenwich,E05014084,E14001223,E09000011,E09000011
+2024,2024,Middle Park & Horn Park,Eltham and Chislehurst,Greenwich,Greenwich,E05014085,E14001223,E09000011,E09000011
+2024,2024,"Mottingham, Coldharbour & New Eltham",Eltham and Chislehurst,Greenwich,Greenwich,E05014086,E14001223,E09000011,E09000011
+2024,2024,Plumstead & Glyndon,Erith and Thamesmead,Greenwich,Greenwich,E05014087,E14001229,E09000011,E09000011
+2024,2024,Plumstead Common,Erith and Thamesmead,Greenwich,Greenwich,E05014088,E14001229,E09000011,E09000011
+2024,2024,Plumstead Common,Greenwich and Woolwich,Greenwich,Greenwich,E05014088,E14001257,E09000011,E09000011
+2024,2024,Shooters Hill,Erith and Thamesmead,Greenwich,Greenwich,E05014089,E14001229,E09000011,E09000011
+2024,2024,Shooters Hill,Greenwich and Woolwich,Greenwich,Greenwich,E05014089,E14001257,E09000011,E09000011
+2024,2024,Thamesmead Moorings,Erith and Thamesmead,Greenwich,Greenwich,E05014090,E14001229,E09000011,E09000011
+2024,2024,West Thamesmead,Erith and Thamesmead,Greenwich,Greenwich,E05014091,E14001229,E09000011,E09000011
+2024,2024,Woolwich Arsenal,Erith and Thamesmead,Greenwich,Greenwich,E05014092,E14001229,E09000011,E09000011
+2024,2024,Woolwich Arsenal,Greenwich and Woolwich,Greenwich,Greenwich,E05014092,E14001257,E09000011,E09000011
+2024,2024,Woolwich Common,Erith and Thamesmead,Greenwich,Greenwich,E05014093,E14001229,E09000011,E09000011
+2024,2024,Woolwich Common,Greenwich and Woolwich,Greenwich,Greenwich,E05014093,E14001257,E09000011,E09000011
+2024,2024,Woolwich Dockyard,Greenwich and Woolwich,Greenwich,Greenwich,E05014094,E14001257,E09000011,E09000011
+2024,2024,Orpington,Orpington,Bromley,Bromley,E05014001,E14001417,E09000006,E09000006
+2024,2024,Colham & Cowley,Uxbridge and South Ruislip,Hillingdon,Hillingdon,E05013566,E14001558,E09000017,E09000017
+2024,2024,Becontree,Barking,Barking and Dagenham,Barking and Dagenham,E05014057,E14001073,E09000002,E09000002
+2024,2024,Penge & Cator,Beckenham and Penge,Bromley,Bromley,E05014002,E14001083,E09000006,E09000006
+2024,2024,Petts Wood & Knoll,Bromley and Biggin Hill,Bromley,Bromley,E05014003,E14001137,E09000006,E09000006
+2024,2024,Petts Wood & Knoll,Orpington,Bromley,Bromley,E05014003,E14001417,E09000006,E09000006
+2024,2024,Plaistow,Bromley and Biggin Hill,Bromley,Bromley,E05014004,E14001137,E09000006,E09000006
+2024,2024,Shortlands & Park Langley,Beckenham and Penge,Bromley,Bromley,E05014005,E14001083,E09000006,E09000006
+2024,2024,Shortlands & Park Langley,Bromley and Biggin Hill,Bromley,Bromley,E05014005,E14001137,E09000006,E09000006
+2024,2024,St Mary Cray,Orpington,Bromley,Bromley,E05014006,E14001417,E09000006,E09000006
+2024,2024,Eastcote,"Ruislip, Northwood and Pinner",Hillingdon,Hillingdon,E05013567,E14001454,E09000017,E09000017
+2024,2024,Harefield Village,"Ruislip, Northwood and Pinner",Hillingdon,Hillingdon,E05013568,E14001454,E09000017,E09000017
+2024,2024,Hayes Town,Hayes and Harlington,Hillingdon,Hillingdon,E05013569,E14001276,E09000017,E09000017
+2024,2024,Heathrow Villages,Hayes and Harlington,Hillingdon,Hillingdon,E05013570,E14001276,E09000017,E09000017
+2024,2024,Hillingdon East,Uxbridge and South Ruislip,Hillingdon,Hillingdon,E05013571,E14001558,E09000017,E09000017
+2024,2024,Hillingdon West,Uxbridge and South Ruislip,Hillingdon,Hillingdon,E05013572,E14001558,E09000017,E09000017
+2024,2024,Ickenham & South Harefield,Uxbridge and South Ruislip,Hillingdon,Hillingdon,E05013573,E14001558,E09000017,E09000017
+2024,2024,Northwood,"Ruislip, Northwood and Pinner",Hillingdon,Hillingdon,E05013574,E14001454,E09000017,E09000017
+2024,2024,Northwood Hills,"Ruislip, Northwood and Pinner",Hillingdon,Hillingdon,E05013575,E14001454,E09000017,E09000017
+2024,2024,Pinkwell,Hayes and Harlington,Hillingdon,Hillingdon,E05013576,E14001276,E09000017,E09000017
+2024,2024,Ruislip,"Ruislip, Northwood and Pinner",Hillingdon,Hillingdon,E05013577,E14001454,E09000017,E09000017
+2024,2024,Ruislip Manor,Uxbridge and South Ruislip,Hillingdon,Hillingdon,E05013578,E14001558,E09000017,E09000017
+2024,2024,South Ruislip,Uxbridge and South Ruislip,Hillingdon,Hillingdon,E05013579,E14001558,E09000017,E09000017
+2024,2024,Uxbridge,Uxbridge and South Ruislip,Hillingdon,Hillingdon,E05013580,E14001558,E09000017,E09000017
+2024,2024,West Drayton,Hayes and Harlington,Hillingdon,Hillingdon,E05013581,E14001276,E09000017,E09000017
+2024,2024,Wood End,Hayes and Harlington,Hillingdon,Hillingdon,E05013582,E14001276,E09000017,E09000017
+2024,2024,Yeading,Hayes and Harlington,Hillingdon,Hillingdon,E05013583,E14001276,E09000017,E09000017
+2024,2024,Yiewsley,Uxbridge and South Ruislip,Hillingdon,Hillingdon,E05013584,E14001558,E09000017,E09000017
+2024,2024,Bedfont,Feltham and Heston,Hounslow,Hounslow,E05013606,E14001236,E09000018,E09000018
+2024,2024,Brentford East,Brentford and Isleworth,Hounslow,Hounslow,E05013607,E14001124,E09000018,E09000018
+2024,2024,Brentford West,Brentford and Isleworth,Hounslow,Hounslow,E05013608,E14001124,E09000018,E09000018
+2024,2024,Chiswick Gunnersbury,Hammersmith and Chiswick,Hounslow,Hounslow,E05013609,E14001264,E09000018,E09000018
+2024,2024,Chiswick Homefields,Hammersmith and Chiswick,Hounslow,Hounslow,E05013610,E14001264,E09000018,E09000018
+2024,2024,Stroud Green,Hornsey and Friern Barnet,Haringey,Haringey,E05013600,E14001293,E09000014,E09000014
+2024,2024,Chiswick Riverside,Hammersmith and Chiswick,Hounslow,Hounslow,E05013611,E14001264,E09000018,E09000018
+2024,2024,Tottenham Central,Tottenham,Haringey,Haringey,E05013601,E14001553,E09000014,E09000014
+2024,2024,Cranford,Feltham and Heston,Hounslow,Hounslow,E05013612,E14001236,E09000018,E09000018
+2024,2024,Tottenham Hale,Tottenham,Haringey,Haringey,E05013602,E14001553,E09000014,E09000014
+2024,2024,Feltham North,Feltham and Heston,Hounslow,Hounslow,E05013613,E14001236,E09000018,E09000018
+2024,2024,West Green,Tottenham,Haringey,Haringey,E05013603,E14001553,E09000014,E09000014
+2024,2024,Feltham West,Feltham and Heston,Hounslow,Hounslow,E05013614,E14001236,E09000018,E09000018
+2024,2024,White Hart Lane,Southgate and Wood Green,Haringey,Haringey,E05013604,E14001503,E09000014,E09000014
+2024,2024,Hanworth Park,Feltham and Heston,Hounslow,Hounslow,E05013615,E14001236,E09000018,E09000018
+2024,2024,Woodside,Southgate and Wood Green,Haringey,Haringey,E05013605,E14001503,E09000014,E09000014
+2024,2024,Hanworth Village,Feltham and Heston,Hounslow,Hounslow,E05013616,E14001236,E09000018,E09000018
+2024,2024,Belmont,Harrow East,Harrow,Harrow,E05013542,E14001270,E09000015,E09000015
+2024,2024,Heston Central,Feltham and Heston,Hounslow,Hounslow,E05013617,E14001236,E09000018,E09000018
+2024,2024,Heston East,Brentford and Isleworth,Hounslow,Hounslow,E05013618,E14001124,E09000018,E09000018
+2024,2024,Heston West,Feltham and Heston,Hounslow,Hounslow,E05013619,E14001236,E09000018,E09000018
+2024,2024,Hounslow Central,Brentford and Isleworth,Hounslow,Hounslow,E05013620,E14001124,E09000018,E09000018
+2024,2024,Hounslow East,Brentford and Isleworth,Hounslow,Hounslow,E05013621,E14001124,E09000018,E09000018
+2024,2024,Hounslow Heath,Brentford and Isleworth,Hounslow,Hounslow,E05013622,E14001124,E09000018,E09000018
+2024,2024,Hounslow South,Brentford and Isleworth,Hounslow,Hounslow,E05013623,E14001124,E09000018,E09000018
+2024,2024,Hounslow West,Feltham and Heston,Hounslow,Hounslow,E05013624,E14001236,E09000018,E09000018
+2024,2024,Isleworth,Brentford and Isleworth,Hounslow,Hounslow,E05013625,E14001124,E09000018,E09000018
+2024,2024,Osterley & Spring Grove,Brentford and Isleworth,Hounslow,Hounslow,E05013626,E14001124,E09000018,E09000018
+2024,2024,Syon & Brentford Lock,Brentford and Isleworth,Hounslow,Hounslow,E05013627,E14001124,E09000018,E09000018
+2024,2024,Chadwell Heath,Dagenham and Rainham,Barking and Dagenham,Barking and Dagenham,E05014058,E14001189,E09000002,E09000002
+2024,2024,Canons,Harrow East,Harrow,Harrow,E05013543,E14001270,E09000015,E09000015
+2024,2024,St Paul's Cray,Orpington,Bromley,Bromley,E05014007,E14001417,E09000006,E09000006
+2024,2024,West Wickham,Beckenham and Penge,Bromley,Bromley,E05014008,E14001083,E09000006,E09000006
+2024,2024,Belsize,Hampstead and Highgate,Camden,Camden,E05013652,E14001265,E09000007,E09000007
+2024,2024,Bloomsbury,Holborn and St Pancras,Camden,Camden,E05013653,E14001290,E09000007,E09000007
+2024,2024,Camden Square,Holborn and St Pancras,Camden,Camden,E05013654,E14001290,E09000007,E09000007
+2024,2024,Camden Town,Holborn and St Pancras,Camden,Camden,E05013655,E14001290,E09000007,E09000007
+2024,2024,Fortune Green,Hampstead and Highgate,Camden,Camden,E05013656,E14001265,E09000007,E09000007
+2024,2024,Frognal,Hampstead and Highgate,Camden,Camden,E05013657,E14001265,E09000007,E09000007
+2024,2024,Gospel Oak,Hampstead and Highgate,Camden,Camden,E05013658,E14001265,E09000007,E09000007
+2024,2024,Hampstead Town,Hampstead and Highgate,Camden,Camden,E05013659,E14001265,E09000007,E09000007
+2024,2024,Haverstock,Holborn and St Pancras,Camden,Camden,E05013660,E14001290,E09000007,E09000007
+2024,2024,Highgate,Hampstead and Highgate,Camden,Camden,E05013661,E14001265,E09000007,E09000007
+2024,2024,Holborn & Covent Garden,Holborn and St Pancras,Camden,Camden,E05013662,E14001290,E09000007,E09000007
+2024,2024,Kentish Town North,Holborn and St Pancras,Camden,Camden,E05013663,E14001290,E09000007,E09000007
+2024,2024,Kentish Town South,Holborn and St Pancras,Camden,Camden,E05013664,E14001290,E09000007,E09000007
+2024,2024,Kilburn,Hampstead and Highgate,Camden,Camden,E05013665,E14001265,E09000007,E09000007
+2024,2024,King's Cross,Holborn and St Pancras,Camden,Camden,E05013666,E14001290,E09000007,E09000007
+2024,2024,Primrose Hill,Hampstead and Highgate,Camden,Camden,E05013667,E14001265,E09000007,E09000007
+2024,2024,Primrose Hill,Holborn and St Pancras,Camden,Camden,E05013667,E14001290,E09000007,E09000007
+2024,2024,Regent's Park,Holborn and St Pancras,Camden,Camden,E05013668,E14001290,E09000007,E09000007
+2024,2024,St Pancras & Somers Town,Holborn and St Pancras,Camden,Camden,E05013669,E14001290,E09000007,E09000007
+2024,2024,South Hampstead,Hampstead and Highgate,Camden,Camden,E05013670,E14001265,E09000007,E09000007
+2024,2024,West Hampstead,Hampstead and Highgate,Camden,Camden,E05013671,E14001265,E09000007,E09000007
+2024,2024,Addiscombe East,Croydon East,Croydon,Croydon,E05011462,E14001186,E09000008,E09000008
+2024,2024,Bexleyheath,Bexleyheath and Crayford,Bexley,Bexley,E05011219,E14001089,E09000004,E09000004
+2024,2024,Addiscombe West,Croydon East,Croydon,Croydon,E05011463,E14001186,E09000008,E09000008
+2024,2024,Bensham Manor,Croydon West,Croydon,Croydon,E05011464,E14001188,E09000008,E09000008
+2024,2024,Broad Green,Croydon West,Croydon,Croydon,E05011465,E14001188,E09000008,E09000008
+2024,2024,Coulsdon Town,Croydon South,Croydon,Croydon,E05011466,E14001187,E09000008,E09000008
+2024,2024,Crystal Palace & Upper Norwood,Streatham and Croydon North,Croydon,Croydon,E05011467,E14001527,E09000008,E09000008
+2024,2024,Fairfield,Croydon West,Croydon,Croydon,E05011468,E14001188,E09000008,E09000008
+2024,2024,Kenley,Croydon South,Croydon,Croydon,E05011469,E14001187,E09000008,E09000008
+2024,2024,Blackfen & Lamorbey,Old Bexley and Sidcup,Bexley,Bexley,E05011220,E14001414,E09000004,E09000004
+2024,2024,Blendon & Penhill,Old Bexley and Sidcup,Bexley,Bexley,E05011221,E14001414,E09000004,E09000004
+2024,2024,Crayford,Bexleyheath and Crayford,Bexley,Bexley,E05011222,E14001089,E09000004,E09000004
+2024,2024,Crook Log,Bexleyheath and Crayford,Bexley,Bexley,E05011223,E14001089,E09000004,E09000004
+2024,2024,East Wickham,Old Bexley and Sidcup,Bexley,Bexley,E05011224,E14001414,E09000004,E09000004
+2024,2024,Erith,Erith and Thamesmead,Bexley,Bexley,E05011225,E14001229,E09000004,E09000004
+2024,2024,Falconwood & Welling,Old Bexley and Sidcup,Bexley,Bexley,E05011226,E14001414,E09000004,E09000004
+2024,2024,Longlands,Old Bexley and Sidcup,Bexley,Bexley,E05011227,E14001414,E09000004,E09000004
+2024,2024,Northumberland Heath,Bexleyheath and Crayford,Bexley,Bexley,E05011228,E14001089,E09000004,E09000004
+2024,2024,St Mary's & St James,Old Bexley and Sidcup,Bexley,Bexley,E05011229,E14001414,E09000004,E09000004
+2024,2024,Sidcup,Old Bexley and Sidcup,Bexley,Bexley,E05011230,E14001414,E09000004,E09000004
+2024,2024,Slade Green & Northend,Bexleyheath and Crayford,Bexley,Bexley,E05011231,E14001089,E09000004,E09000004
+2024,2024,Thamesmead East,Erith and Thamesmead,Bexley,Bexley,E05011232,E14001229,E09000004,E09000004
+2024,2024,West Heath,Bexleyheath and Crayford,Bexley,Bexley,E05011233,E14001089,E09000004,E09000004
+2024,2024,Alperton,Brent West,Brent,Brent,E05013496,E14001123,E09000005,E09000005
+2024,2024,Barnhill,Brent West,Brent,Brent,E05013497,E14001123,E09000005,E09000005
+2024,2024,Brondesbury Park,Brent East,Brent,Brent,E05013498,E14001122,E09000005,E09000005
+2024,2024,Cricklewood & Mapesbury,Brent East,Brent,Brent,E05013499,E14001122,E09000005,E09000005
+2024,2024,Dollis Hill,Brent East,Brent,Brent,E05013500,E14001122,E09000005,E09000005
+2024,2024,Harlesden & Kensal Green,Queen's Park and Maida Vale,Brent,Brent,E05013501,E14001435,E09000005,E09000005
+2024,2024,Kenton,Brent West,Brent,Brent,E05013502,E14001123,E09000005,E09000005
+2024,2024,Kilburn,Queen's Park and Maida Vale,Brent,Brent,E05013503,E14001435,E09000005,E09000005
+2024,2024,Kingsbury,Brent East,Brent,Brent,E05013504,E14001122,E09000005,E09000005
+2024,2024,Northwick Park,Brent West,Brent,Brent,E05013505,E14001123,E09000005,E09000005
+2024,2024,Preston,Brent West,Brent,Brent,E05013506,E14001123,E09000005,E09000005
+2024,2024,Queens Park,Queen's Park and Maida Vale,Brent,Brent,E05013507,E14001435,E09000005,E09000005
+2024,2024,Queensbury,Harrow East,Brent,Brent,E05013508,E14001270,E09000005,E09000005
+2024,2024,Roundwood,Brent East,Brent,Brent,E05013509,E14001122,E09000005,E09000005
+2024,2024,Stonebridge,Brent East,Brent,Brent,E05013510,E14001122,E09000005,E09000005
+2024,2024,Sudbury,Brent West,Brent,Brent,E05013511,E14001123,E09000005,E09000005
+2024,2024,Tokyngton,Brent West,Brent,Brent,E05013512,E14001123,E09000005,E09000005
+2024,2024,Welsh Harp,Brent East,Brent,Brent,E05013513,E14001122,E09000005,E09000005
+2024,2024,Wembley Central,Brent West,Brent,Brent,E05013514,E14001123,E09000005,E09000005
+2024,2024,Wembley Hill,Brent West,Brent,Brent,E05013515,E14001123,E09000005,E09000005
+2024,2024,Wembley Park,Brent West,Brent,Brent,E05013516,E14001123,E09000005,E09000005
+2024,2024,Willesden Green,Brent East,Brent,Brent,E05013517,E14001122,E09000005,E09000005
+2024,2024,Beckenham Town & Copers Cope,Beckenham and Penge,Bromley,Bromley,E05013987,E14001083,E09000006,E09000006
+2024,2024,Bickley & Sundridge,Bromley and Biggin Hill,Bromley,Bromley,E05013988,E14001137,E09000006,E09000006
+2024,2024,Biggin Hill,Bromley and Biggin Hill,Bromley,Bromley,E05013989,E14001137,E09000006,E09000006
+2024,2024,Bromley Common & Holwood,Bromley and Biggin Hill,Bromley,Bromley,E05013990,E14001137,E09000006,E09000006
+2024,2024,Bromley Common & Holwood,Orpington,Bromley,Bromley,E05013990,E14001417,E09000006,E09000006
+2024,2024,Bromley Town,Bromley and Biggin Hill,Bromley,Bromley,E05013991,E14001137,E09000006,E09000006
+2024,2024,Chadwell Heath,Ilford South,Barking and Dagenham,Barking and Dagenham,E05014058,E14001301,E09000002,E09000002
+2024,2024,Centenary,Harrow East,Harrow,Harrow,E05013544,E14001270,E09000015,E09000015
+2024,2024,Edgware,Harrow East,Harrow,Harrow,E05013545,E14001270,E09000015,E09000015
+2024,2024,Greenhill,Harrow West,Harrow,Harrow,E05013546,E14001271,E09000015,E09000015
+2024,2024,Harrow on the Hill,Harrow West,Harrow,Harrow,E05013547,E14001271,E09000015,E09000015
+2024,2024,Harrow Weald,Harrow East,Harrow,Harrow,E05013548,E14001270,E09000015,E09000015
+2024,2024,Hatch End,"Ruislip, Northwood and Pinner",Harrow,Harrow,E05013549,E14001454,E09000015,E09000015
+2024,2024,Headstone,Harrow West,Harrow,Harrow,E05013550,E14001271,E09000015,E09000015
+2024,2024,Kenton East,Harrow East,Harrow,Harrow,E05013551,E14001270,E09000015,E09000015
+2024,2024,Kenton West,Harrow East,Harrow,Harrow,E05013552,E14001270,E09000015,E09000015
+2024,2024,Marlborough,Harrow West,Harrow,Harrow,E05013553,E14001271,E09000015,E09000015
+2024,2024,North Harrow,Harrow West,Harrow,Harrow,E05013554,E14001271,E09000015,E09000015
+2024,2024,Pinner,"Ruislip, Northwood and Pinner",Harrow,Harrow,E05013555,E14001454,E09000015,E09000015
+2024,2024,Pinner South,"Ruislip, Northwood and Pinner",Harrow,Harrow,E05013556,E14001454,E09000015,E09000015
+2024,2024,Rayners Lane,Harrow West,Harrow,Harrow,E05013557,E14001271,E09000015,E09000015
+2024,2024,Roxbourne,Harrow West,Harrow,Harrow,E05013558,E14001271,E09000015,E09000015
+2024,2024,Roxeth,Harrow West,Harrow,Harrow,E05013559,E14001271,E09000015,E09000015
+2024,2024,Stanmore,Harrow East,Harrow,Harrow,E05013560,E14001270,E09000015,E09000015
+2024,2024,Eastbrook & Rush Green,Dagenham and Rainham,Barking and Dagenham,Barking and Dagenham,E05014059,E14001189,E09000002,E09000002
+2024,2024,Wealdstone North,Harrow West,Harrow,Harrow,E05013561,E14001271,E09000015,E09000015
+2024,2024,Eastbury,Barking,Barking and Dagenham,Barking and Dagenham,E05014060,E14001073,E09000002,E09000002
+2024,2024,Wealdstone South,Harrow West,Harrow,Harrow,E05013562,E14001271,E09000015,E09000015
+2024,2024,Gascoigne,Barking,Barking and Dagenham,Barking and Dagenham,E05014061,E14001073,E09000002,E09000002
+2024,2024,West Harrow,Harrow West,Harrow,Harrow,E05013563,E14001271,E09000015,E09000015
+2024,2024,Goresbrook,Barking,Barking and Dagenham,Barking and Dagenham,E05014062,E14001073,E09000002,E09000002
+2024,2024,Beam Park,Dagenham and Rainham,Havering,Havering,E05013967,E14001189,E09000016,E09000016
+2024,2024,Goresbrook,Dagenham and Rainham,Barking and Dagenham,Barking and Dagenham,E05014062,E14001189,E09000002,E09000002
+2024,2024,Cranham,Hornchurch and Upminster,Havering,Havering,E05013968,E14001292,E09000016,E09000016
+2024,2024,Heath,Dagenham and Rainham,Barking and Dagenham,Barking and Dagenham,E05014063,E14001189,E09000002,E09000002
+2024,2024,Elm Park,Dagenham and Rainham,Havering,Havering,E05013969,E14001189,E09000016,E09000016
+2024,2024,Longbridge,Barking,Barking and Dagenham,Barking and Dagenham,E05014064,E14001073,E09000002,E09000002
+2024,2024,Mayesbrook,Barking,Barking and Dagenham,Barking and Dagenham,E05014065,E14001073,E09000002,E09000002
+2024,2024,Emerson Park,Hornchurch and Upminster,Havering,Havering,E05013970,E14001292,E09000016,E09000016
+2024,2024,Northbury,Barking,Barking and Dagenham,Barking and Dagenham,E05014066,E14001073,E09000002,E09000002
+2024,2024,Gooshays,Hornchurch and Upminster,Havering,Havering,E05013971,E14001292,E09000016,E09000016
+2024,2024,Parsloes,Barking,Barking and Dagenham,Barking and Dagenham,E05014067,E14001073,E09000002,E09000002
+2024,2024,Hacton,Dagenham and Rainham,Havering,Havering,E05013972,E14001189,E09000016,E09000016
+2024,2024,Parsloes,Dagenham and Rainham,Barking and Dagenham,Barking and Dagenham,E05014067,E14001189,E09000002,E09000002
+2024,2024,Hacton,Hornchurch and Upminster,Havering,Havering,E05013972,E14001292,E09000016,E09000016
+2024,2024,Thames View,Barking,Barking and Dagenham,Barking and Dagenham,E05014068,E14001073,E09000002,E09000002
+2024,2024,Harold Wood,Hornchurch and Upminster,Havering,Havering,E05013973,E14001292,E09000016,E09000016
+2024,2024,Valence,Barking,Barking and Dagenham,Barking and Dagenham,E05014069,E14001073,E09000002,E09000002
+2024,2024,Havering-atte-Bower,Hornchurch and Upminster,Havering,Havering,E05013974,E14001292,E09000016,E09000016
+2024,2024,Valence,Dagenham and Rainham,Barking and Dagenham,Barking and Dagenham,E05014069,E14001189,E09000002,E09000002
+2024,2024,Havering-atte-Bower,Romford,Havering,Havering,E05013974,E14001448,E09000016,E09000016
+2024,2024,Village,Dagenham and Rainham,Barking and Dagenham,Barking and Dagenham,E05014070,E14001189,E09000002,E09000002
+2024,2024,Heaton,Hornchurch and Upminster,Havering,Havering,E05013975,E14001292,E09000016,E09000016
+2024,2024,Whalebone,Dagenham and Rainham,Barking and Dagenham,Barking and Dagenham,E05014071,E14001189,E09000002,E09000002
+2024,2024,Hylands & Harrow Lodge,Romford,Havering,Havering,E05013976,E14001448,E09000016,E09000016
+2024,2024,Marshalls & Rise Park,Romford,Havering,Havering,E05013977,E14001448,E09000016,E09000016
+2024,2024,Mawneys,Romford,Havering,Havering,E05013978,E14001448,E09000016,E09000016
+2024,2024,Rainham & Wennington,Dagenham and Rainham,Havering,Havering,E05013979,E14001189,E09000016,E09000016
+2024,2024,Barnet Vale,Chipping Barnet,Barnet,Barnet,E05013628,E14001169,E09000003,E09000003
+2024,2024,Brunswick Park,Chipping Barnet,Barnet,Barnet,E05013629,E14001169,E09000003,E09000003
+2024,2024,Burnt Oak,Hendon,Barnet,Barnet,E05013630,E14001279,E09000003,E09000003
+2024,2024,Childs Hill,Finchley and Golders Green,Barnet,Barnet,E05013631,E14001238,E09000003,E09000003
+2024,2024,Colindale North,Hendon,Barnet,Barnet,E05013632,E14001279,E09000003,E09000003
+2024,2024,Colindale South,Hendon,Barnet,Barnet,E05013633,E14001279,E09000003,E09000003
+2024,2024,Cricklewood,Finchley and Golders Green,Barnet,Barnet,E05013634,E14001238,E09000003,E09000003
+2024,2024,East Barnet,Chipping Barnet,Barnet,Barnet,E05013635,E14001169,E09000003,E09000003
+2024,2024,East Finchley,Finchley and Golders Green,Barnet,Barnet,E05013636,E14001238,E09000003,E09000003
+2024,2024,Edgware,Hendon,Barnet,Barnet,E05013637,E14001279,E09000003,E09000003
+2024,2024,Edgwarebury,Chipping Barnet,Barnet,Barnet,E05013638,E14001169,E09000003,E09000003
+2024,2024,Finchley Church End,Finchley and Golders Green,Barnet,Barnet,E05013639,E14001238,E09000003,E09000003
+2024,2024,Friern Barnet,Hornsey and Friern Barnet,Barnet,Barnet,E05013640,E14001293,E09000003,E09000003
+2024,2024,Garden Suburb,Finchley and Golders Green,Barnet,Barnet,E05013641,E14001238,E09000003,E09000003
+2024,2024,Golders Green,Finchley and Golders Green,Barnet,Barnet,E05013642,E14001238,E09000003,E09000003
+2024,2024,Hendon,Hendon,Barnet,Barnet,E05013643,E14001279,E09000003,E09000003
+2024,2024,High Barnet,Chipping Barnet,Barnet,Barnet,E05013644,E14001169,E09000003,E09000003
+2024,2024,Mill Hill,Hendon,Barnet,Barnet,E05013645,E14001279,E09000003,E09000003
+2024,2024,Totteridge & Woodside,Chipping Barnet,Barnet,Barnet,E05013646,E14001169,E09000003,E09000003
+2024,2024,Arsenal,Islington North,Islington,Islington,E05013697,E14001305,E09000019,E09000019
+2024,2024,Barnsbury,Islington South and Finsbury,Islington,Islington,E05013698,E14001306,E09000019,E09000019
+2024,2024,Bunhill,Islington South and Finsbury,Islington,Islington,E05013699,E14001306,E09000019,E09000019
+2024,2024,Caledonian,Islington South and Finsbury,Islington,Islington,E05013700,E14001306,E09000019,E09000019
+2024,2024,Canonbury,Islington South and Finsbury,Islington,Islington,E05013701,E14001306,E09000019,E09000019
+2024,2024,Clerkenwell,Islington South and Finsbury,Islington,Islington,E05013702,E14001306,E09000019,E09000019
+2024,2024,Finsbury Park,Islington North,Islington,Islington,E05013703,E14001305,E09000019,E09000019
+2024,2024,Highbury,Islington North,Islington,Islington,E05013704,E14001305,E09000019,E09000019
+2024,2024,Hillrise,Islington North,Islington,Islington,E05013705,E14001305,E09000019,E09000019
+2024,2024,Holloway,Islington South and Finsbury,Islington,Islington,E05013706,E14001306,E09000019,E09000019
+2024,2024,Junction,Islington North,Islington,Islington,E05013707,E14001305,E09000019,E09000019
+2024,2024,Laycock,Islington South and Finsbury,Islington,Islington,E05013708,E14001306,E09000019,E09000019
+2024,2024,Mildmay,Islington North,Islington,Islington,E05013709,E14001305,E09000019,E09000019
+2024,2024,St Mary's & St James',Islington South and Finsbury,Islington,Islington,E05013710,E14001306,E09000019,E09000019
+2024,2024,St Peter's & Canalside,Islington South and Finsbury,Islington,Islington,E05013711,E14001306,E09000019,E09000019
+2024,2024,Tollington,Islington North,Islington,Islington,E05013712,E14001305,E09000019,E09000019
+2024,2024,Tufnell Park,Islington North,Islington,Islington,E05013713,E14001305,E09000019,E09000019
+2024,2024,Abingdon,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009388,E14001310,E09000020,E09000020
+2024,2024,Brompton & Hans Town,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009389,E14001310,E09000020,E09000020
+2024,2024,Campden,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009390,E14001310,E09000020,E09000020
+2024,2024,Chelsea Riverside,Chelsea and Fulham,Kensington and Chelsea,Kensington and Chelsea,E05009391,E14001160,E09000020,E09000020
+2024,2024,Colville,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009392,E14001310,E09000020,E09000020
+2024,2024,Courtfield,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009393,E14001310,E09000020,E09000020
+2024,2024,Dalgarno,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009394,E14001310,E09000020,E09000020
+2024,2024,Earl's Court,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009395,E14001310,E09000020,E09000020
+2024,2024,Golborne,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009396,E14001310,E09000020,E09000020
+2024,2024,Holland,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009397,E14001310,E09000020,E09000020
+2024,2024,Norland,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009398,E14001310,E09000020,E09000020
+2024,2024,Notting Dale,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009399,E14001310,E09000020,E09000020
+2024,2024,Pembridge,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009400,E14001310,E09000020,E09000020
+2024,2024,Queen's Gate,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009401,E14001310,E09000020,E09000020
+2024,2024,Redcliffe,Chelsea and Fulham,Kensington and Chelsea,Kensington and Chelsea,E05009402,E14001160,E09000020,E09000020
+2024,2024,Royal Hospital,Chelsea and Fulham,Kensington and Chelsea,Kensington and Chelsea,E05009403,E14001160,E09000020,E09000020
+2024,2024,St. Helen's,Kensington and Bayswater,Kensington and Chelsea,Kensington and Chelsea,E05009404,E14001310,E09000020,E09000020
+2024,2024,Stanley,Chelsea and Fulham,Kensington and Chelsea,Kensington and Chelsea,E05009405,E14001160,E09000020,E09000020
+2024,2024,Alexandra,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013928,E14001312,E09000021,E09000021
+2024,2024,Berrylands,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013929,E14001312,E09000021,E09000021
+2024,2024,Canbury Gardens,Richmond Park,Kingston upon Thames,Kingston upon Thames,E05013930,E14001445,E09000021,E09000021
+2024,2024,Chessington South & Malden Rushett,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013931,E14001312,E09000021,E09000021
+2024,2024,Coombe Hill,Richmond Park,Kingston upon Thames,Kingston upon Thames,E05013932,E14001445,E09000021,E09000021
+2024,2024,Coombe Vale,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013933,E14001312,E09000021,E09000021
+2024,2024,Coombe Vale,Richmond Park,Kingston upon Thames,Kingston upon Thames,E05013933,E14001445,E09000021,E09000021
+2024,2024,Green Lane & St James,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013934,E14001312,E09000021,E09000021
+2024,2024,Green Lane & St James,Wimbledon,Kingston upon Thames,Kingston upon Thames,E05013934,E14001586,E09000021,E09000021
+2024,2024,Hook & Chessington North,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013935,E14001312,E09000021,E09000021
+2024,2024,King George's & Sunray,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013936,E14001312,E09000021,E09000021
+2024,2024,Kingston Gate,Richmond Park,Kingston upon Thames,Kingston upon Thames,E05013937,E14001445,E09000021,E09000021
+2024,2024,Kingston Town,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013938,E14001312,E09000021,E09000021
+2024,2024,Motspur Park & Old Malden East,Wimbledon,Kingston upon Thames,Kingston upon Thames,E05013939,E14001586,E09000021,E09000021
+2024,2024,New Malden Village,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013940,E14001312,E09000021,E09000021
+2024,2024,Champion Hill,Dulwich and West Norwood,Southwark,Southwark,E05011097,E14001205,E09000028,E09000028
+2024,2024,Forest Hill,Lewisham West and East Dulwich,Lewisham,Lewisham,E05013722,E14001333,E09000023,E09000023
+2024,2024,Plaistow West & Canning Town East,West Ham and Beckton,Newham,Newham,E05013920,E14001576,E09000025,E09000025
+2024,2024,Shaftesbury & Queenstown,Battersea,Wandsworth,Wandsworth,E05014019,E14001081,E09000032,E09000032
+2024,2024,Limehouse,Poplar and Limehouse,Tower Hamlets,Tower Hamlets,E05009326,E14001430,E09000030,E09000030
+2024,2024,Fairview,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000118,N05000014,N09000001,N09000001
+2024,2024,New Malden Village,Wimbledon,Kingston upon Thames,Kingston upon Thames,E05013940,E14001586,E09000021,E09000021
+2024,2024,South Balham,Tooting,Wandsworth,Wandsworth,E05014020,E14001550,E09000032,E09000032
+2024,2024,Southfields,Putney,Wandsworth,Wandsworth,E05014021,E14001434,E09000032,E09000032
+2024,2024,Thamesfield,Putney,Wandsworth,Wandsworth,E05014022,E14001434,E09000032,E09000032
+2024,2024,Tooting Bec,Tooting,Wandsworth,Wandsworth,E05014023,E14001550,E09000032,E09000032
+2024,2024,Tooting Broadway,Tooting,Wandsworth,Wandsworth,E05014024,E14001550,E09000032,E09000032
+2024,2024,Trinity,Tooting,Wandsworth,Wandsworth,E05014025,E14001550,E09000032,E09000032
+2024,2024,Wandle,Tooting,Wandsworth,Wandsworth,E05014026,E14001550,E09000032,E09000032
+2024,2024,Wandsworth Common,Tooting,Wandsworth,Wandsworth,E05014027,E14001550,E09000032,E09000032
+2024,2024,Wandsworth Town,Battersea,Wandsworth,Wandsworth,E05014028,E14001081,E09000032,E09000032
+2024,2024,Wandsworth Town,Putney,Wandsworth,Wandsworth,E05014028,E14001434,E09000032,E09000032
+2024,2024,Wandsworth Town,Tooting,Wandsworth,Wandsworth,E05014028,E14001550,E09000032,E09000032
+2024,2024,West Hill,Putney,Wandsworth,Wandsworth,E05014029,E14001434,E09000032,E09000032
+2024,2024,West Putney,Putney,Wandsworth,Wandsworth,E05014030,E14001434,E09000032,E09000032
+2024,2024,Abbey Road,Cities of London and Westminster,Westminster,Westminster,E05013792,E14001172,E09000033,E09000033
+2024,2024,Bayswater,Kensington and Bayswater,Westminster,Westminster,E05013793,E14001310,E09000033,E09000033
+2024,2024,Church Street,Queen's Park and Maida Vale,Westminster,Westminster,E05013794,E14001435,E09000033,E09000033
+2024,2024,Harrow Road,Queen's Park and Maida Vale,Westminster,Westminster,E05013795,E14001435,E09000033,E09000033
+2024,2024,Hyde Park,Cities of London and Westminster,Westminster,Westminster,E05013796,E14001172,E09000033,E09000033
+2024,2024,Knightsbridge & Belgravia,Cities of London and Westminster,Westminster,Westminster,E05013797,E14001172,E09000033,E09000033
+2024,2024,Lancaster Gate,Kensington and Bayswater,Westminster,Westminster,E05013798,E14001310,E09000033,E09000033
+2024,2024,Little Venice,Queen's Park and Maida Vale,Westminster,Westminster,E05013799,E14001435,E09000033,E09000033
+2024,2024,Maida Vale,Queen's Park and Maida Vale,Westminster,Westminster,E05013800,E14001435,E09000033,E09000033
+2024,2024,Marylebone,Cities of London and Westminster,Westminster,Westminster,E05013801,E14001172,E09000033,E09000033
+2024,2024,Pimlico North,Cities of London and Westminster,Westminster,Westminster,E05013802,E14001172,E09000033,E09000033
+2024,2024,Pimlico South,Cities of London and Westminster,Westminster,Westminster,E05013803,E14001172,E09000033,E09000033
+2024,2024,Queen's Park,Queen's Park and Maida Vale,Westminster,Westminster,E05013804,E14001435,E09000033,E09000033
+2024,2024,Regent's Park,Cities of London and Westminster,Westminster,Westminster,E05013805,E14001172,E09000033,E09000033
+2024,2024,St James's,Cities of London and Westminster,Westminster,Westminster,E05013806,E14001172,E09000033,E09000033
+2024,2024,Vincent Square,Cities of London and Westminster,Westminster,Westminster,E05013807,E14001172,E09000033,E09000033
+2024,2024,West End,Cities of London and Westminster,Westminster,Westminster,E05013808,E14001172,E09000033,E09000033
+2024,2024,Westbourne,Queen's Park and Maida Vale,Westminster,Westminster,E05013809,E14001435,E09000033,E09000033
+2024,2024,Abbey,Belfast North,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000101,N05000002,N09000001,N09000001
+2024,2024,Abbey,East Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000101,N05000005,N09000001,N09000001
+2024,2024,Aldergrove,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000102,N05000014,N09000001,N09000001
+2024,2024,Antrim Centre,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000103,N05000014,N09000001,N09000001
+2024,2024,Ballyclare East,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000104,N05000014,N09000001,N09000001
+2024,2024,Ballyclare West,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000105,N05000014,N09000001,N09000001
+2024,2024,Mile End,Poplar and Limehouse,Tower Hamlets,Tower Hamlets,E05009327,E14001430,E09000030,E09000030
+2024,2024,Chaucer,Bermondsey and Old Southwark,Southwark,Southwark,E05011098,E14001085,E09000028,E09000028
+2024,2024,Grove Park,Lewisham East,Lewisham,Lewisham,E05013723,E14001331,E09000023,E09000023
+2024,2024,Plashet,East Ham,Newham,Newham,E05013921,E14001213,E09000025,E09000025
+2024,2024,Fountain Hill,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000119,N05000014,N09000001,N09000001
+2024,2024,Norbiton,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013941,E14001312,E09000021,E09000021
+2024,2024,Ballyduff,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000106,N05000014,N09000001,N09000001
+2024,2024,Ballyhenry,Belfast North,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000107,N05000002,N09000001,N09000001
+2024,2024,Ballynure,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000108,N05000014,N09000001,N09000001
+2024,2024,Ballyrobert,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000109,N05000014,N09000001,N09000001
+2024,2024,Burnthill,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000110,N05000014,N09000001,N09000001
+2024,2024,Carnmoney,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000111,N05000014,N09000001,N09000001
+2024,2024,Carnmoney Hill,Belfast North,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000112,N05000002,N09000001,N09000001
+2024,2024,Clady,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000113,N05000014,N09000001,N09000001
+2024,2024,Collinbridge,Belfast North,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000114,N05000002,N09000001,N09000001
+2024,2024,Cranfield,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000115,N05000014,N09000001,N09000001
+2024,2024,Crumlin,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000116,N05000014,N09000001,N09000001
+2024,2024,Doagh,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000117,N05000014,N09000001,N09000001
+2024,2024,Old Malden,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013942,E14001312,E09000021,E09000021
+2024,2024,Old Malden,Wimbledon,Kingston upon Thames,Kingston upon Thames,E05013942,E14001586,E09000021,E09000021
+2024,2024,St Mark's & Seething Wells,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013943,E14001312,E09000021,E09000021
+2024,2024,Surbiton Hill,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013944,E14001312,E09000021,E09000021
+2024,2024,Tolworth,Kingston and Surbiton,Kingston upon Thames,Kingston upon Thames,E05013945,E14001312,E09000021,E09000021
+2024,2024,Tudor,Richmond Park,Kingston upon Thames,Kingston upon Thames,E05013946,E14001445,E09000021,E09000021
+2024,2024,Brixton Acre Lane,Clapham and Brixton Hill,Lambeth,Lambeth,E05014095,E14001175,E09000022,E09000022
+2024,2024,Brixton North,Clapham and Brixton Hill,Lambeth,Lambeth,E05014096,E14001175,E09000022,E09000022
+2024,2024,Brixton North,Dulwich and West Norwood,Lambeth,Lambeth,E05014096,E14001205,E09000022,E09000022
+2024,2024,Brixton Rush Common,Clapham and Brixton Hill,Lambeth,Lambeth,E05014097,E14001175,E09000022,E09000022
+2024,2024,Brixton Rush Common,Dulwich and West Norwood,Lambeth,Lambeth,E05014097,E14001205,E09000022,E09000022
+2024,2024,Brixton Windrush,Dulwich and West Norwood,Lambeth,Lambeth,E05014098,E14001205,E09000022,E09000022
+2024,2024,Clapham Common & Abbeville,Clapham and Brixton Hill,Lambeth,Lambeth,E05014099,E14001175,E09000022,E09000022
+2024,2024,Clapham East,Clapham and Brixton Hill,Lambeth,Lambeth,E05014100,E14001175,E09000022,E09000022
+2024,2024,Clapham Park,Clapham and Brixton Hill,Lambeth,Lambeth,E05014101,E14001175,E09000022,E09000022
+2024,2024,Dulwich Hill,Lewisham West and East Dulwich,Southwark,Southwark,E05011099,E14001333,E09000028,E09000028
+2024,2024,Clapham Park,Streatham and Croydon North,Lambeth,Lambeth,E05014101,E14001527,E09000022,E09000022
+2024,2024,Dulwich Village,Dulwich and West Norwood,Southwark,Southwark,E05011100,E14001205,E09000028,E09000028
+2024,2024,Clapham Town,Clapham and Brixton Hill,Lambeth,Lambeth,E05014102,E14001175,E09000022,E09000022
+2024,2024,Dulwich Wood,Dulwich and West Norwood,Southwark,Southwark,E05011101,E14001205,E09000028,E09000028
+2024,2024,Faraday,Peckham,Southwark,Southwark,E05011102,E14001421,E09000028,E09000028
+2024,2024,Goose Green,Lewisham West and East Dulwich,Southwark,Southwark,E05011103,E14001333,E09000028,E09000028
+2024,2024,London Bridge & West Bermondsey,Bermondsey and Old Southwark,Southwark,Southwark,E05011104,E14001085,E09000028,E09000028
+2024,2024,Newington,Vauxhall and Camberwell Green,Southwark,Southwark,E05011105,E14001559,E09000028,E09000028
+2024,2024,North Bermondsey,Bermondsey and Old Southwark,Southwark,Southwark,E05011106,E14001085,E09000028,E09000028
+2024,2024,North Walworth,Peckham,Southwark,Southwark,E05011107,E14001421,E09000028,E09000028
+2024,2024,Nunhead & Queen's Road,Peckham,Southwark,Southwark,E05011108,E14001421,E09000028,E09000028
+2024,2024,Old Kent Road,Peckham,Southwark,Southwark,E05011109,E14001421,E09000028,E09000028
+2024,2024,Peckham,Peckham,Southwark,Southwark,E05011110,E14001421,E09000028,E09000028
+2024,2024,Peckham Rye,Lewisham West and East Dulwich,Southwark,Southwark,E05011111,E14001333,E09000028,E09000028
+2024,2024,Rotherhithe,Bermondsey and Old Southwark,Southwark,Southwark,E05011112,E14001085,E09000028,E09000028
+2024,2024,Rye Lane,Peckham,Southwark,Southwark,E05011113,E14001421,E09000028,E09000028
+2024,2024,St George's,Bermondsey and Old Southwark,Southwark,Southwark,E05011114,E14001085,E09000028,E09000028
+2024,2024,St Giles,Peckham,Southwark,Southwark,E05011115,E14001421,E09000028,E09000028
+2024,2024,South Bermondsey,Bermondsey and Old Southwark,Southwark,Southwark,E05011116,E14001085,E09000028,E09000028
+2024,2024,Surrey Docks,Bermondsey and Old Southwark,Southwark,Southwark,E05011117,E14001085,E09000028,E09000028
+2024,2024,Beddington,Carshalton and Wallington,Sutton,Sutton,E05013754,E14001153,E09000029,E09000029
+2024,2024,Belmont,Sutton and Cheam,Sutton,Sutton,E05013755,E14001534,E09000029,E09000029
+2024,2024,Carshalton Central,Carshalton and Wallington,Sutton,Sutton,E05013756,E14001153,E09000029,E09000029
+2024,2024,Carshalton South & Clockhouse,Carshalton and Wallington,Sutton,Sutton,E05013757,E14001153,E09000029,E09000029
+2024,2024,Cheam,Sutton and Cheam,Sutton,Sutton,E05013758,E14001534,E09000029,E09000029
+2024,2024,Hackbridge,Carshalton and Wallington,Sutton,Sutton,E05013759,E14001153,E09000029,E09000029
+2024,2024,North Cheam,Sutton and Cheam,Sutton,Sutton,E05013760,E14001534,E09000029,E09000029
+2024,2024,St Helier East,Carshalton and Wallington,Sutton,Sutton,E05013761,E14001153,E09000029,E09000029
+2024,2024,St Helier West,Carshalton and Wallington,Sutton,Sutton,E05013762,E14001153,E09000029,E09000029
+2024,2024,South Beddington & Roundshaw,Carshalton and Wallington,Sutton,Sutton,E05013763,E14001153,E09000029,E09000029
+2024,2024,Stonecot,Sutton and Cheam,Sutton,Sutton,E05013764,E14001534,E09000029,E09000029
+2024,2024,Sutton Central,Sutton and Cheam,Sutton,Sutton,E05013765,E14001534,E09000029,E09000029
+2024,2024,Sutton North,Sutton and Cheam,Sutton,Sutton,E05013766,E14001534,E09000029,E09000029
+2024,2024,Sutton South,Sutton and Cheam,Sutton,Sutton,E05013767,E14001534,E09000029,E09000029
+2024,2024,Sutton West & East Cheam,Sutton and Cheam,Sutton,Sutton,E05013768,E14001534,E09000029,E09000029
+2024,2024,The Wrythe,Carshalton and Wallington,Sutton,Sutton,E05013769,E14001153,E09000029,E09000029
+2024,2024,Wallington North,Carshalton and Wallington,Sutton,Sutton,E05013770,E14001153,E09000029,E09000029
+2024,2024,Wallington South,Carshalton and Wallington,Sutton,Sutton,E05013771,E14001153,E09000029,E09000029
+2024,2024,Worcester Park North,Sutton and Cheam,Sutton,Sutton,E05013772,E14001534,E09000029,E09000029
+2024,2024,Glebe,Belfast North,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000120,N05000002,N09000001,N09000001
+2024,2024,Poplar,Poplar and Limehouse,Tower Hamlets,Tower Hamlets,E05009328,E14001430,E09000030,E09000030
+2024,2024,Royal Albert,West Ham and Beckton,Newham,Newham,E05013922,E14001576,E09000025,E09000025
+2024,2024,Hither Green,Lewisham East,Lewisham,Lewisham,E05013724,E14001331,E09000023,E09000023
+2024,2024,Worcester Park South,Sutton and Cheam,Sutton,Sutton,E05013773,E14001534,E09000029,E09000029
+2024,2024,Bethnal Green East,Bethnal Green and Stepney,Tower Hamlets,Tower Hamlets,E05009317,E14001086,E09000030,E09000030
+2024,2024,Blackwall & Cubitt Town,Poplar and Limehouse,Tower Hamlets,Tower Hamlets,E05009318,E14001430,E09000030,E09000030
+2024,2024,Bow East,Stratford and Bow,Tower Hamlets,Tower Hamlets,E05009319,E14001525,E09000030,E09000030
+2024,2024,Bow West,Stratford and Bow,Tower Hamlets,Tower Hamlets,E05009320,E14001525,E09000030,E09000030
+2024,2024,Bromley North,Stratford and Bow,Tower Hamlets,Tower Hamlets,E05009321,E14001525,E09000030,E09000030
+2024,2024,Bromley South,Poplar and Limehouse,Tower Hamlets,Tower Hamlets,E05009322,E14001430,E09000030,E09000030
+2024,2024,Canary Wharf,Poplar and Limehouse,Tower Hamlets,Tower Hamlets,E05009323,E14001430,E09000030,E09000030
+2024,2024,Island Gardens,Poplar and Limehouse,Tower Hamlets,Tower Hamlets,E05009324,E14001430,E09000030,E09000030
+2024,2024,Lansbury,Poplar and Limehouse,Tower Hamlets,Tower Hamlets,E05009325,E14001430,E09000030,E09000030
+2024,2024,St Dunstan's,Bethnal Green and Stepney,Tower Hamlets,Tower Hamlets,E05009329,E14001086,E09000030,E09000030
+2024,2024,St Katharine's & Wapping,Poplar and Limehouse,Tower Hamlets,Tower Hamlets,E05009330,E14001430,E09000030,E09000030
+2024,2024,Bethnal Green West,Bethnal Green and Stepney,Tower Hamlets,Tower Hamlets,E05009331,E14001086,E09000030,E09000030
+2024,2024,Shadwell,Bethnal Green and Stepney,Tower Hamlets,Tower Hamlets,E05009332,E14001086,E09000030,E09000030
+2024,2024,Spitalfields & Banglatown,Bethnal Green and Stepney,Tower Hamlets,Tower Hamlets,E05009333,E14001086,E09000030,E09000030
+2024,2024,Stepney Green,Bethnal Green and Stepney,Tower Hamlets,Tower Hamlets,E05009334,E14001086,E09000030,E09000030
+2024,2024,Weavers,Bethnal Green and Stepney,Tower Hamlets,Tower Hamlets,E05009335,E14001086,E09000030,E09000030
+2024,2024,Whitechapel,Bethnal Green and Stepney,Tower Hamlets,Tower Hamlets,E05009336,E14001086,E09000030,E09000030
+2024,2024,Cann Hall,Leyton and Wanstead,Waltham Forest,Waltham Forest,E05013882,E14001334,E09000031,E09000031
+2024,2024,Cathall,Leyton and Wanstead,Waltham Forest,Waltham Forest,E05013883,E14001334,E09000031,E09000031
+2024,2024,Chapel End,Walthamstow,Waltham Forest,Waltham Forest,E05013884,E14001563,E09000031,E09000031
+2024,2024,Chingford Green,Chingford and Woodford Green,Waltham Forest,Waltham Forest,E05013885,E14001167,E09000031,E09000031
+2024,2024,Endlebury,Chingford and Woodford Green,Waltham Forest,Waltham Forest,E05013886,E14001167,E09000031,E09000031
+2024,2024,Forest,Leyton and Wanstead,Waltham Forest,Waltham Forest,E05013887,E14001334,E09000031,E09000031
+2024,2024,Grove Green,Leyton and Wanstead,Waltham Forest,Waltham Forest,E05013888,E14001334,E09000031,E09000031
+2024,2024,Hale End & Highams Park South,Chingford and Woodford Green,Waltham Forest,Waltham Forest,E05013889,E14001167,E09000031,E09000031
+2024,2024,Ladywell,Lewisham North,Lewisham,Lewisham,E05013725,E14001332,E09000023,E09000023
+2024,2024,Hale End & Highams Park South,Walthamstow,Waltham Forest,Waltham Forest,E05013889,E14001563,E09000031,E09000031
+2024,2024,Glengormley,Belfast North,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000121,N05000002,N09000001,N09000001
+2024,2024,Lee Green,Lewisham East,Lewisham,Lewisham,E05013726,E14001331,E09000023,E09000023
+2024,2024,Hatch Lane & Highams Park North,Chingford and Woodford Green,Waltham Forest,Waltham Forest,E05013890,E14001167,E09000031,E09000031
+2024,2024,Greystone,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000122,N05000014,N09000001,N09000001
+2024,2024,Gipsy Hill,Dulwich and West Norwood,Lambeth,Lambeth,E05014103,E14001205,E09000022,E09000022
+2024,2024,Royal Victoria,West Ham and Beckton,Newham,Newham,E05013923,E14001576,E09000025,E09000025
+2024,2024,Herne Hill & Loughborough Junction,Dulwich and West Norwood,Lambeth,Lambeth,E05014104,E14001205,E09000022,E09000022
+2024,2024,Stratford,Stratford and Bow,Newham,Newham,E05013924,E14001525,E09000025,E09000025
+2024,2024,Kennington,Vauxhall and Camberwell Green,Lambeth,Lambeth,E05014105,E14001559,E09000022,E09000022
+2024,2024,Stratford Olympic Park,Stratford and Bow,Newham,Newham,E05013925,E14001525,E09000025,E09000025
+2024,2024,Knight's Hill,Dulwich and West Norwood,Lambeth,Lambeth,E05014106,E14001205,E09000022,E09000022
+2024,2024,Wall End,East Ham,Newham,Newham,E05013926,E14001213,E09000025,E09000025
+2024,2024,Myatt's Fields,Vauxhall and Camberwell Green,Lambeth,Lambeth,E05014107,E14001559,E09000022,E09000022
+2024,2024,West Ham,West Ham and Beckton,Newham,Newham,E05013927,E14001576,E09000025,E09000025
+2024,2024,Oval,Vauxhall and Camberwell Green,Lambeth,Lambeth,E05014108,E14001559,E09000022,E09000022
+2024,2024,Aldborough,Ilford North,Redbridge,Redbridge,E05011234,E14001300,E09000026,E09000026
+2024,2024,St Martin's,Clapham and Brixton Hill,Lambeth,Lambeth,E05014109,E14001175,E09000022,E09000022
+2024,2024,Barkingside,Ilford North,Redbridge,Redbridge,E05011235,E14001300,E09000026,E09000026
+2024,2024,St Martin's,Dulwich and West Norwood,Lambeth,Lambeth,E05014109,E14001205,E09000022,E09000022
+2024,2024,Bridge,Chingford and Woodford Green,Redbridge,Redbridge,E05011236,E14001167,E09000026,E09000026
+2024,2024,Lewisham Central,Lewisham North,Lewisham,Lewisham,E05013727,E14001332,E09000023,E09000023
+2024,2024,St Martin's,Streatham and Croydon North,Lambeth,Lambeth,E05014109,E14001527,E09000022,E09000022
+2024,2024,Chadwell,Ilford South,Redbridge,Redbridge,E05011237,E14001301,E09000026,E09000026
+2024,2024,Hightown,Belfast North,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000123,N05000002,N09000001,N09000001
+2024,2024,High Street,Walthamstow,Waltham Forest,Waltham Forest,E05013891,E14001563,E09000031,E09000031
+2024,2024,Churchfields,Chingford and Woodford Green,Redbridge,Redbridge,E05011238,E14001167,E09000026,E09000026
+2024,2024,Higham Hill,Walthamstow,Waltham Forest,Waltham Forest,E05013892,E14001563,E09000031,E09000031
+2024,2024,Hoe Street,Leyton and Wanstead,Waltham Forest,Waltham Forest,E05013893,E14001334,E09000031,E09000031
+2024,2024,Clayhall,Ilford North,Redbridge,Redbridge,E05011239,E14001300,E09000026,E09000026
+2024,2024,Hoe Street,Walthamstow,Waltham Forest,Waltham Forest,E05013893,E14001563,E09000031,E09000031
+2024,2024,Clementswood,Ilford South,Redbridge,Redbridge,E05011240,E14001301,E09000026,E09000026
+2024,2024,Larkswood,Chingford and Woodford Green,Waltham Forest,Waltham Forest,E05013894,E14001167,E09000031,E09000031
+2024,2024,Cranbrook,Ilford North,Redbridge,Redbridge,E05011241,E14001300,E09000026,E09000026
+2024,2024,Larkswood,Walthamstow,Waltham Forest,Waltham Forest,E05013894,E14001563,E09000031,E09000031
+2024,2024,Fairlop,Ilford North,Redbridge,Redbridge,E05011242,E14001300,E09000026,E09000026
+2024,2024,Lea Bridge,Walthamstow,Waltham Forest,Waltham Forest,E05013895,E14001563,E09000031,E09000031
+2024,2024,Fullwell,Ilford North,Redbridge,Redbridge,E05011243,E14001300,E09000026,E09000026
+2024,2024,Leyton,Leyton and Wanstead,Waltham Forest,Waltham Forest,E05013896,E14001334,E09000031,E09000031
+2024,2024,Goodmayes,Ilford South,Redbridge,Redbridge,E05011244,E14001301,E09000026,E09000026
+2024,2024,Leyton,Walthamstow,Waltham Forest,Waltham Forest,E05013896,E14001563,E09000031,E09000031
+2024,2024,Hainault,Ilford North,Redbridge,Redbridge,E05011245,E14001300,E09000026,E09000026
+2024,2024,Leytonstone,Leyton and Wanstead,Waltham Forest,Waltham Forest,E05013897,E14001334,E09000031,E09000031
+2024,2024,Ilford Town,Ilford South,Redbridge,Redbridge,E05011246,E14001301,E09000026,E09000026
+2024,2024,New Cross Gate,Lewisham North,Lewisham,Lewisham,E05013728,E14001332,E09000023,E09000023
+2024,2024,Markhouse,Walthamstow,Waltham Forest,Waltham Forest,E05013898,E14001563,E09000031,E09000031
+2024,2024,Loxford,Ilford South,Redbridge,Redbridge,E05011247,E14001301,E09000026,E09000026
+2024,2024,Stockwell East,Clapham and Brixton Hill,Lambeth,Lambeth,E05014110,E14001175,E09000022,E09000022
+2024,2024,Jordanstown,East Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000124,N05000005,N09000001,N09000001
+2024,2024,Mallusk,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000125,N05000014,N09000001,N09000001
+2024,2024,Monkstown,East Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000126,N05000005,N09000001,N09000001
+2024,2024,Mossley,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000127,N05000014,N09000001,N09000001
+2024,2024,O'Neill,Belfast North,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000128,N05000002,N09000001,N09000001
+2024,2024,Parkgate,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000129,N05000014,N09000001,N09000001
+2024,2024,Randalstown,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000130,N05000014,N09000001,N09000001
+2024,2024,Rathcoole,Belfast North,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000131,N05000002,N09000001,N09000001
+2024,2024,Rostulla,East Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000132,N05000005,N09000001,N09000001
+2024,2024,Shilvodan,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000133,N05000014,N09000001,N09000001
+2024,2024,Springfarm,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000134,N05000014,N09000001,N09000001
+2024,2024,Steeple,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000135,N05000014,N09000001,N09000001
+2024,2024,Stiles,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000136,N05000014,N09000001,N09000001
+2024,2024,Templepatrick,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000137,N05000014,N09000001,N09000001
+2024,2024,Toome,South Antrim,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000138,N05000014,N09000001,N09000001
+2024,2024,Valley,Belfast North,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000139,N05000002,N09000001,N09000001
+2024,2024,Whitehouse,Belfast North,Antrim and Newtownabbey,Antrim and Newtownabbey,N08000140,N05000002,N09000001,N09000001
+2024,2024,Aghagallon,Lagan Valley,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000201,N05000009,N09000002,N09000002
+2024,2024,Ballybay,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000202,N05000017,N09000002,N09000002
+2024,2024,Banbridge East,South Down,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000203,N05000015,N09000002,N09000002
+2024,2024,Banbridge East,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000203,N05000017,N09000002,N09000002
+2024,2024,Banbridge North,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000204,N05000017,N09000002,N09000002
+2024,2024,Banbridge South,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000205,N05000017,N09000002,N09000002
+2024,2024,Mayfield,Ilford South,Redbridge,Redbridge,E05011248,E14001301,E09000026,E09000026
+2024,2024,Banbridge West,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000206,N05000017,N09000002,N09000002
+2024,2024,Monkhams,Chingford and Woodford Green,Redbridge,Redbridge,E05011249,E14001167,E09000026,E09000026
+2024,2024,Blackwatertown,Fermanagh and South Tyrone,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000207,N05000007,N09000002,N09000002
+2024,2024,Stockwell East,Vauxhall and Camberwell Green,Lambeth,Lambeth,E05014110,E14001559,E09000022,E09000022
+2024,2024,Newbury,Ilford South,Redbridge,Redbridge,E05011250,E14001301,E09000026,E09000026
+2024,2024,Seven Kings,Ilford South,Redbridge,Redbridge,E05011251,E14001301,E09000026,E09000026
+2024,2024,Stockwell West & Larkhall,Clapham and Brixton Hill,Lambeth,Lambeth,E05014111,E14001175,E09000022,E09000022
+2024,2024,South Woodford,Leyton and Wanstead,Redbridge,Redbridge,E05011252,E14001334,E09000026,E09000026
+2024,2024,Perry Vale,Lewisham West and East Dulwich,Lewisham,Lewisham,E05013729,E14001333,E09000023,E09000023
+2024,2024,Valentines,Ilford North,Redbridge,Redbridge,E05011253,E14001300,E09000026,E09000026
+2024,2024,Stockwell West & Larkhall,Vauxhall and Camberwell Green,Lambeth,Lambeth,E05014111,E14001559,E09000022,E09000022
+2024,2024,Bleary,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000208,N05000017,N09000002,N09000002
+2024,2024,St James,Walthamstow,Waltham Forest,Waltham Forest,E05013899,E14001563,E09000031,E09000031
+2024,2024,Wanstead Park,Leyton and Wanstead,Redbridge,Redbridge,E05011254,E14001334,E09000026,E09000026
+2024,2024,Upper Walthamstow,Chingford and Woodford Green,Waltham Forest,Waltham Forest,E05013900,E14001167,E09000031,E09000031
+2024,2024,Upper Walthamstow,Walthamstow,Waltham Forest,Waltham Forest,E05013900,E14001563,E09000031,E09000031
+2024,2024,Wanstead Village,Leyton and Wanstead,Redbridge,Redbridge,E05011255,E14001334,E09000026,E09000026
+2024,2024,Rushey Green,Lewisham East,Lewisham,Lewisham,E05013730,E14001331,E09000023,E09000023
+2024,2024,Valley,Chingford and Woodford Green,Waltham Forest,Waltham Forest,E05013901,E14001167,E09000031,E09000031
+2024,2024,Brownlow,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000209,N05000017,N09000002,N09000002
+2024,2024,Barnes,Richmond Park,Richmond upon Thames,Richmond upon Thames,E05013774,E14001445,E09000027,E09000027
+2024,2024,Streatham Common & Vale,Streatham and Croydon North,Lambeth,Lambeth,E05014112,E14001527,E09000022,E09000022
+2024,2024,Sydenham,Lewisham West and East Dulwich,Lewisham,Lewisham,E05013731,E14001333,E09000023,E09000023
+2024,2024,William Morris,Walthamstow,Waltham Forest,Waltham Forest,E05013902,E14001563,E09000031,E09000031
+2024,2024,Wood Street,Walthamstow,Waltham Forest,Waltham Forest,E05013903,E14001563,E09000031,E09000031
+2024,2024,Balham,Battersea,Wandsworth,Wandsworth,E05014009,E14001081,E09000032,E09000032
+2024,2024,Balham,Tooting,Wandsworth,Wandsworth,E05014009,E14001550,E09000032,E09000032
+2024,2024,Battersea Park,Battersea,Wandsworth,Wandsworth,E05014010,E14001081,E09000032,E09000032
+2024,2024,Telegraph Hill,Lewisham North,Lewisham,Lewisham,E05013732,E14001332,E09000023,E09000023
+2024,2024,East Sheen,Richmond Park,Richmond upon Thames,Richmond upon Thames,E05013775,E14001445,E09000027,E09000027
+2024,2024,East Putney,Putney,Wandsworth,Wandsworth,E05014011,E14001434,E09000032,E09000032
+2024,2024,Abbey,Wimbledon,Merton,Merton,E05013810,E14001586,E09000024,E09000024
+2024,2024,Streatham Hill East,Streatham and Croydon North,Lambeth,Lambeth,E05014113,E14001527,E09000022,E09000022
+2024,2024,Cathedral,Newry and Armagh,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000210,N05000011,N09000002,N09000002
+2024,2024,Cannon Hill,Mitcham and Morden,Merton,Merton,E05013811,E14001371,E09000024,E09000024
+2024,2024,Corcrain,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000211,N05000017,N09000002,N09000002
+2024,2024,Colliers Wood,Mitcham and Morden,Merton,Merton,E05013812,E14001371,E09000024,E09000024
+2024,2024,Craigavon Centre,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000212,N05000017,N09000002,N09000002
+2024,2024,Cricket Green,Mitcham and Morden,Merton,Merton,E05013813,E14001371,E09000024,E09000024
+2024,2024,Demesne,Newry and Armagh,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000213,N05000011,N09000002,N09000002
+2024,2024,Figge's Marsh,Mitcham and Morden,Merton,Merton,E05013814,E14001371,E09000024,E09000024
+2024,2024,Derrytrasna,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000214,N05000017,N09000002,N09000002
+2024,2024,Graveney,Mitcham and Morden,Merton,Merton,E05013815,E14001371,E09000024,E09000024
+2024,2024,Donaghcloney,Lagan Valley,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000215,N05000009,N09000002,N09000002
+2024,2024,Hillside,Wimbledon,Merton,Merton,E05013816,E14001586,E09000024,E09000024
+2024,2024,Donaghcloney,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000215,N05000017,N09000002,N09000002
+2024,2024,Lavender Fields,Mitcham and Morden,Merton,Merton,E05013817,E14001371,E09000024,E09000024
+2024,2024,Fulwell & Hampton Hill,Twickenham,Richmond upon Thames,Richmond upon Thames,E05013776,E14001556,E09000027,E09000027
+2024,2024,Dromore,Lagan Valley,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000216,N05000009,N09000002,N09000002
+2024,2024,Streatham Hill West & Thornton,Clapham and Brixton Hill,Lambeth,Lambeth,E05014114,E14001175,E09000022,E09000022
+2024,2024,Falconbrook,Battersea,Wandsworth,Wandsworth,E05014012,E14001081,E09000032,E09000032
+2024,2024,Longthornton,Mitcham and Morden,Merton,Merton,E05013818,E14001371,E09000024,E09000024
+2024,2024,"Ham, Petersham & Richmond Riverside",Richmond Park,Richmond upon Thames,Richmond upon Thames,E05013777,E14001445,E09000027,E09000027
+2024,2024,Gilford,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000217,N05000017,N09000002,N09000002
+2024,2024,Streatham Hill West & Thornton,Streatham and Croydon North,Lambeth,Lambeth,E05014114,E14001527,E09000022,E09000022
+2024,2024,Furzedown,Tooting,Wandsworth,Wandsworth,E05014013,E14001550,E09000032,E09000032
+2024,2024,Lower Morden,Mitcham and Morden,Merton,Merton,E05013819,E14001371,E09000024,E09000024
+2024,2024,Hampton,Twickenham,Richmond upon Thames,Richmond upon Thames,E05013778,E14001556,E09000027,E09000027
+2024,2024,Lavender,Battersea,Wandsworth,Wandsworth,E05014014,E14001081,E09000032,E09000032
+2024,2024,Merton Park,Wimbledon,Merton,Merton,E05013820,E14001586,E09000024,E09000024
+2024,2024,Streatham St Leonard's,Streatham and Croydon North,Lambeth,Lambeth,E05014115,E14001527,E09000022,E09000022
+2024,2024,Gransha,Lagan Valley,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000218,N05000009,N09000002,N09000002
+2024,2024,Pollards Hill,Mitcham and Morden,Merton,Merton,E05013821,E14001371,E09000024,E09000024
+2024,2024,Gransha,South Down,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000218,N05000015,N09000002,N09000002
+2024,2024,Ravensbury,Mitcham and Morden,Merton,Merton,E05013822,E14001371,E09000024,E09000024
+2024,2024,Hamiltonsbawn,Newry and Armagh,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000219,N05000011,N09000002,N09000002
+2024,2024,Streatham Wells,Streatham and Croydon North,Lambeth,Lambeth,E05014116,E14001527,E09000022,E09000022
+2024,2024,Nine Elms,Battersea,Wandsworth,Wandsworth,E05014015,E14001081,E09000032,E09000032
+2024,2024,Raynes Park,Wimbledon,Merton,Merton,E05013823,E14001586,E09000024,E09000024
+2024,2024,Hampton North,Twickenham,Richmond upon Thames,Richmond upon Thames,E05013779,E14001556,E09000027,E09000027
+2024,2024,Keady,Newry and Armagh,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000220,N05000011,N09000002,N09000002
+2024,2024,Vauxhall,Vauxhall and Camberwell Green,Lambeth,Lambeth,E05014117,E14001559,E09000022,E09000022
+2024,2024,Northcote,Battersea,Wandsworth,Wandsworth,E05014016,E14001081,E09000032,E09000032
+2024,2024,St Helier,Mitcham and Morden,Merton,Merton,E05013824,E14001371,E09000024,E09000024
+2024,2024,Hampton Wick & South Teddington,Twickenham,Richmond upon Thames,Richmond upon Thames,E05013780,E14001556,E09000027,E09000027
+2024,2024,Kernan,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000221,N05000017,N09000002,N09000002
+2024,2024,Waterloo & South Bank,Vauxhall and Camberwell Green,Lambeth,Lambeth,E05014118,E14001559,E09000022,E09000022
+2024,2024,Roehampton,Putney,Wandsworth,Wandsworth,E05014017,E14001434,E09000032,E09000032
+2024,2024,Village,Wimbledon,Merton,Merton,E05013825,E14001586,E09000024,E09000024
+2024,2024,Heathfield,Twickenham,Richmond upon Thames,Richmond upon Thames,E05013781,E14001556,E09000027,E09000027
+2024,2024,Killycomain,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000222,N05000017,N09000002,N09000002
+2024,2024,West Dulwich,Clapham and Brixton Hill,Lambeth,Lambeth,E05014119,E14001175,E09000022,E09000022
+2024,2024,St Mary's,Battersea,Wandsworth,Wandsworth,E05014018,E14001081,E09000032,E09000032
+2024,2024,Wandle,Wimbledon,Merton,Merton,E05013826,E14001586,E09000024,E09000024
+2024,2024,Kew,Richmond Park,Richmond upon Thames,Richmond upon Thames,E05013782,E14001445,E09000027,E09000027
+2024,2024,Knocknashane,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000223,N05000017,N09000002,N09000002
+2024,2024,West Dulwich,Dulwich and West Norwood,Lambeth,Lambeth,E05014119,E14001205,E09000022,E09000022
+2024,2024,St Mary's,Putney,Wandsworth,Wandsworth,E05014018,E14001434,E09000032,E09000032
+2024,2024,West Barnes,Wimbledon,Merton,Merton,E05013827,E14001586,E09000024,E09000024
+2024,2024,Wimbledon Park,Wimbledon,Merton,Merton,E05013828,E14001586,E09000024,E09000024
+2024,2024,Wimbledon Town & Dundonald,Wimbledon,Merton,Merton,E05013829,E14001586,E09000024,E09000024
+2024,2024,Beckton,West Ham and Beckton,Newham,Newham,E05013904,E14001576,E09000025,E09000025
+2024,2024,Boleyn,East Ham,Newham,Newham,E05013905,E14001213,E09000025,E09000025
+2024,2024,Canning Town North,West Ham and Beckton,Newham,Newham,E05013906,E14001576,E09000025,E09000025
+2024,2024,Canning Town South,West Ham and Beckton,Newham,Newham,E05013907,E14001576,E09000025,E09000025
+2024,2024,Custom House,West Ham and Beckton,Newham,Newham,E05013908,E14001576,E09000025,E09000025
+2024,2024,East Ham,East Ham,Newham,Newham,E05013909,E14001213,E09000025,E09000025
+2024,2024,East Ham South,East Ham,Newham,Newham,E05013910,E14001213,E09000025,E09000025
+2024,2024,Forest Gate North,Stratford and Bow,Newham,Newham,E05013911,E14001525,E09000025,E09000025
+2024,2024,Forest Gate South,East Ham,Newham,Newham,E05013912,E14001213,E09000025,E09000025
+2024,2024,Forest Gate South,Stratford and Bow,Newham,Newham,E05013912,E14001525,E09000025,E09000025
+2024,2024,Green Street East,East Ham,Newham,Newham,E05013913,E14001213,E09000025,E09000025
+2024,2024,Green Street West,Stratford and Bow,Newham,Newham,E05013914,E14001525,E09000025,E09000025
+2024,2024,Green Street West,West Ham and Beckton,Newham,Newham,E05013914,E14001576,E09000025,E09000025
+2024,2024,Little Ilford,East Ham,Newham,Newham,E05013915,E14001213,E09000025,E09000025
+2024,2024,Manor Park,East Ham,Newham,Newham,E05013916,E14001213,E09000025,E09000025
+2024,2024,Maryland,Stratford and Bow,Newham,Newham,E05013917,E14001525,E09000025,E09000025
+2024,2024,Plaistow North,East Ham,Newham,Newham,E05013918,E14001213,E09000025,E09000025
+2024,2024,Plaistow North,West Ham and Beckton,Newham,Newham,E05013918,E14001576,E09000025,E09000025
+2024,2024,Plaistow South,West Ham and Beckton,Newham,Newham,E05013919,E14001576,E09000025,E09000025
+2024,2024,Bellingham,Lewisham East,Lewisham,Lewisham,E05013714,E14001331,E09000023,E09000023
+2024,2024,Lough Road,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000224,N05000017,N09000002,N09000002
+2024,2024,Mortlake & Barnes Common,Richmond Park,Richmond upon Thames,Richmond upon Thames,E05013783,E14001445,E09000027,E09000027
+2024,2024,North Richmond,Richmond Park,Richmond upon Thames,Richmond upon Thames,E05013784,E14001445,E09000027,E09000027
+2024,2024,St Margarets & North Twickenham,Twickenham,Richmond upon Thames,Richmond upon Thames,E05013785,E14001556,E09000027,E09000027
+2024,2024,South Richmond,Richmond Park,Richmond upon Thames,Richmond upon Thames,E05013786,E14001445,E09000027,E09000027
+2024,2024,South Twickenham,Twickenham,Richmond upon Thames,Richmond upon Thames,E05013787,E14001556,E09000027,E09000027
+2024,2024,Teddington,Twickenham,Richmond upon Thames,Richmond upon Thames,E05013788,E14001556,E09000027,E09000027
+2024,2024,Twickenham Riverside,Twickenham,Richmond upon Thames,Richmond upon Thames,E05013789,E14001556,E09000027,E09000027
+2024,2024,West Twickenham,Twickenham,Richmond upon Thames,Richmond upon Thames,E05013790,E14001556,E09000027,E09000027
+2024,2024,Blackheath,Lewisham North,Lewisham,Lewisham,E05013715,E14001332,E09000023,E09000023
+2024,2024,Whitton,Brentford and Isleworth,Richmond upon Thames,Richmond upon Thames,E05013791,E14001124,E09000027,E09000027
+2024,2024,Borough & Bankside,Bermondsey and Old Southwark,Southwark,Southwark,E05011095,E14001085,E09000028,E09000028
+2024,2024,Camberwell Green,Vauxhall and Camberwell Green,Southwark,Southwark,E05011096,E14001559,E09000028,E09000028
+2024,2024,Brockley,Lewisham North,Lewisham,Lewisham,E05013716,E14001332,E09000023,E09000023
+2024,2024,Catford South,Lewisham East,Lewisham,Lewisham,E05013717,E14001331,E09000023,E09000023
+2024,2024,Crofton Park,Lewisham West and East Dulwich,Lewisham,Lewisham,E05013718,E14001333,E09000023,E09000023
+2024,2024,Deptford,Lewisham North,Lewisham,Lewisham,E05013719,E14001332,E09000023,E09000023
+2024,2024,Downham,Lewisham East,Lewisham,Lewisham,E05013720,E14001331,E09000023,E09000023
+2024,2024,Evelyn,Lewisham North,Lewisham,Lewisham,E05013721,E14001332,E09000023,E09000023
+2024,2024,Loughbrickland,South Down,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000225,N05000015,N09000002,N09000002
+2024,2024,Loughgall,Mid Ulster,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000226,N05000010,N09000002,N09000002
+2024,2024,Loughgall,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000226,N05000017,N09000002,N09000002
+2024,2024,Ballyhanwood,Belfast East,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000702,N05000001,N09000007,N09000007
+2024,2024,Magheralin,Lagan Valley,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000227,N05000009,N09000002,N09000002
+2024,2024,Mahon,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000228,N05000017,N09000002,N09000002
+2024,2024,Markethill,Newry and Armagh,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000229,N05000011,N09000002,N09000002
+2024,2024,Ballymacash,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000703,N05000009,N09000007,N09000007
+2024,2024,Ballymacbrennan,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000704,N05000009,N09000007,N09000007
+2024,2024,Ballymacoss,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000705,N05000009,N09000007,N09000007
+2024,2024,Beechill,Belfast South and Mid Down,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000706,N05000003,N09000007,N09000007
+2024,2024,Blaris,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000707,N05000009,N09000007,N09000007
+2024,2024,Cairnshill,Belfast South and Mid Down,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000708,N05000003,N09000007,N09000007
+2024,2024,Carrowreagh,Belfast East,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000709,N05000001,N09000007,N09000007
+2024,2024,Carryduff East,Belfast South and Mid Down,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000710,N05000003,N09000007,N09000007
+2024,2024,Carryduff West,Belfast South and Mid Down,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000711,N05000003,N09000007,N09000007
+2024,2024,Derryaghy,Belfast West,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000712,N05000004,N09000007,N09000007
+2024,2024,Dromara,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000713,N05000009,N09000007,N09000007
+2024,2024,Drumbo,Belfast South and Mid Down,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000714,N05000003,N09000007,N09000007
+2024,2024,Dundonald,Belfast East,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000715,N05000001,N09000007,N09000007
+2024,2024,Enler,Belfast East,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000716,N05000001,N09000007,N09000007
+2024,2024,Galwally,Belfast South and Mid Down,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000717,N05000003,N09000007,N09000007
+2024,2024,Mourneview,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000230,N05000017,N09000002,N09000002
+2024,2024,Navan,Newry and Armagh,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000231,N05000011,N09000002,N09000002
+2024,2024,Parklake,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000232,N05000017,N09000002,N09000002
+2024,2024,Quilly,Lagan Valley,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000233,N05000009,N09000002,N09000002
+2024,2024,Rathfriland,South Down,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000234,N05000015,N09000002,N09000002
+2024,2024,Richhill,Newry and Armagh,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000235,N05000011,N09000002,N09000002
+2024,2024,Seagahan,Newry and Armagh,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000236,N05000011,N09000002,N09000002
+2024,2024,Shankill,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000237,N05000017,N09000002,N09000002
+2024,2024,Tandragee,Newry and Armagh,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000238,N05000011,N09000002,N09000002
+2024,2024,The Birches,Mid Ulster,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000239,N05000010,N09000002,N09000002
+2024,2024,The Birches,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000239,N05000017,N09000002,N09000002
+2024,2024,The Mall,Newry and Armagh,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000240,N05000011,N09000002,N09000002
+2024,2024,Waringstown,Upper Bann,"Armagh City, Banbridge and Craigavon","Armagh City, Banbridge and Craigavon",N08000241,N05000017,N09000002,N09000002
+2024,2024,Andersonstown,Belfast West,Belfast,Belfast,N08000301,N05000004,N09000003,N09000003
+2024,2024,Ardoyne,Belfast North,Belfast,Belfast,N08000302,N05000002,N09000003,N09000003
+2024,2024,Ballygomartin,Belfast West,Belfast,Belfast,N08000303,N05000004,N09000003,N09000003
+2024,2024,Ballymacarrett,Belfast East,Belfast,Belfast,N08000304,N05000001,N09000003,N09000003
+2024,2024,Ballymurphy,Belfast West,Belfast,Belfast,N08000305,N05000004,N09000003,N09000003
+2024,2024,Ballysillan,Belfast North,Belfast,Belfast,N08000306,N05000002,N09000003,N09000003
+2024,2024,Beechmount,Belfast West,Belfast,Belfast,N08000307,N05000004,N09000003,N09000003
+2024,2024,Beersbridge,Belfast East,Belfast,Belfast,N08000308,N05000001,N09000003,N09000003
+2024,2024,Bellevue,Belfast North,Belfast,Belfast,N08000309,N05000002,N09000003,N09000003
+2024,2024,Belmont,Belfast East,Belfast,Belfast,N08000310,N05000001,N09000003,N09000003
+2024,2024,Belvoir,Belfast South and Mid Down,Belfast,Belfast,N08000311,N05000003,N09000003,N09000003
+2024,2024,Blackstaff,Belfast South and Mid Down,Belfast,Belfast,N08000312,N05000003,N09000003,N09000003
+2024,2024,Bloomfield,Belfast East,Belfast,Belfast,N08000313,N05000001,N09000003,N09000003
+2024,2024,Cavehill,Belfast North,Belfast,Belfast,N08000314,N05000002,N09000003,N09000003
+2024,2024,Central,Belfast South and Mid Down,Belfast,Belfast,N08000315,N05000003,N09000003,N09000003
+2024,2024,Chichester Park,Belfast North,Belfast,Belfast,N08000316,N05000002,N09000003,N09000003
+2024,2024,Cliftonville,Belfast North,Belfast,Belfast,N08000317,N05000002,N09000003,N09000003
+2024,2024,Clonard,Belfast West,Belfast,Belfast,N08000318,N05000004,N09000003,N09000003
+2024,2024,Collin Glen,Belfast West,Belfast,Belfast,N08000319,N05000004,N09000003,N09000003
+2024,2024,Connswater,Belfast East,Belfast,Belfast,N08000320,N05000001,N09000003,N09000003
+2024,2024,Cregagh,Belfast East,Belfast,Belfast,N08000321,N05000001,N09000003,N09000003
+2024,2024,Greystone,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000422,N05000006,N09000004,N09000004
+2024,2024,Glebe,Mid Ulster,Mid Ulster,Mid Ulster,N08000921,N05000010,N09000009,N09000009
+2024,2024,Mayobridge,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001030,N05000015,N09000010,N09000010
+2024,2024,Duncairn,Belfast North,Belfast,Belfast,N08000322,N05000002,N09000003,N09000003
+2024,2024,Shantallow East,Foyle,Derry City and Strabane,Derry City and Strabane,N08000532,N05000008,N09000005,N09000005
+2024,2024,Dunmurry,Belfast West,Belfast,Belfast,N08000323,N05000004,N09000003,N09000003
+2024,2024,Falls,Belfast West,Belfast,Belfast,N08000324,N05000004,N09000003,N09000003
+2024,2024,Sheriff's Mountain,Foyle,Derry City and Strabane,Derry City and Strabane,N08000533,N05000008,N09000005,N09000005
+2024,2024,Falls Park,Belfast West,Belfast,Belfast,N08000325,N05000004,N09000003,N09000003
+2024,2024,Sion Mills,West Tyrone,Derry City and Strabane,Derry City and Strabane,N08000534,N05000018,N09000005,N09000005
+2024,2024,Finaghy,Belfast South and Mid Down,Belfast,Belfast,N08000326,N05000003,N09000003,N09000003
+2024,2024,Skeoge,Foyle,Derry City and Strabane,Derry City and Strabane,N08000535,N05000008,N09000005,N09000005
+2024,2024,Forth River,Belfast North,Belfast,Belfast,N08000327,N05000002,N09000003,N09000003
+2024,2024,Slievekirk,West Tyrone,Derry City and Strabane,Derry City and Strabane,N08000536,N05000018,N09000005,N09000005
+2024,2024,Fortwilliam,Belfast North,Belfast,Belfast,N08000328,N05000002,N09000003,N09000003
+2024,2024,Springtown,Foyle,Derry City and Strabane,Derry City and Strabane,N08000537,N05000008,N09000005,N09000005
+2024,2024,Garnerville,North Down,Belfast,Belfast,N08000329,N05000013,N09000003,N09000003
+2024,2024,Strabane North,West Tyrone,Derry City and Strabane,Derry City and Strabane,N08000538,N05000018,N09000005,N09000005
+2024,2024,Gilnahirk,Belfast East,Belfast,Belfast,N08000330,N05000001,N09000003,N09000003
+2024,2024,Strabane West,West Tyrone,Derry City and Strabane,Derry City and Strabane,N08000539,N05000018,N09000005,N09000005
+2024,2024,Hillfoot,Belfast East,Belfast,Belfast,N08000331,N05000001,N09000003,N09000003
+2024,2024,Victoria,Foyle,Derry City and Strabane,Derry City and Strabane,N08000540,N05000008,N09000005,N09000005
+2024,2024,Mullaghbane,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001031,N05000011,N09000010,N09000010
+2024,2024,Killyman,Mid Ulster,Mid Ulster,Mid Ulster,N08000922,N05000010,N09000009,N09000009
+2024,2024,Innisfayle,Belfast North,Belfast,Belfast,N08000332,N05000002,N09000003,N09000003
+2024,2024,Ballinamallard,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000601,N05000007,N09000006,N09000006
+2024,2024,Hopefield,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000423,N05000006,N09000004,N09000004
+2024,2024,Carnlough and Glenarm,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000812,N05000005,N09000008,N09000008
+2024,2024,Murlough,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001032,N05000015,N09000010,N09000010
+2024,2024,Killymeal,Fermanagh and South Tyrone,Mid Ulster,Mid Ulster,N08000923,N05000007,N09000009,N09000009
+2024,2024,Glenavy,South Antrim,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000718,N05000014,N09000007,N09000007
+2024,2024,Graham's Bridge,Belfast East,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000719,N05000001,N09000007,N09000007
+2024,2024,Knock,Belfast East,Belfast,Belfast,N08000333,N05000001,N09000003,N09000003
+2024,2024,Harmony Hill,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000720,N05000009,N09000007,N09000007
+2024,2024,Ladybrook,Belfast West,Belfast,Belfast,N08000334,N05000004,N09000003,N09000003
+2024,2024,Hilden,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000721,N05000009,N09000007,N09000007
+2024,2024,Lagmore,Belfast West,Belfast,Belfast,N08000335,N05000004,N09000003,N09000003
+2024,2024,Hillhall,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000722,N05000009,N09000007,N09000007
+2024,2024,Legoniel,Belfast North,Belfast,Belfast,N08000336,N05000002,N09000003,N09000003
+2024,2024,Hillsborough,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000723,N05000009,N09000007,N09000007
+2024,2024,Malone,Belfast South and Mid Down,Belfast,Belfast,N08000337,N05000003,N09000003,N09000003
+2024,2024,Knockbracken,Belfast South and Mid Down,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000724,N05000003,N09000007,N09000007
+2024,2024,Merok,Belfast East,Belfast,Belfast,N08000338,N05000001,N09000003,N09000003
+2024,2024,Kilrea,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000424,N05000006,N09000004,N09000004
+2024,2024,Castle,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000813,N05000005,N09000008,N09000008
+2024,2024,Knockmore,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000725,N05000009,N09000007,N09000007
+2024,2024,Kinbane,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000425,N05000012,N09000004,N09000004
+2024,2024,Musgrave,Belfast South and Mid Down,Belfast,Belfast,N08000339,N05000003,N09000003,N09000003
+2024,2024,Belcoo and Garrison,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000602,N05000007,N09000006,N09000006
+2024,2024,Newtownhamilton,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001033,N05000011,N09000010,N09000010
+2024,2024,Lissan,Mid Ulster,Mid Ulster,Mid Ulster,N08000924,N05000010,N09000009,N09000009
+2024,2024,Loughry,Mid Ulster,Mid Ulster,Mid Ulster,N08000925,N05000010,N09000009,N09000009
+2024,2024,Lower Glenshane,Mid Ulster,Mid Ulster,Mid Ulster,N08000926,N05000010,N09000009,N09000009
+2024,2024,Maghera,Mid Ulster,Mid Ulster,Mid Ulster,N08000927,N05000010,N09000009,N09000009
+2024,2024,Moy,Fermanagh and South Tyrone,Mid Ulster,Mid Ulster,N08000928,N05000007,N09000009,N09000009
+2024,2024,Moygashel,Fermanagh and South Tyrone,Mid Ulster,Mid Ulster,N08000929,N05000007,N09000009,N09000009
+2024,2024,Mullaghmore,Fermanagh and South Tyrone,Mid Ulster,Mid Ulster,N08000930,N05000007,N09000009,N09000009
+2024,2024,Oaklands,Mid Ulster,Mid Ulster,Mid Ulster,N08000931,N05000010,N09000009,N09000009
+2024,2024,Pomeroy,West Tyrone,Mid Ulster,Mid Ulster,N08000932,N05000018,N09000009,N09000009
+2024,2024,Stewartstown,Mid Ulster,Mid Ulster,Mid Ulster,N08000933,N05000010,N09000009,N09000009
+2024,2024,Swatragh,Mid Ulster,Mid Ulster,Mid Ulster,N08000934,N05000010,N09000009,N09000009
+2024,2024,Tamlaght O'Crilly,Mid Ulster,Mid Ulster,Mid Ulster,N08000935,N05000010,N09000009,N09000009
+2024,2024,The Loup,Mid Ulster,Mid Ulster,Mid Ulster,N08000936,N05000010,N09000009,N09000009
+2024,2024,Tobermore,Mid Ulster,Mid Ulster,Mid Ulster,N08000937,N05000010,N09000009,N09000009
+2024,2024,Town Parks East,Mid Ulster,Mid Ulster,Mid Ulster,N08000938,N05000010,N09000009,N09000009
+2024,2024,Valley,Mid Ulster,Mid Ulster,Mid Ulster,N08000939,N05000010,N09000009,N09000009
+2024,2024,Washing Bay,Mid Ulster,Mid Ulster,Mid Ulster,N08000940,N05000010,N09000009,N09000009
+2024,2024,New Lodge,Belfast North,Belfast,Belfast,N08000340,N05000002,N09000003,N09000003
+2024,2024,Loughguile and Stranocum,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000426,N05000012,N09000004,N09000004
+2024,2024,Abbey,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001001,N05000011,N09000010,N09000010
+2024,2024,Quoile,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001034,N05000015,N09000010,N09000010
+2024,2024,Orangefield,Belfast East,Belfast,Belfast,N08000341,N05000001,N09000003,N09000003
+2024,2024,Belleek and Boa,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000603,N05000007,N09000006,N09000006
+2024,2024,Lurigethan,East Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000427,N05000005,N09000004,N09000004
+2024,2024,Castle Demesne,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000814,N05000012,N09000008,N09000008
+2024,2024,Annalong,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001002,N05000015,N09000010,N09000010
+2024,2024,Quoile,Strangford,"Newry, Mourne and Down","Newry, Mourne and Down",N08001034,N05000016,N09000010,N09000010
+2024,2024,Lagan,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000726,N05000009,N09000007,N09000007
+2024,2024,Ormeau,Belfast South and Mid Down,Belfast,Belfast,N08000342,N05000003,N09000003,N09000003
+2024,2024,Beragh,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000604,N05000018,N09000006,N09000006
+2024,2024,Macosquin,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000428,N05000006,N09000004,N09000004
+2024,2024,Craigyhill,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000815,N05000005,N09000008,N09000008
+2024,2024,Cullybackey,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000816,N05000012,N09000008,N09000008
+2024,2024,Curran and Inver,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000817,N05000005,N09000008,N09000008
+2024,2024,Fair Green,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000818,N05000012,N09000008,N09000008
+2024,2024,Galgorm,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000819,N05000012,N09000008,N09000008
+2024,2024,Gardenmore,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000820,N05000005,N09000008,N09000008
+2024,2024,Glenravel,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000821,N05000005,N09000008,N09000008
+2024,2024,Glenwhirry,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000822,N05000005,N09000008,N09000008
+2024,2024,Gortalee,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000823,N05000005,N09000008,N09000008
+2024,2024,Grange,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000824,N05000012,N09000008,N09000008
+2024,2024,Greenisland,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000825,N05000005,N09000008,N09000008
+2024,2024,Islandmagee,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000826,N05000005,N09000008,N09000008
+2024,2024,Kells,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000827,N05000012,N09000008,N09000008
+2024,2024,Kilroot,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000828,N05000005,N09000008,N09000008
+2024,2024,Kilwaughter,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000829,N05000005,N09000008,N09000008
+2024,2024,Kirkinriola,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000830,N05000012,N09000008,N09000008
+2024,2024,Love Lane,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000831,N05000005,N09000008,N09000008
+2024,2024,Maine,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000832,N05000012,N09000008,N09000008
+2024,2024,Park,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000833,N05000012,N09000008,N09000008
+2024,2024,Portglenone,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000834,N05000012,N09000008,N09000008
+2024,2024,Slemish,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000835,N05000005,N09000008,N09000008
+2024,2024,Sunnylands,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000836,N05000005,N09000008,N09000008
+2024,2024,The Maidens,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000837,N05000005,N09000008,N09000008
+2024,2024,Victoria,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000838,N05000005,N09000008,N09000008
+2024,2024,Whitehead South,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000839,N05000005,N09000008,N09000008
+2024,2024,Woodburn,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000840,N05000005,N09000008,N09000008
+2024,2024,Ardboe,Mid Ulster,Mid Ulster,Mid Ulster,N08000901,N05000010,N09000009,N09000009
+2024,2024,Augher and Clogher,Fermanagh and South Tyrone,Mid Ulster,Mid Ulster,N08000902,N05000007,N09000009,N09000009
+2024,2024,Aughnacloy,Fermanagh and South Tyrone,Mid Ulster,Mid Ulster,N08000903,N05000007,N09000009,N09000009
+2024,2024,Ballygawley,Fermanagh and South Tyrone,Mid Ulster,Mid Ulster,N08000904,N05000007,N09000009,N09000009
+2024,2024,Ballymaguigan,Mid Ulster,Mid Ulster,Mid Ulster,N08000905,N05000010,N09000009,N09000009
+2024,2024,Ballysaggart,Fermanagh and South Tyrone,Mid Ulster,Mid Ulster,N08000906,N05000007,N09000009,N09000009
+2024,2024,Bellaghy,Mid Ulster,Mid Ulster,Mid Ulster,N08000907,N05000010,N09000009,N09000009
+2024,2024,Caledon,Fermanagh and South Tyrone,Mid Ulster,Mid Ulster,N08000908,N05000007,N09000009,N09000009
+2024,2024,Castlecaulfield,Fermanagh and South Tyrone,Mid Ulster,Mid Ulster,N08000909,N05000007,N09000009,N09000009
+2024,2024,Castlecaulfield,Mid Ulster,Mid Ulster,Mid Ulster,N08000909,N05000010,N09000009,N09000009
+2024,2024,Castledawson,Mid Ulster,Mid Ulster,Mid Ulster,N08000910,N05000010,N09000009,N09000009
+2024,2024,Coagh,Mid Ulster,Mid Ulster,Mid Ulster,N08000911,N05000010,N09000009,N09000009
+2024,2024,Coalisland North,Mid Ulster,Mid Ulster,Mid Ulster,N08000912,N05000010,N09000009,N09000009
+2024,2024,Coalisland South,Mid Ulster,Mid Ulster,Mid Ulster,N08000913,N05000010,N09000009,N09000009
+2024,2024,Cookstown East,Mid Ulster,Mid Ulster,Mid Ulster,N08000914,N05000010,N09000009,N09000009
+2024,2024,Cookstown South,Mid Ulster,Mid Ulster,Mid Ulster,N08000915,N05000010,N09000009,N09000009
+2024,2024,Cookstown West,Mid Ulster,Mid Ulster,Mid Ulster,N08000916,N05000010,N09000009,N09000009
+2024,2024,Coolshinny,Mid Ulster,Mid Ulster,Mid Ulster,N08000917,N05000010,N09000009,N09000009
+2024,2024,Donaghmore,Mid Ulster,Mid Ulster,Mid Ulster,N08000918,N05000010,N09000009,N09000009
+2024,2024,Draperstown,Mid Ulster,Mid Ulster,Mid Ulster,N08000919,N05000010,N09000009,N09000009
+2024,2024,Fivemiletown,Fermanagh and South Tyrone,Mid Ulster,Mid Ulster,N08000920,N05000007,N09000009,N09000009
+2024,2024,Poleglass,Belfast West,Belfast,Belfast,N08000343,N05000004,N09000003,N09000003
+2024,2024,Ravenhill,Belfast South and Mid Down,Belfast,Belfast,N08000344,N05000003,N09000003,N09000003
+2024,2024,Rosetta,Belfast South and Mid Down,Belfast,Belfast,N08000345,N05000003,N09000003,N09000003
+2024,2024,Sandown,Belfast East,Belfast,Belfast,N08000346,N05000001,N09000003,N09000003
+2024,2024,Shandon,Belfast East,Belfast,Belfast,N08000347,N05000001,N09000003,N09000003
+2024,2024,Shankill,Belfast West,Belfast,Belfast,N08000348,N05000004,N09000003,N09000003
+2024,2024,Shaw's Road,Belfast West,Belfast,Belfast,N08000349,N05000004,N09000003,N09000003
+2024,2024,Stewartstown,Belfast West,Belfast,Belfast,N08000350,N05000004,N09000003,N09000003
+2024,2024,Stormont,Belfast East,Belfast,Belfast,N08000351,N05000001,N09000003,N09000003
+2024,2024,Stranmillis,Belfast South and Mid Down,Belfast,Belfast,N08000352,N05000003,N09000003,N09000003
+2024,2024,Sydenham,Belfast East,Belfast,Belfast,N08000353,N05000001,N09000003,N09000003
+2024,2024,Turf Lodge,Belfast West,Belfast,Belfast,N08000354,N05000004,N09000003,N09000003
+2024,2024,Twinbrook,Belfast West,Belfast,Belfast,N08000355,N05000004,N09000003,N09000003
+2024,2024,Upper Malone,Belfast South and Mid Down,Belfast,Belfast,N08000356,N05000003,N09000003,N09000003
+2024,2024,Water Works,Belfast North,Belfast,Belfast,N08000357,N05000002,N09000003,N09000003
+2024,2024,Windsor,Belfast South and Mid Down,Belfast,Belfast,N08000358,N05000003,N09000003,N09000003
+2024,2024,Woodstock,Belfast East,Belfast,Belfast,N08000359,N05000001,N09000003,N09000003
+2024,2024,Woodvale,Belfast West,Belfast,Belfast,N08000360,N05000004,N09000003,N09000003
+2024,2024,Aghadowey,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000401,N05000006,N09000004,N09000004
+2024,2024,Altahullion,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000402,N05000006,N09000004,N09000004
+2024,2024,Atlantic,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000403,N05000006,N09000004,N09000004
+2024,2024,Ballycastle,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000404,N05000012,N09000004,N09000004
+2024,2024,Ballykelly,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000405,N05000006,N09000004,N09000004
+2024,2024,Ballymoney East,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000406,N05000012,N09000004,N09000004
+2024,2024,Ballymoney North,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000407,N05000012,N09000004,N09000004
+2024,2024,Ballymoney South,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000408,N05000012,N09000004,N09000004
+2024,2024,Castlerock,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000409,N05000006,N09000004,N09000004
+2024,2024,Churchland,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000410,N05000006,N09000004,N09000004
+2024,2024,Clogh Mills,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000411,N05000012,N09000004,N09000004
+2024,2024,Coolessan,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000412,N05000006,N09000004,N09000004
+2024,2024,Dervock,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000413,N05000012,N09000004,N09000004
+2024,2024,Drumsurn,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000414,N05000006,N09000004,N09000004
+2024,2024,Dundooan,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000415,N05000006,N09000004,N09000004
+2024,2024,Dungiven,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000416,N05000006,N09000004,N09000004
+2024,2024,Dunloy,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000417,N05000012,N09000004,N09000004
+2024,2024,Feeny,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000418,N05000006,N09000004,N09000004
+2024,2024,Garvagh,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000419,N05000006,N09000004,N09000004
+2024,2024,Giant's Causeway,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000420,N05000012,N09000004,N09000004
+2024,2024,Greysteel,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000421,N05000006,N09000004,N09000004
+2024,2024,"Boho, Cleenish and Letterbreen",Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000605,N05000007,N09000006,N09000006
+2024,2024,Brookeborough,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000606,N05000007,N09000006,N09000006
+2024,2024,Camowen,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000607,N05000018,N09000006,N09000006
+2024,2024,Castlecoole,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000608,N05000007,N09000006,N09000006
+2024,2024,Coolnagard,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000609,N05000018,N09000006,N09000006
+2024,2024,Dergmoney,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000610,N05000018,N09000006,N09000006
+2024,2024,Derrygonnelly,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000611,N05000007,N09000006,N09000006
+2024,2024,Derrylin,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000612,N05000007,N09000006,N09000006
+2024,2024,Donagh,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000613,N05000007,N09000006,N09000006
+2024,2024,Dromore,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000614,N05000018,N09000006,N09000006
+2024,2024,Drumnakilly,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000615,N05000018,N09000006,N09000006
+2024,2024,Drumquin,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000616,N05000018,N09000006,N09000006
+2024,2024,Ederney and Kesh,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000617,N05000007,N09000006,N09000006
+2024,2024,Erne,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000618,N05000007,N09000006,N09000006
+2024,2024,Fairy Water,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000619,N05000018,N09000006,N09000006
+2024,2024,Fintona,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000620,N05000018,N09000006,N09000006
+2024,2024,Florence Court and Kinawley,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000621,N05000007,N09000006,N09000006
+2024,2024,Gortin,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000622,N05000018,N09000006,N09000006
+2024,2024,Gortrush,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000623,N05000018,N09000006,N09000006
+2024,2024,Irvinestown,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000624,N05000007,N09000006,N09000006
+2024,2024,Killyclogher,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000625,N05000018,N09000006,N09000006
+2024,2024,Lisbellaw,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000626,N05000007,N09000006,N09000006
+2024,2024,Lisnarrick,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000627,N05000007,N09000006,N09000006
+2024,2024,Lisnaskea,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000628,N05000007,N09000006,N09000006
+2024,2024,Maguiresbridge,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000629,N05000007,N09000006,N09000006
+2024,2024,Newtownbutler,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000630,N05000007,N09000006,N09000006
+2024,2024,Newtownsaville,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000631,N05000018,N09000006,N09000006
+2024,2024,Owenkillew,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000632,N05000018,N09000006,N09000006
+2024,2024,Portora,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000633,N05000007,N09000006,N09000006
+2024,2024,Rosslea,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000634,N05000007,N09000006,N09000006
+2024,2024,Rossorry,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000635,N05000007,N09000006,N09000006
+2024,2024,Sixmilecross,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000636,N05000018,N09000006,N09000006
+2024,2024,Strule,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000637,N05000018,N09000006,N09000006
+2024,2024,Tempo,Fermanagh and South Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000638,N05000007,N09000006,N09000006
+2024,2024,Termon,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000639,N05000018,N09000006,N09000006
+2024,2024,Trillick,West Tyrone,Fermanagh and Omagh,Fermanagh and Omagh,N08000640,N05000018,N09000006,N09000006
+2024,2024,Ballinderry,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000701,N05000009,N09000007,N09000007
+2024,2024,Magilligan,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000429,N05000006,N09000004,N09000004
+2024,2024,Lagan Valley,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000727,N05000009,N09000007,N09000007
+2024,2024,Rostrevor,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001035,N05000015,N09000010,N09000010
+2024,2024,Ballybot,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001003,N05000011,N09000010,N09000010
+2024,2024,Ballydugan,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001004,N05000015,N09000010,N09000010
+2024,2024,Ballynahinch,Strangford,"Newry, Mourne and Down","Newry, Mourne and Down",N08001005,N05000016,N09000010,N09000010
+2024,2024,Ballyward,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001006,N05000015,N09000010,N09000010
+2024,2024,Ballyward,Strangford,"Newry, Mourne and Down","Newry, Mourne and Down",N08001006,N05000016,N09000010,N09000010
+2024,2024,Bessbrook,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001007,N05000011,N09000010,N09000010
+2024,2024,Binnian,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001008,N05000015,N09000010,N09000010
+2024,2024,Burren,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001009,N05000015,N09000010,N09000010
+2024,2024,Camlough,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001010,N05000011,N09000010,N09000010
+2024,2024,Castlewellan,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001011,N05000015,N09000010,N09000010
+2024,2024,Cathedral,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001012,N05000015,N09000010,N09000010
+2024,2024,Crossgar and Killyleagh,Strangford,"Newry, Mourne and Down","Newry, Mourne and Down",N08001013,N05000016,N09000010,N09000010
+2024,2024,Crossmaglen,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001014,N05000011,N09000010,N09000010
+2024,2024,Damolly,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001015,N05000011,N09000010,N09000010
+2024,2024,Derryboy,Strangford,"Newry, Mourne and Down","Newry, Mourne and Down",N08001016,N05000016,N09000010,N09000010
+2024,2024,Derryleckagh,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001017,N05000015,N09000010,N09000010
+2024,2024,Donard,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001018,N05000015,N09000010,N09000010
+2024,2024,Drumalane,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001019,N05000011,N09000010,N09000010
+2024,2024,Drumaness,Strangford,"Newry, Mourne and Down","Newry, Mourne and Down",N08001020,N05000016,N09000010,N09000010
+2024,2024,Dundrum,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001021,N05000015,N09000010,N09000010
+2024,2024,Fathom,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001022,N05000011,N09000010,N09000010
+2024,2024,Forkhill,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001023,N05000011,N09000010,N09000010
+2024,2024,Hilltown,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001024,N05000015,N09000010,N09000010
+2024,2024,Kilkeel,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001025,N05000015,N09000010,N09000010
+2024,2024,Kilmore,Strangford,"Newry, Mourne and Down","Newry, Mourne and Down",N08001026,N05000016,N09000010,N09000010
+2024,2024,Knocknashinna,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001027,N05000015,N09000010,N09000010
+2024,2024,Lecale,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001028,N05000015,N09000010,N09000010
+2024,2024,Lisnacree,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001029,N05000015,N09000010,N09000010
+2024,2024,Mountsandel,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000430,N05000006,N09000004,N09000004
+2024,2024,Saintfield,Belfast South and Mid Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001036,N05000003,N09000010,N09000010
+2024,2024,Lambeg,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000728,N05000009,N09000007,N09000007
+2024,2024,Lisnagarvey,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000729,N05000009,N09000007,N09000007
+2024,2024,Maghaberry,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000730,N05000009,N09000007,N09000007
+2024,2024,Magheralave,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000731,N05000009,N09000007,N09000007
+2024,2024,Maze,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000732,N05000009,N09000007,N09000007
+2024,2024,Moira,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000733,N05000009,N09000007,N09000007
+2024,2024,Moneyreagh,Belfast South and Mid Down,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000734,N05000003,N09000007,N09000007
+2024,2024,Newtownbreda,Belfast South and Mid Down,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000735,N05000003,N09000007,N09000007
+2024,2024,Old Warren,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000736,N05000009,N09000007,N09000007
+2024,2024,Ravernet,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000737,N05000009,N09000007,N09000007
+2024,2024,Stonyford,South Antrim,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000738,N05000014,N09000007,N09000007
+2024,2024,Wallace Park,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000739,N05000009,N09000007,N09000007
+2024,2024,White Mountain,Lagan Valley,Lisburn and Castlereagh,Lisburn and Castlereagh,N08000740,N05000009,N09000007,N09000007
+2024,2024,Academy,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000801,N05000012,N09000008,N09000008
+2024,2024,Ahoghill,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000802,N05000012,N09000008,N09000008
+2024,2024,Ardeevin,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000803,N05000012,N09000008,N09000008
+2024,2024,Ballee and Harryville,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000804,N05000012,N09000008,N09000008
+2024,2024,Ballycarry and Glynn,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000805,N05000005,N09000008,N09000008
+2024,2024,Ballykeel,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000806,N05000012,N09000008,N09000008
+2024,2024,Boneybefore,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000807,N05000005,N09000008,N09000008
+2024,2024,Braidwater,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000808,N05000012,N09000008,N09000008
+2024,2024,Broughshane,North Antrim,Mid and East Antrim,Mid and East Antrim,N08000809,N05000012,N09000008,N09000008
+2024,2024,Burleigh Hill,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000810,N05000005,N09000008,N09000008
+2024,2024,Cairncastle,East Antrim,Mid and East Antrim,Mid and East Antrim,N08000811,N05000005,N09000008,N09000008
+2024,2024,Portrush and Dunluce,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000431,N05000006,N09000004,N09000004
+2024,2024,Portstewart,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000432,N05000006,N09000004,N09000004
+2024,2024,Quarry,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000433,N05000006,N09000004,N09000004
+2024,2024,Rasharkin,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000434,N05000012,N09000004,N09000004
+2024,2024,Roeside,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000435,N05000006,N09000004,N09000004
+2024,2024,Route,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000436,N05000012,N09000004,N09000004
+2024,2024,Torr Head and Rathlin,North Antrim,Causeway Coast and Glens,Causeway Coast and Glens,N08000437,N05000012,N09000004,N09000004
+2024,2024,University,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000438,N05000006,N09000004,N09000004
+2024,2024,Waterside,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000439,N05000006,N09000004,N09000004
+2024,2024,Windy Hall,East Londonderry,Causeway Coast and Glens,Causeway Coast and Glens,N08000440,N05000006,N09000004,N09000004
+2024,2024,Artigarvan,West Tyrone,Derry City and Strabane,Derry City and Strabane,N08000501,N05000018,N09000005,N09000005
+2024,2024,Ballycolman,West Tyrone,Derry City and Strabane,Derry City and Strabane,N08000502,N05000018,N09000005,N09000005
+2024,2024,Ballymagroarty,Foyle,Derry City and Strabane,Derry City and Strabane,N08000503,N05000008,N09000005,N09000005
+2024,2024,Brandywell,Foyle,Derry City and Strabane,Derry City and Strabane,N08000504,N05000008,N09000005,N09000005
+2024,2024,Carn Hill,Foyle,Derry City and Strabane,Derry City and Strabane,N08000505,N05000008,N09000005,N09000005
+2024,2024,Castlederg,West Tyrone,Derry City and Strabane,Derry City and Strabane,N08000506,N05000018,N09000005,N09000005
+2024,2024,Caw,Foyle,Derry City and Strabane,Derry City and Strabane,N08000507,N05000008,N09000005,N09000005
+2024,2024,City Walls,Foyle,Derry City and Strabane,Derry City and Strabane,N08000508,N05000008,N09000005,N09000005
+2024,2024,Claudy,East Londonderry,Derry City and Strabane,Derry City and Strabane,N08000509,N05000006,N09000005,N09000005
+2024,2024,Clondermot,Foyle,Derry City and Strabane,Derry City and Strabane,N08000510,N05000008,N09000005,N09000005
+2024,2024,Creggan,Foyle,Derry City and Strabane,Derry City and Strabane,N08000511,N05000008,N09000005,N09000005
+2024,2024,Creggan South,Foyle,Derry City and Strabane,Derry City and Strabane,N08000512,N05000008,N09000005,N09000005
+2024,2024,Culmore,Foyle,Derry City and Strabane,Derry City and Strabane,N08000513,N05000008,N09000005,N09000005
+2024,2024,Drumahoe,Foyle,Derry City and Strabane,Derry City and Strabane,N08000514,N05000008,N09000005,N09000005
+2024,2024,Dunnamanagh,West Tyrone,Derry City and Strabane,Derry City and Strabane,N08000515,N05000018,N09000005,N09000005
+2024,2024,Ebrington,Foyle,Derry City and Strabane,Derry City and Strabane,N08000516,N05000008,N09000005,N09000005
+2024,2024,Eglinton,East Londonderry,Derry City and Strabane,Derry City and Strabane,N08000517,N05000006,N09000005,N09000005
+2024,2024,Enagh,Foyle,Derry City and Strabane,Derry City and Strabane,N08000518,N05000008,N09000005,N09000005
+2024,2024,Finn,West Tyrone,Derry City and Strabane,Derry City and Strabane,N08000519,N05000018,N09000005,N09000005
+2024,2024,Foyle Springs,Foyle,Derry City and Strabane,Derry City and Strabane,N08000520,N05000008,N09000005,N09000005
+2024,2024,Galliagh,Foyle,Derry City and Strabane,Derry City and Strabane,N08000521,N05000008,N09000005,N09000005
+2024,2024,Glenderg,West Tyrone,Derry City and Strabane,Derry City and Strabane,N08000522,N05000018,N09000005,N09000005
+2024,2024,Glenelly Valley,West Tyrone,Derry City and Strabane,Derry City and Strabane,N08000523,N05000018,N09000005,N09000005
+2024,2024,Kilfennan,Foyle,Derry City and Strabane,Derry City and Strabane,N08000524,N05000008,N09000005,N09000005
+2024,2024,Lisnagelvin,Foyle,Derry City and Strabane,Derry City and Strabane,N08000525,N05000008,N09000005,N09000005
+2024,2024,Madam's Bank,Foyle,Derry City and Strabane,Derry City and Strabane,N08000526,N05000008,N09000005,N09000005
+2024,2024,New Buildings,Foyle,Derry City and Strabane,Derry City and Strabane,N08000527,N05000008,N09000005,N09000005
+2024,2024,Newtownstewart,West Tyrone,Derry City and Strabane,Derry City and Strabane,N08000528,N05000018,N09000005,N09000005
+2024,2024,Northland,Foyle,Derry City and Strabane,Derry City and Strabane,N08000529,N05000008,N09000005,N09000005
+2024,2024,Park,East Londonderry,Derry City and Strabane,Derry City and Strabane,N08000530,N05000006,N09000005,N09000005
+2024,2024,Shantallow,Foyle,Derry City and Strabane,Derry City and Strabane,N08000531,N05000008,N09000005,N09000005
+2024,2024,St. Patrick's,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001037,N05000011,N09000010,N09000010
+2024,2024,Strangford,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001038,N05000015,N09000010,N09000010
+2024,2024,Strangford,Strangford,"Newry, Mourne and Down","Newry, Mourne and Down",N08001038,N05000016,N09000010,N09000010
+2024,2024,Tollymore,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001039,N05000015,N09000010,N09000010
+2024,2024,Warrenpoint,South Down,"Newry, Mourne and Down","Newry, Mourne and Down",N08001040,N05000015,N09000010,N09000010
+2024,2024,Whitecross,Newry and Armagh,"Newry, Mourne and Down","Newry, Mourne and Down",N08001041,N05000011,N09000010,N09000010
+2024,2024,Ballycrochan,North Down,Ards and North Down,Ards and North Down,N08001101,N05000013,N09000011,N09000011
+2024,2024,Ballygowan,Strangford,Ards and North Down,Ards and North Down,N08001102,N05000016,N09000011,N09000011
+2024,2024,Ballygrainey,North Down,Ards and North Down,Ards and North Down,N08001103,N05000013,N09000011,N09000011
+2024,2024,Ballyholme,North Down,Ards and North Down,Ards and North Down,N08001104,N05000013,N09000011,N09000011
+2024,2024,Ballymagee,North Down,Ards and North Down,Ards and North Down,N08001105,N05000013,N09000011,N09000011
+2024,2024,Ballywalter,Strangford,Ards and North Down,Ards and North Down,N08001106,N05000016,N09000011,N09000011
+2024,2024,Bloomfield,North Down,Ards and North Down,Ards and North Down,N08001107,N05000013,N09000011,N09000011
+2024,2024,Broadway,North Down,Ards and North Down,Ards and North Down,N08001108,N05000013,N09000011,N09000011
+2024,2024,Bryansburn,North Down,Ards and North Down,Ards and North Down,N08001109,N05000013,N09000011,N09000011
+2024,2024,Carrowdore,North Down,Ards and North Down,Ards and North Down,N08001110,N05000013,N09000011,N09000011
+2024,2024,Carrowdore,Strangford,Ards and North Down,Ards and North Down,N08001110,N05000016,N09000011,N09000011
+2024,2024,Castle,North Down,Ards and North Down,Ards and North Down,N08001111,N05000013,N09000011,N09000011
+2024,2024,Clandeboye,North Down,Ards and North Down,Ards and North Down,N08001112,N05000013,N09000011,N09000011
+2024,2024,Comber North,Strangford,Ards and North Down,Ards and North Down,N08001113,N05000016,N09000011,N09000011
+2024,2024,Comber South,Strangford,Ards and North Down,Ards and North Down,N08001114,N05000016,N09000011,N09000011
+2024,2024,Comber West,Strangford,Ards and North Down,Ards and North Down,N08001115,N05000016,N09000011,N09000011
+2024,2024,Conway Square,Strangford,Ards and North Down,Ards and North Down,N08001116,N05000016,N09000011,N09000011
+2024,2024,Cronstown,Strangford,Ards and North Down,Ards and North Down,N08001117,N05000016,N09000011,N09000011
+2024,2024,Cultra,North Down,Ards and North Down,Ards and North Down,N08001118,N05000013,N09000011,N09000011
+2024,2024,Donaghadee,North Down,Ards and North Down,Ards and North Down,N08001119,N05000013,N09000011,N09000011
+2024,2024,Glen,Strangford,Ards and North Down,Ards and North Down,N08001120,N05000016,N09000011,N09000011
+2024,2024,Gregstown,Strangford,Ards and North Down,Ards and North Down,N08001121,N05000016,N09000011,N09000011
+2024,2024,Groomsport,North Down,Ards and North Down,Ards and North Down,N08001122,N05000013,N09000011,N09000011
+2024,2024,Harbour,North Down,Ards and North Down,Ards and North Down,N08001123,N05000013,N09000011,N09000011
+2024,2024,Helen's Bay,North Down,Ards and North Down,Ards and North Down,N08001124,N05000013,N09000011,N09000011
+2024,2024,Holywood,North Down,Ards and North Down,Ards and North Down,N08001125,N05000013,N09000011,N09000011
+2024,2024,Kilcooley,North Down,Ards and North Down,Ards and North Down,N08001126,N05000013,N09000011,N09000011
+2024,2024,Killinchy,Strangford,Ards and North Down,Ards and North Down,N08001127,N05000016,N09000011,N09000011
+2024,2024,Kircubbin,Strangford,Ards and North Down,Ards and North Down,N08001128,N05000016,N09000011,N09000011
+2024,2024,Loughries,North Down,Ards and North Down,Ards and North Down,N08001129,N05000013,N09000011,N09000011
+2024,2024,Loughries,Strangford,Ards and North Down,Ards and North Down,N08001129,N05000016,N09000011,N09000011
+2024,2024,Loughview,North Down,Ards and North Down,Ards and North Down,N08001130,N05000013,N09000011,N09000011
+2024,2024,Movilla,Strangford,Ards and North Down,Ards and North Down,N08001131,N05000016,N09000011,N09000011
+2024,2024,Portaferry,Strangford,Ards and North Down,Ards and North Down,N08001132,N05000016,N09000011,N09000011
+2024,2024,Portavogie,Strangford,Ards and North Down,Ards and North Down,N08001133,N05000016,N09000011,N09000011
+2024,2024,Rathgael,North Down,Ards and North Down,Ards and North Down,N08001134,N05000013,N09000011,N09000011
+2024,2024,Rathmore,North Down,Ards and North Down,Ards and North Down,N08001135,N05000013,N09000011,N09000011
+2024,2024,Scrabo,Strangford,Ards and North Down,Ards and North Down,N08001136,N05000016,N09000011,N09000011
+2024,2024,Silverbirch,North Down,Ards and North Down,Ards and North Down,N08001137,N05000013,N09000011,N09000011
+2024,2024,Silverstream,North Down,Ards and North Down,Ards and North Down,N08001138,N05000013,N09000011,N09000011
+2024,2024,Warren,North Down,Ards and North Down,Ards and North Down,N08001139,N05000013,N09000011,N09000011
+2024,2024,West Winds,Strangford,Ards and North Down,Ards and North Down,N08001140,N05000016,N09000011,N09000011
+2024,2024,Clackmannanshire West,Alloa and Grangemouth,Clackmannanshire,Clackmannanshire,S13002875,S14000064,S12000005,S12000005
+2024,2024,Clackmannanshire North,Alloa and Grangemouth,Clackmannanshire,Clackmannanshire,S13002876,S14000064,S12000005,S12000005
+2024,2024,Clackmannanshire Central,Alloa and Grangemouth,Clackmannanshire,Clackmannanshire,S13002877,S14000064,S12000005,S12000005
+2024,2024,Clackmannanshire South,Alloa and Grangemouth,Clackmannanshire,Clackmannanshire,S13002878,S14000064,S12000005,S12000005
+2024,2024,Clackmannanshire East,Alloa and Grangemouth,Clackmannanshire,Clackmannanshire,S13002879,S14000064,S12000005,S12000005
+2024,2024,Clackmannanshire East,Dunfermline and Dollar,Clackmannanshire,Clackmannanshire,S13002879,S14000076,S12000005,S12000005
+2024,2024,Stranraer and the Rhins,Dumfries and Galloway,Dumfries and Galloway,Dumfries and Galloway,S13002880,S14000073,S12000006,S12000006
+2024,2024,Mid Galloway and Wigtown West,Dumfries and Galloway,Dumfries and Galloway,Dumfries and Galloway,S13002881,S14000073,S12000006,S12000006
+2024,2024,Dee and Glenkens,Dumfries and Galloway,Dumfries and Galloway,Dumfries and Galloway,S13002882,S14000073,S12000006,S12000006
+2024,2024,Castle Douglas and Crocketford,Dumfries and Galloway,Dumfries and Galloway,Dumfries and Galloway,S13002883,S14000073,S12000006,S12000006
+2024,2024,Abbey,Dumfries and Galloway,Dumfries and Galloway,Dumfries and Galloway,S13002884,S14000073,S12000006,S12000006
+2024,2024,North West Dumfries,Dumfries and Galloway,Dumfries and Galloway,Dumfries and Galloway,S13002885,S14000073,S12000006,S12000006
+2024,2024,Mid and Upper Nithsdale,Dumfries and Galloway,Dumfries and Galloway,Dumfries and Galloway,S13002886,S14000073,S12000006,S12000006
+2024,2024,Mid and Upper Nithsdale,"Dumfriesshire, Clydesdale and Tweeddale",Dumfries and Galloway,Dumfries and Galloway,S13002886,S14000074,S12000006,S12000006
+2024,2024,Lochar,Dumfries and Galloway,Dumfries and Galloway,Dumfries and Galloway,S13002887,S14000073,S12000006,S12000006
+2024,2024,Lochar,"Dumfriesshire, Clydesdale and Tweeddale",Dumfries and Galloway,Dumfries and Galloway,S13002887,S14000074,S12000006,S12000006
+2024,2024,Nith,Dumfries and Galloway,Dumfries and Galloway,Dumfries and Galloway,S13002888,S14000073,S12000006,S12000006
+2024,2024,Annandale South,"Dumfriesshire, Clydesdale and Tweeddale",Dumfries and Galloway,Dumfries and Galloway,S13002889,S14000074,S12000006,S12000006
+2024,2024,Annandale North,"Dumfriesshire, Clydesdale and Tweeddale",Dumfries and Galloway,Dumfries and Galloway,S13002890,S14000074,S12000006,S12000006
+2024,2024,Annandale East and Eskdale,"Dumfriesshire, Clydesdale and Tweeddale",Dumfries and Galloway,Dumfries and Galloway,S13002891,S14000074,S12000006,S12000006
+2024,2024,Annick,Kilmarnock and Loudoun,East Ayrshire,East Ayrshire,S13002892,S14000110,S12000008,S12000008
+2024,2024,Kilmarnock North,Kilmarnock and Loudoun,East Ayrshire,East Ayrshire,S13002893,S14000110,S12000008,S12000008
+2024,2024,Kilmarnock West and Crosshouse,Kilmarnock and Loudoun,East Ayrshire,East Ayrshire,S13002894,S14000110,S12000008,S12000008
+2024,2024,Kilmarnock East and Hurlford,Kilmarnock and Loudoun,East Ayrshire,East Ayrshire,S13002895,S14000110,S12000008,S12000008
+2024,2024,Kilmarnock South,Kilmarnock and Loudoun,East Ayrshire,East Ayrshire,S13002896,S14000110,S12000008,S12000008
+2024,2024,Irvine Valley,Kilmarnock and Loudoun,East Ayrshire,East Ayrshire,S13002897,S14000110,S12000008,S12000008
+2024,2024,Ballochmyle,Kilmarnock and Loudoun,East Ayrshire,East Ayrshire,S13002898,S14000110,S12000008,S12000008
+2024,2024,Cumnock and New Cumnock,"Ayr, Carrick and Cumnock",East Ayrshire,East Ayrshire,S13002899,S14000107,S12000008,S12000008
+2024,2024,Cumnock and New Cumnock,Kilmarnock and Loudoun,East Ayrshire,East Ayrshire,S13002899,S14000110,S12000008,S12000008
+2024,2024,Doon Valley,"Ayr, Carrick and Cumnock",East Ayrshire,East Ayrshire,S13002900,S14000107,S12000008,S12000008
+2024,2024,Musselburgh,Edinburgh East and Musselburgh,East Lothian,East Lothian,S13002908,S14000078,S12000010,S12000010
+2024,2024,Musselburgh,Lothian East,East Lothian,East Lothian,S13002908,S14000096,S12000010,S12000010
+2024,2024,"Preston, Seton and Gosford",Lothian East,East Lothian,East Lothian,S13002909,S14000096,S12000010,S12000010
+2024,2024,"Tranent, Wallyford and Macmerry",Lothian East,East Lothian,East Lothian,S13002910,S14000096,S12000010,S12000010
+2024,2024,North Berwick Coastal,Lothian East,East Lothian,East Lothian,S13002911,S14000096,S12000010,S12000010
+2024,2024,Haddington and Lammermuir,Lothian East,East Lothian,East Lothian,S13002912,S14000096,S12000010,S12000010
+2024,2024,Dunbar and East Linton,Lothian East,East Lothian,East Lothian,S13002913,S14000096,S12000010,S12000010
+2024,2024,George St/Harbour,Aberdeen South,Aberdeen City,Aberdeen City,S13002842,S14000061,S12000033,S12000033
+2024,2024,Inverclyde South,Inverclyde and Renfrewshire West,Inverclyde,Inverclyde,S13003017,S14000093,S12000018,S12000018
+2024,2024,Corstorphine/Murrayfield,Edinburgh West,City of Edinburgh,City of Edinburgh,S13002924,S14000082,S12000036,S12000036
+2024,2024,Whitburn and Blackburn,Bathgate and Linlithgow,West Lothian,West Lothian,S13002826,S14000068,S12000040,S12000040
+2024,2024,Cowdenbeath,Glenrothes and Mid Fife,Fife,Fife,S13003128,S14000090,S12000047,S12000047
+2024,2024,Troon,Central Ayrshire,South Ayrshire,South Ayrshire,S13003087,S14000109,S12000028,S12000028
+2024,2024,Prestwick,Central Ayrshire,South Ayrshire,South Ayrshire,S13003088,S14000109,S12000028,S12000028
+2024,2024,Ayr North,"Ayr, Carrick and Cumnock",South Ayrshire,South Ayrshire,S13003089,S14000107,S12000028,S12000028
+2024,2024,Ayr North,Central Ayrshire,South Ayrshire,South Ayrshire,S13003089,S14000109,S12000028,S12000028
+2024,2024,Ayr East,"Ayr, Carrick and Cumnock",South Ayrshire,South Ayrshire,S13003090,S14000107,S12000028,S12000028
+2024,2024,Ayr West,"Ayr, Carrick and Cumnock",South Ayrshire,South Ayrshire,S13003091,S14000107,S12000028,S12000028
+2024,2024,Kyle,Central Ayrshire,South Ayrshire,South Ayrshire,S13003092,S14000109,S12000028,S12000028
+2024,2024,"Maybole, North Carrick and Coylton","Ayr, Carrick and Cumnock",South Ayrshire,South Ayrshire,S13003093,S14000107,S12000028,S12000028
+2024,2024,"Maybole, North Carrick and Coylton",Central Ayrshire,South Ayrshire,South Ayrshire,S13003093,S14000109,S12000028,S12000028
+2024,2024,Girvan and South Carrick,"Ayr, Carrick and Cumnock",South Ayrshire,South Ayrshire,S13003094,S14000107,S12000028,S12000028
+2024,2024,Clydesdale West,Hamilton and Clyde Valley,South Lanarkshire,South Lanarkshire,S13003095,S14000092,S12000029,S12000029
+2024,2024,Clydesdale West,"Motherwell, Wishaw and Carluke",South Lanarkshire,South Lanarkshire,S13003095,S14000099,S12000029,S12000029
+2024,2024,Clydesdale North,Hamilton and Clyde Valley,South Lanarkshire,South Lanarkshire,S13003096,S14000092,S12000029,S12000029
+2024,2024,Clydesdale North,"Motherwell, Wishaw and Carluke",South Lanarkshire,South Lanarkshire,S13003096,S14000099,S12000029,S12000029
+2024,2024,Clydesdale East,"Dumfriesshire, Clydesdale and Tweeddale",South Lanarkshire,South Lanarkshire,S13003097,S14000074,S12000029,S12000029
+2024,2024,Clydesdale South,"Dumfriesshire, Clydesdale and Tweeddale",South Lanarkshire,South Lanarkshire,S13003098,S14000074,S12000029,S12000029
+2024,2024,Clydesdale South,Hamilton and Clyde Valley,South Lanarkshire,South Lanarkshire,S13003098,S14000092,S12000029,S12000029
+2024,2024,Avondale and Stonehouse,East Kilbride and Strathaven,South Lanarkshire,South Lanarkshire,S13003099,S14000077,S12000029,S12000029
+2024,2024,East Kilbride South,East Kilbride and Strathaven,South Lanarkshire,South Lanarkshire,S13003100,S14000077,S12000029,S12000029
+2024,2024,East Kilbride Central South,East Kilbride and Strathaven,South Lanarkshire,South Lanarkshire,S13003101,S14000077,S12000029,S12000029
+2024,2024,East Kilbride Central North,East Kilbride and Strathaven,South Lanarkshire,South Lanarkshire,S13003102,S14000077,S12000029,S12000029
+2024,2024,East Kilbride West,East Kilbride and Strathaven,South Lanarkshire,South Lanarkshire,S13003103,S14000077,S12000029,S12000029
+2024,2024,East Kilbride East,East Kilbride and Strathaven,South Lanarkshire,South Lanarkshire,S13003104,S14000077,S12000029,S12000029
+2024,2024,Rutherglen South,Rutherglen,South Lanarkshire,South Lanarkshire,S13003105,S14000104,S12000029,S12000029
+2024,2024,Rutherglen Central and North,Rutherglen,South Lanarkshire,South Lanarkshire,S13003106,S14000104,S12000029,S12000029
+2024,2024,Cambuslang West,Rutherglen,South Lanarkshire,South Lanarkshire,S13003107,S14000104,S12000029,S12000029
+2024,2024,Cambuslang East,Rutherglen,South Lanarkshire,South Lanarkshire,S13003108,S14000104,S12000029,S12000029
+2024,2024,Blantyre,Rutherglen,South Lanarkshire,South Lanarkshire,S13003109,S14000104,S12000029,S12000029
+2024,2024,Bothwell and Uddingston,Rutherglen,South Lanarkshire,South Lanarkshire,S13003110,S14000104,S12000029,S12000029
+2024,2024,Hamilton North and East,Hamilton and Clyde Valley,South Lanarkshire,South Lanarkshire,S13003111,S14000092,S12000029,S12000029
+2024,2024,Hamilton West and Earnock,Hamilton and Clyde Valley,South Lanarkshire,South Lanarkshire,S13003112,S14000092,S12000029,S12000029
+2024,2024,Hamilton South,Hamilton and Clyde Valley,South Lanarkshire,South Lanarkshire,S13003113,S14000092,S12000029,S12000029
+2024,2024,Larkhall,Hamilton and Clyde Valley,South Lanarkshire,South Lanarkshire,S13003114,S14000092,S12000029,S12000029
+2024,2024,Trossachs and Teith,Stirling and Strathallan,Stirling,Stirling,S13003115,S14000105,S12000030,S12000030
+2024,2024,Forth and Endrick,Stirling and Strathallan,Stirling,Stirling,S13003116,S14000105,S12000030,S12000030
+2024,2024,Dunblane and Bridge of Allan,Stirling and Strathallan,Stirling,Stirling,S13003117,S14000105,S12000030,S12000030
+2024,2024,Stirling North,Stirling and Strathallan,Stirling,Stirling,S13003118,S14000105,S12000030,S12000030
+2024,2024,Stirling West,Stirling and Strathallan,Stirling,Stirling,S13003119,S14000105,S12000030,S12000030
+2024,2024,Lower Deeside,Aberdeen South,Aberdeen City,Aberdeen City,S13002843,S14000061,S12000033,S12000033
+2024,2024,Sighthill/Gorgie,Edinburgh South West,City of Edinburgh,City of Edinburgh,S13002925,S14000081,S12000036,S12000036
+2024,2024,Bathgate,Bathgate and Linlithgow,West Lothian,West Lothian,S13002827,S14000068,S12000040,S12000040
+2024,2024,Glenrothes West and Kinglassie,Glenrothes and Mid Fife,Fife,Fife,S13003129,S14000090,S12000047,S12000047
+2024,2024,Stirling East,Stirling and Strathallan,Stirling,Stirling,S13003120,S14000105,S12000030,S12000030
+2024,2024,Bannockburn,Stirling and Strathallan,Stirling,Stirling,S13003121,S14000105,S12000030,S12000030
+2024,2024,Dyce/Bucksburn/Danestone,Aberdeen North,Aberdeen City,Aberdeen City,S13002835,S14000060,S12000033,S12000033
+2024,2024,Bridge of Don,Aberdeen North,Aberdeen City,Aberdeen City,S13002836,S14000060,S12000033,S12000033
+2024,2024,Kingswells/Sheddocksley/Summerhill,Aberdeen North,Aberdeen City,Aberdeen City,S13002837,S14000060,S12000033,S12000033
+2024,2024,Northfield/Mastrick North,Aberdeen North,Aberdeen City,Aberdeen City,S13002838,S14000060,S12000033,S12000033
+2024,2024,Hilton/Woodside/Stockethill,Aberdeen North,Aberdeen City,Aberdeen City,S13002839,S14000060,S12000033,S12000033
+2024,2024,Tillydrone/Seaton/Old Aberdeen,Aberdeen North,Aberdeen City,Aberdeen City,S13002840,S14000060,S12000033,S12000033
+2024,2024,Midstocket/Rosemount,Aberdeen North,Aberdeen City,Aberdeen City,S13002841,S14000060,S12000033,S12000033
+2024,2024,Midstocket/Rosemount,Aberdeen South,Aberdeen City,Aberdeen City,S13002841,S14000061,S12000033,S12000033
+2024,2024,Bo'ness and Blackness,Bathgate and Linlithgow,Falkirk,Falkirk,S13002936,S14000068,S12000014,S12000014
+2024,2024,Grangemouth,Alloa and Grangemouth,Falkirk,Falkirk,S13002937,S14000064,S12000014,S12000014
+2024,2024,Denny and Banknock,Falkirk,Falkirk,Falkirk,S13002938,S14000083,S12000014,S12000014
+2024,2024,"Carse, Kinnaird and Tryst",Alloa and Grangemouth,Falkirk,Falkirk,S13002939,S14000064,S12000014,S12000014
+2024,2024,Bonnybridge and Larbert,Alloa and Grangemouth,Falkirk,Falkirk,S13002940,S14000064,S12000014,S12000014
+2024,2024,Bonnybridge and Larbert,Falkirk,Falkirk,Falkirk,S13002940,S14000083,S12000014,S12000014
+2024,2024,Falkirk North,Falkirk,Falkirk,Falkirk,S13002941,S14000083,S12000014,S12000014
+2024,2024,Falkirk South,Falkirk,Falkirk,Falkirk,S13002942,S14000083,S12000014,S12000014
+2024,2024,Lower Braes,Falkirk,Falkirk,Falkirk,S13002943,S14000083,S12000014,S12000014
+2024,2024,Upper Braes,Falkirk,Falkirk,Falkirk,S13002944,S14000083,S12000014,S12000014
+2024,2024,Sighthill/Gorgie,Edinburgh West,City of Edinburgh,City of Edinburgh,S13002925,S14000082,S12000036,S12000036
+2024,2024,"North, West and Central Sutherland","Caithness, Sutherland and Easter Ross",Highland,Highland,S13002990,S14000069,S12000017,S12000017
+2024,2024,Colinton/Fairmilehead,Edinburgh South,City of Edinburgh,City of Edinburgh,S13002926,S14000080,S12000036,S12000036
+2024,2024,Thurso and Northwest Caithness,"Caithness, Sutherland and Easter Ross",Highland,Highland,S13002991,S14000069,S12000017,S12000017
+2024,2024,Colinton/Fairmilehead,Edinburgh South West,City of Edinburgh,City of Edinburgh,S13002926,S14000081,S12000036,S12000036
+2024,2024,Fountainbridge/Craiglockhart,Edinburgh South West,City of Edinburgh,City of Edinburgh,S13002927,S14000081,S12000036,S12000036
+2024,2024,Morningside,Edinburgh South,City of Edinburgh,City of Edinburgh,S13002928,S14000080,S12000036,S12000036
+2024,2024,Morningside,Edinburgh South West,City of Edinburgh,City of Edinburgh,S13002928,S14000081,S12000036,S12000036
+2024,2024,City Centre,Edinburgh East and Musselburgh,City of Edinburgh,City of Edinburgh,S13002929,S14000078,S12000036,S12000036
+2024,2024,City Centre,Edinburgh North and Leith,City of Edinburgh,City of Edinburgh,S13002929,S14000079,S12000036,S12000036
+2024,2024,City Centre,Edinburgh South West,City of Edinburgh,City of Edinburgh,S13002929,S14000081,S12000036,S12000036
+2024,2024,City Centre,Edinburgh West,City of Edinburgh,City of Edinburgh,S13002929,S14000082,S12000036,S12000036
+2024,2024,Leith Walk,Edinburgh East and Musselburgh,City of Edinburgh,City of Edinburgh,S13002930,S14000078,S12000036,S12000036
+2024,2024,Leith Walk,Edinburgh North and Leith,City of Edinburgh,City of Edinburgh,S13002930,S14000079,S12000036,S12000036
+2024,2024,Leith,Edinburgh East and Musselburgh,City of Edinburgh,City of Edinburgh,S13002931,S14000078,S12000036,S12000036
+2024,2024,Leith,Edinburgh North and Leith,City of Edinburgh,City of Edinburgh,S13002931,S14000079,S12000036,S12000036
+2024,2024,Craigentinny/Duddingston,Edinburgh East and Musselburgh,City of Edinburgh,City of Edinburgh,S13002932,S14000078,S12000036,S12000036
+2024,2024,Southside/Newington,Edinburgh East and Musselburgh,City of Edinburgh,City of Edinburgh,S13002933,S14000078,S12000036,S12000036
+2024,2024,Southside/Newington,Edinburgh South,City of Edinburgh,City of Edinburgh,S13002933,S14000080,S12000036,S12000036
+2024,2024,Liberton/Gilmerton,Edinburgh South,City of Edinburgh,City of Edinburgh,S13002934,S14000080,S12000036,S12000036
+2024,2024,Portobello/Craigmillar,Edinburgh East and Musselburgh,City of Edinburgh,City of Edinburgh,S13002935,S14000078,S12000036,S12000036
+2024,2024,Renfrew North and Braehead,Paisley and Renfrewshire North,Renfrewshire,Renfrewshire,S13003075,S14000101,S12000038,S12000038
+2024,2024,Renfrew South and Gallowhill,Paisley and Renfrewshire North,Renfrewshire,Renfrewshire,S13003076,S14000101,S12000038,S12000038
+2024,2024,Paisley Northeast and Ralston,Paisley and Renfrewshire North,Renfrewshire,Renfrewshire,S13003077,S14000101,S12000038,S12000038
+2024,2024,Paisley Northwest,Paisley and Renfrewshire North,Renfrewshire,Renfrewshire,S13003078,S14000101,S12000038,S12000038
+2024,2024,Paisley Northwest,Paisley and Renfrewshire South,Renfrewshire,Renfrewshire,S13003078,S14000102,S12000038,S12000038
+2024,2024,Paisley East and Central,Paisley and Renfrewshire South,Renfrewshire,Renfrewshire,S13003079,S14000102,S12000038,S12000038
+2024,2024,Paisley Southeast,Paisley and Renfrewshire South,Renfrewshire,Renfrewshire,S13003080,S14000102,S12000038,S12000038
+2024,2024,Paisley Southwest,Paisley and Renfrewshire South,Renfrewshire,Renfrewshire,S13003081,S14000102,S12000038,S12000038
+2024,2024,Johnstone South and Elderslie,Paisley and Renfrewshire South,Renfrewshire,Renfrewshire,S13003082,S14000102,S12000038,S12000038
+2024,2024,"Johnstone North, Kilbarchan, Howwood and Lochwinnoch",Paisley and Renfrewshire South,Renfrewshire,Renfrewshire,S13003083,S14000102,S12000038,S12000038
+2024,2024,"Houston, Crosslee and Linwood",Inverclyde and Renfrewshire West,Renfrewshire,Renfrewshire,S13003084,S14000093,S12000038,S12000038
+2024,2024,Hazlehead/Queens Cross/Countesswells,Aberdeen South,Aberdeen City,Aberdeen City,S13002844,S14000061,S12000033,S12000033
+2024,2024,"Lochgelly, Cardenden and Benarty",Glenrothes and Mid Fife,Fife,Fife,S13003130,S14000090,S12000047,S12000047
+2024,2024,Armadale and Blackridge,Bathgate and Linlithgow,West Lothian,West Lothian,S13002828,S14000068,S12000040,S12000040
+2024,2024,"Houston, Crosslee and Linwood",Paisley and Renfrewshire North,Renfrewshire,Renfrewshire,S13003084,S14000101,S12000038,S12000038
+2024,2024,"Houston, Crosslee and Linwood",Paisley and Renfrewshire South,Renfrewshire,Renfrewshire,S13003084,S14000102,S12000038,S12000038
+2024,2024,"Bishopton, Bridge of Weir and Langbank",Inverclyde and Renfrewshire West,Renfrewshire,Renfrewshire,S13003085,S14000093,S12000038,S12000038
+2024,2024,"Bishopton, Bridge of Weir and Langbank",Paisley and Renfrewshire North,Renfrewshire,Renfrewshire,S13003085,S14000101,S12000038,S12000038
+2024,2024,Erskine and Inchinnan,Paisley and Renfrewshire North,Renfrewshire,Renfrewshire,S13003086,S14000101,S12000038,S12000038
+2024,2024,Lomond,West Dunbartonshire,West Dunbartonshire,West Dunbartonshire,S13003122,S14000106,S12000039,S12000039
+2024,2024,Leven,West Dunbartonshire,West Dunbartonshire,West Dunbartonshire,S13003123,S14000106,S12000039,S12000039
+2024,2024,Dumbarton,West Dunbartonshire,West Dunbartonshire,West Dunbartonshire,S13003124,S14000106,S12000039,S12000039
+2024,2024,Kilpatrick,West Dunbartonshire,West Dunbartonshire,West Dunbartonshire,S13003125,S14000106,S12000039,S12000039
+2024,2024,Clydebank Central,West Dunbartonshire,West Dunbartonshire,West Dunbartonshire,S13003126,S14000106,S12000039,S12000039
+2024,2024,Clydebank Waterfront,West Dunbartonshire,West Dunbartonshire,West Dunbartonshire,S13003127,S14000106,S12000039,S12000039
+2024,2024,Linlithgow,Bathgate and Linlithgow,West Lothian,West Lothian,S13002820,S14000068,S12000040,S12000040
+2024,2024,"Broxburn, Uphall and Winchburgh",Bathgate and Linlithgow,West Lothian,West Lothian,S13002821,S14000068,S12000040,S12000040
+2024,2024,"Broxburn, Uphall and Winchburgh",Livingston,West Lothian,West Lothian,S13002821,S14000095,S12000040,S12000040
+2024,2024,Livingston North,Livingston,West Lothian,West Lothian,S13002822,S14000095,S12000040,S12000040
+2024,2024,Livingston South,Livingston,West Lothian,West Lothian,S13002823,S14000095,S12000040,S12000040
+2024,2024,East Livingston and East Calder,Livingston,West Lothian,West Lothian,S13002824,S14000095,S12000040,S12000040
+2024,2024,Fauldhouse and the Breich Valley,Livingston,West Lothian,West Lothian,S13002825,S14000095,S12000040,S12000040
+2024,2024,Speyside Glenlivet,"Moray West, Nairn and Strathspey",Moray,Moray,S13003024,S14000098,S12000020,S12000020
+2024,2024,Keith and Cullen,Aberdeenshire North and Moray East,Moray,Moray,S13003025,S14000062,S12000020,S12000020
+2024,2024,Buckie,Aberdeenshire North and Moray East,Moray,Moray,S13003026,S14000062,S12000020,S12000020
+2024,2024,Fochabers Lhanbryde,Aberdeenshire North and Moray East,Moray,Moray,S13003027,S14000062,S12000020,S12000020
+2024,2024,Fochabers Lhanbryde,"Moray West, Nairn and Strathspey",Moray,Moray,S13003027,S14000098,S12000020,S12000020
+2024,2024,Heldon and Laich,"Moray West, Nairn and Strathspey",Moray,Moray,S13003028,S14000098,S12000020,S12000020
+2024,2024,Elgin City North,"Moray West, Nairn and Strathspey",Moray,Moray,S13003029,S14000098,S12000020,S12000020
+2024,2024,Elgin City South,"Moray West, Nairn and Strathspey",Moray,Moray,S13003030,S14000098,S12000020,S12000020
+2024,2024,Forres,"Moray West, Nairn and Strathspey",Moray,Moray,S13003031,S14000098,S12000020,S12000020
+2024,2024,Irvine West,Central Ayrshire,North Ayrshire,North Ayrshire,S13003032,S14000109,S12000021,S12000021
+2024,2024,Irvine East,Central Ayrshire,North Ayrshire,North Ayrshire,S13003033,S14000109,S12000021,S12000021
+2024,2024,Kilwinning,Central Ayrshire,North Ayrshire,North Ayrshire,S13003034,S14000109,S12000021,S12000021
+2024,2024,Irvine South,Central Ayrshire,North Ayrshire,North Ayrshire,S13003041,S14000109,S12000021,S12000021
+2024,2024,Tweeddale West,"Dumfriesshire, Clydesdale and Tweeddale",Scottish Borders,Scottish Borders,S13002761,S14000074,S12000026,S12000026
+2024,2024,Tweeddale East,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002762,S14000108,S12000026,S12000026
+2024,2024,Tweeddale East,"Dumfriesshire, Clydesdale and Tweeddale",Scottish Borders,Scottish Borders,S13002762,S14000074,S12000026,S12000026
+2024,2024,Galashiels and District,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002763,S14000108,S12000026,S12000026
+2024,2024,Selkirkshire,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002764,S14000108,S12000026,S12000026
+2024,2024,Leaderdale and Melrose,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002765,S14000108,S12000026,S12000026
+2024,2024,Mid Berwickshire,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002766,S14000108,S12000026,S12000026
+2024,2024,East Berwickshire,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002767,S14000108,S12000026,S12000026
+2024,2024,Kelso and District,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002768,S14000108,S12000026,S12000026
+2024,2024,Jedburgh and District,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002769,S14000108,S12000026,S12000026
+2024,2024,Hawick and Denholm,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002770,S14000108,S12000026,S12000026
+2024,2024,Hawick and Hermitage,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002771,S14000108,S12000026,S12000026
+2024,2024,West Fife and Coastal Villages,Dunfermline and Dollar,Fife,Fife,S13003131,S14000076,S12000047,S12000047
+2024,2024,Wick and East Caithness,"Caithness, Sutherland and Easter Ross",Highland,Highland,S13002992,S14000069,S12000017,S12000017
+2024,2024,Airyhall/Broomhill/Garthdee,Aberdeen South,Aberdeen City,Aberdeen City,S13002845,S14000061,S12000033,S12000033
+2024,2024,Kirriemuir and Dean,Angus and Perthshire Glens,Angus,Angus,S13002867,S14000065,S12000041,S12000041
+2024,2024,Brechin and Edzell,Angus and Perthshire Glens,Angus,Angus,S13002868,S14000065,S12000041,S12000041
+2024,2024,Forfar and District,Angus and Perthshire Glens,Angus,Angus,S13002869,S14000065,S12000041,S12000041
+2024,2024,Monifieth and Sidlaw,Angus and Perthshire Glens,Angus,Angus,S13002870,S14000065,S12000041,S12000041
+2024,2024,Monifieth and Sidlaw,Arbroath and Broughty Ferry,Angus,Angus,S13002870,S14000066,S12000041,S12000041
+2024,2024,Carnoustie and District,Arbroath and Broughty Ferry,Angus,Angus,S13002871,S14000066,S12000041,S12000041
+2024,2024,"Arbroath West, Letham and Friockheim",Arbroath and Broughty Ferry,Angus,Angus,S13002872,S14000066,S12000041,S12000041
+2024,2024,Arbroath East and Lunan,Arbroath and Broughty Ferry,Angus,Angus,S13002873,S14000066,S12000041,S12000041
+2024,2024,Montrose and District,Angus and Perthshire Glens,Angus,Angus,S13002874,S14000065,S12000041,S12000041
+2024,2024,Strathmartine,Dundee Central,Dundee City,Dundee City,S13002545,S14000075,S12000042,S12000042
+2024,2024,Lochee,Dundee Central,Dundee City,Dundee City,S13002546,S14000075,S12000042,S12000042
+2024,2024,West End,Dundee Central,Dundee City,Dundee City,S13002547,S14000075,S12000042,S12000042
+2024,2024,Coldside,Dundee Central,Dundee City,Dundee City,S13002548,S14000075,S12000042,S12000042
+2024,2024,Maryfield,Dundee Central,Dundee City,Dundee City,S13002549,S14000075,S12000042,S12000042
+2024,2024,East End,Arbroath and Broughty Ferry,Dundee City,Dundee City,S13002551,S14000066,S12000042,S12000042
+2024,2024,East End,Dundee Central,Dundee City,Dundee City,S13002551,S14000075,S12000042,S12000042
+2024,2024,The Ferry,Arbroath and Broughty Ferry,Dundee City,Dundee City,S13002552,S14000066,S12000042,S12000042
+2024,2024,North East,Arbroath and Broughty Ferry,Dundee City,Dundee City,S13002830,S14000066,S12000042,S12000042
+2024,2024,Torry/Ferryhill,Aberdeen South,Aberdeen City,Aberdeen City,S13002846,S14000061,S12000033,S12000033
+2024,2024,Milngavie,Mid Dunbartonshire,East Dunbartonshire,East Dunbartonshire,S13002901,S14000097,S12000045,S12000045
+2024,2024,Bearsden North,Mid Dunbartonshire,East Dunbartonshire,East Dunbartonshire,S13002902,S14000097,S12000045,S12000045
+2024,2024,Kincorth/Nigg/Cove,Aberdeen South,Aberdeen City,Aberdeen City,S13002847,S14000061,S12000033,S12000033
+2024,2024,Bearsden South,Mid Dunbartonshire,East Dunbartonshire,East Dunbartonshire,S13002903,S14000097,S12000045,S12000045
+2024,2024,East Sutherland and Edderton,"Caithness, Sutherland and Easter Ross",Highland,Highland,S13002993,S14000069,S12000017,S12000017
+2024,2024,Carse of Gowrie,Perth and Kinross-shire,Perth and Kinross,Perth and Kinross,S13003063,S14000103,S12000048,S12000048
+2024,2024,Banff and District,Aberdeenshire North and Moray East,Aberdeenshire,Aberdeenshire,S13002848,S14000062,S12000034,S12000034
+2024,2024,Bishopbriggs North and Campsie,Mid Dunbartonshire,East Dunbartonshire,East Dunbartonshire,S13002904,S14000097,S12000045,S12000045
+2024,2024,Strathmore,Angus and Perthshire Glens,Perth and Kinross,Perth and Kinross,S13003064,S14000065,S12000048,S12000048
+2024,2024,"Wester Ross, Strathpeffer and Lochalsh","Caithness, Sutherland and Easter Ross",Highland,Highland,S13002994,S14000069,S12000017,S12000017
+2024,2024,Strathmore,Perth and Kinross-shire,Perth and Kinross,Perth and Kinross,S13003064,S14000103,S12000048,S12000048
+2024,2024,"Wester Ross, Strathpeffer and Lochalsh","Inverness, Skye and West Ross-shire",Highland,Highland,S13002994,S14000094,S12000017,S12000017
+2024,2024,Blairgowrie and Glens,Angus and Perthshire Glens,Perth and Kinross,Perth and Kinross,S13003065,S14000065,S12000048,S12000048
+2024,2024,Cromarty Firth,"Caithness, Sutherland and Easter Ross",Highland,Highland,S13002995,S14000069,S12000017,S12000017
+2024,2024,Highland,Angus and Perthshire Glens,Perth and Kinross,Perth and Kinross,S13003066,S14000065,S12000048,S12000048
+2024,2024,Tain and Easter Ross,"Caithness, Sutherland and Easter Ross",Highland,Highland,S13002996,S14000069,S12000017,S12000017
+2024,2024,Strathtay,Angus and Perthshire Glens,Perth and Kinross,Perth and Kinross,S13003067,S14000065,S12000048,S12000048
+2024,2024,Dingwall and Seaforth,"Caithness, Sutherland and Easter Ross",Highland,Highland,S13002997,S14000069,S12000017,S12000017
+2024,2024,Strathtay,Perth and Kinross-shire,Perth and Kinross,Perth and Kinross,S13003067,S14000103,S12000048,S12000048
+2024,2024,Black Isle,"Caithness, Sutherland and Easter Ross",Highland,Highland,S13002998,S14000069,S12000017,S12000017
+2024,2024,Strathearn,Perth and Kinross-shire,Perth and Kinross,Perth and Kinross,S13003068,S14000103,S12000048,S12000048
+2024,2024,Eilean á Chèo,"Inverness, Skye and West Ross-shire",Highland,Highland,S13002999,S14000094,S12000017,S12000017
+2024,2024,Strathallan,Perth and Kinross-shire,Perth and Kinross,Perth and Kinross,S13003069,S14000103,S12000048,S12000048
+2024,2024,Caol and Mallaig,"Inverness, Skye and West Ross-shire",Highland,Highland,S13003000,S14000094,S12000017,S12000017
+2024,2024,Strathallan,Stirling and Strathallan,Perth and Kinross,Perth and Kinross,S13003069,S14000105,S12000048,S12000048
+2024,2024,Aird and Loch Ness,"Caithness, Sutherland and Easter Ross",Highland,Highland,S13003001,S14000069,S12000017,S12000017
+2024,2024,Almond and Earn,Perth and Kinross-shire,Perth and Kinross,Perth and Kinross,S13003071,S14000103,S12000048,S12000048
+2024,2024,Aird and Loch Ness,"Inverness, Skye and West Ross-shire",Highland,Highland,S13003001,S14000094,S12000017,S12000017
+2024,2024,Perth City South,Perth and Kinross-shire,Perth and Kinross,Perth and Kinross,S13003072,S14000103,S12000048,S12000048
+2024,2024,Inverness West,"Inverness, Skye and West Ross-shire",Highland,Highland,S13003002,S14000094,S12000017,S12000017
+2024,2024,Perth City North,Perth and Kinross-shire,Perth and Kinross,Perth and Kinross,S13003073,S14000103,S12000048,S12000048
+2024,2024,Inverness Central,"Inverness, Skye and West Ross-shire",Highland,Highland,S13003003,S14000094,S12000017,S12000017
+2024,2024,Perth City Centre,Perth and Kinross-shire,Perth and Kinross,Perth and Kinross,S13003074,S14000103,S12000048,S12000048
+2024,2024,Inverness Ness-side,"Inverness, Skye and West Ross-shire",Highland,Highland,S13003004,S14000094,S12000017,S12000017
+2024,2024,Kinross-shire,Perth and Kinross-shire,Perth and Kinross,Perth and Kinross,S13003132,S14000103,S12000048,S12000048
+2024,2024,Inverness Millburn,"Inverness, Skye and West Ross-shire",Highland,Highland,S13003005,S14000094,S12000017,S12000017
+2024,2024,Culloden and Ardersier,"Inverness, Skye and West Ross-shire",Highland,Highland,S13003006,S14000094,S12000017,S12000017
+2024,2024,Bishopbriggs South,Mid Dunbartonshire,East Dunbartonshire,East Dunbartonshire,S13002905,S14000097,S12000045,S12000045
+2024,2024,Troup,Aberdeenshire North and Moray East,Aberdeenshire,Aberdeenshire,S13002849,S14000062,S12000034,S12000034
+2024,2024,Lenzie and Kirkintilloch South,Cumbernauld and Kirkintilloch,East Dunbartonshire,East Dunbartonshire,S13002906,S14000072,S12000045,S12000045
+2024,2024,Fraserburgh and District,Aberdeenshire North and Moray East,Aberdeenshire,Aberdeenshire,S13002850,S14000062,S12000034,S12000034
+2024,2024,Lenzie and Kirkintilloch South,Mid Dunbartonshire,East Dunbartonshire,East Dunbartonshire,S13002906,S14000097,S12000045,S12000045
+2024,2024,Central Buchan,Aberdeenshire North and Moray East,Aberdeenshire,Aberdeenshire,S13002851,S14000062,S12000034,S12000034
+2024,2024,Kirkintilloch East and North and Twechar,Cumbernauld and Kirkintilloch,East Dunbartonshire,East Dunbartonshire,S13002907,S14000072,S12000045,S12000045
+2024,2024,Central Buchan,Gordon and Buchan,Aberdeenshire,Aberdeenshire,S13002851,S14000091,S12000034,S12000034
+2024,2024,Kirkintilloch East and North and Twechar,Mid Dunbartonshire,East Dunbartonshire,East Dunbartonshire,S13002907,S14000097,S12000045,S12000045
+2024,2024,Peterhead North and Rattray,Aberdeenshire North and Moray East,Aberdeenshire,Aberdeenshire,S13002852,S14000062,S12000034,S12000034
+2024,2024,Dunfermline North,Cowdenbeath and Kirkcaldy,Fife,Fife,S13002946,S14000071,S12000047,S12000047
+2024,2024,Peterhead South and Cruden,Aberdeenshire North and Moray East,Aberdeenshire,Aberdeenshire,S13002853,S14000062,S12000034,S12000034
+2024,2024,Dunfermline North,Dunfermline and Dollar,Fife,Fife,S13002946,S14000076,S12000047,S12000047
+2024,2024,Turriff and District,Gordon and Buchan,Aberdeenshire,Aberdeenshire,S13002854,S14000091,S12000034,S12000034
+2024,2024,Dunfermline Central,Dunfermline and Dollar,Fife,Fife,S13002947,S14000076,S12000047,S12000047
+2024,2024,Mid Formartine,Gordon and Buchan,Aberdeenshire,Aberdeenshire,S13002855,S14000091,S12000034,S12000034
+2024,2024,Dunfermline South,Dunfermline and Dollar,Fife,Fife,S13002948,S14000076,S12000047,S12000047
+2024,2024,Ellon and District,Gordon and Buchan,Aberdeenshire,Aberdeenshire,S13002856,S14000091,S12000034,S12000034
+2024,2024,Rosyth,Dunfermline and Dollar,Fife,Fife,S13002949,S14000076,S12000047,S12000047
+2024,2024,West Garioch,Gordon and Buchan,Aberdeenshire,Aberdeenshire,S13002857,S14000091,S12000034,S12000034
+2024,2024,Inverkeithing and Dalgety Bay,Cowdenbeath and Kirkcaldy,Fife,Fife,S13002950,S14000071,S12000047,S12000047
+2024,2024,Linn,Glasgow South,Glasgow City,Glasgow City,S13002967,S14000087,S12000049,S12000049
+2024,2024,Culloden and Ardersier,"Moray West, Nairn and Strathspey",Highland,Highland,S13003006,S14000098,S12000017,S12000017
+2024,2024,West Garioch,West Aberdeenshire and Kincardine,Aberdeenshire,Aberdeenshire,S13002857,S14000111,S12000034,S12000034
+2024,2024,"Burntisland, Kinghorn and Western Kirkcaldy",Cowdenbeath and Kirkcaldy,Fife,Fife,S13002953,S14000071,S12000047,S12000047
+2024,2024,Newlands/Auldburn,Glasgow South,Glasgow City,Glasgow City,S13002968,S14000087,S12000049,S12000049
+2024,2024,Nairn and Cawdor,"Moray West, Nairn and Strathspey",Highland,Highland,S13003007,S14000098,S12000017,S12000017
+2024,2024,Inverurie and District,Gordon and Buchan,Aberdeenshire,Aberdeenshire,S13002858,S14000091,S12000034,S12000034
+2024,2024,Kirkcaldy North,Cowdenbeath and Kirkcaldy,Fife,Fife,S13002954,S14000071,S12000047,S12000047
+2024,2024,Newlands/Auldburn,Glasgow South West,Glasgow City,Glasgow City,S13002968,S14000088,S12000049,S12000049
+2024,2024,Inverness South,"Inverness, Skye and West Ross-shire",Highland,Highland,S13003008,S14000094,S12000017,S12000017
+2024,2024,East Garioch,Gordon and Buchan,Aberdeenshire,Aberdeenshire,S13002859,S14000091,S12000034,S12000034
+2024,2024,East Garioch,West Aberdeenshire and Kincardine,Aberdeenshire,Aberdeenshire,S13002859,S14000111,S12000034,S12000034
+2024,2024,Westhill and District,West Aberdeenshire and Kincardine,Aberdeenshire,Aberdeenshire,S13002860,S14000111,S12000034,S12000034
+2024,2024,Greater Pollok,Glasgow South West,Glasgow City,Glasgow City,S13002969,S14000088,S12000049,S12000049
+2024,2024,"Huntly, Strathbogie and Howe of Alford",Gordon and Buchan,Aberdeenshire,Aberdeenshire,S13002861,S14000091,S12000034,S12000034
+2024,2024,Kirkcaldy Central,Cowdenbeath and Kirkcaldy,Fife,Fife,S13002955,S14000071,S12000047,S12000047
+2024,2024,Badenoch and Strathspey,"Moray West, Nairn and Strathspey",Highland,Highland,S13003009,S14000098,S12000017,S12000017
+2024,2024,Kirkcaldy East,Cowdenbeath and Kirkcaldy,Fife,Fife,S13002956,S14000071,S12000047,S12000047
+2024,2024,Fort William and Ardnamurchan,"Argyll, Bute and South Lochaber",Highland,Highland,S13003010,S14000067,S12000017,S12000017
+2024,2024,"Glenrothes North, Leslie and Markinch",Glenrothes and Mid Fife,Fife,Fife,S13002958,S14000090,S12000047,S12000047
+2024,2024,Fort William and Ardnamurchan,"Inverness, Skye and West Ross-shire",Highland,Highland,S13003010,S14000094,S12000017,S12000017
+2024,2024,Glenrothes Central and Thornton,Glenrothes and Mid Fife,Fife,Fife,S13002959,S14000090,S12000047,S12000047
+2024,2024,Inverclyde East,Inverclyde and Renfrewshire West,Inverclyde,Inverclyde,S13003011,S14000093,S12000018,S12000018
+2024,2024,Howe of Fife and Tay Coast,North East Fife,Fife,Fife,S13002960,S14000100,S12000047,S12000047
+2024,2024,Inverclyde East Central,Inverclyde and Renfrewshire West,Inverclyde,Inverclyde,S13003012,S14000093,S12000018,S12000018
+2024,2024,Tay Bridgehead,North East Fife,Fife,Fife,S13002961,S14000100,S12000047,S12000047
+2024,2024,Inverclyde Central,Inverclyde and Renfrewshire West,Inverclyde,Inverclyde,S13003013,S14000093,S12000018,S12000018
+2024,2024,St Andrews,North East Fife,Fife,Fife,S13002962,S14000100,S12000047,S12000047
+2024,2024,Inverclyde North,Inverclyde and Renfrewshire West,Inverclyde,Inverclyde,S13003014,S14000093,S12000018,S12000018
+2024,2024,East Neuk and Landward,North East Fife,Fife,Fife,S13002963,S14000100,S12000047,S12000047
+2024,2024,Inverclyde West,Inverclyde and Renfrewshire West,Inverclyde,Inverclyde,S13003015,S14000093,S12000018,S12000018
+2024,2024,Cupar,North East Fife,Fife,Fife,S13002964,S14000100,S12000047,S12000047
+2024,2024,Inverclyde South West,Inverclyde and Renfrewshire West,Inverclyde,Inverclyde,S13003016,S14000093,S12000018,S12000018
+2024,2024,"Leven, Kennoway and Largo",North East Fife,Fife,Fife,S13002965,S14000100,S12000047,S12000047
+2024,2024,"Buckhaven, Methil and Wemyss Villages",Glenrothes and Mid Fife,Fife,Fife,S13002966,S14000090,S12000047,S12000047
+2024,2024,Cowdenbeath,Cowdenbeath and Kirkcaldy,Fife,Fife,S13003128,S14000071,S12000047,S12000047
+2024,2024,Cardonald,Glasgow South West,Glasgow City,Glasgow City,S13002970,S14000088,S12000049,S12000049
+2024,2024,Cardonald,Paisley and Renfrewshire North,Glasgow City,Glasgow City,S13002970,S14000101,S12000049,S12000049
+2024,2024,Govan,Glasgow South West,Glasgow City,Glasgow City,S13002971,S14000088,S12000049,S12000049
+2024,2024,Pollokshields,Glasgow South,Glasgow City,Glasgow City,S13002972,S14000087,S12000049,S12000049
+2024,2024,Pollokshields,Glasgow South West,Glasgow City,Glasgow City,S13002972,S14000088,S12000049,S12000049
+2024,2024,Langside,Glasgow South,Glasgow City,Glasgow City,S13002973,S14000087,S12000049,S12000049
+2024,2024,Southside Central,Glasgow East,Glasgow City,Glasgow City,S13002974,S14000084,S12000049,S12000049
+2024,2024,Southside Central,Glasgow South,Glasgow City,Glasgow City,S13002974,S14000087,S12000049,S12000049
+2024,2024,Calton,Glasgow East,Glasgow City,Glasgow City,S13002975,S14000084,S12000049,S12000049
+2024,2024,Calton,Glasgow North East,Glasgow City,Glasgow City,S13002975,S14000086,S12000049,S12000049
+2024,2024,Anderston/City/Yorkhill,Glasgow East,Glasgow City,Glasgow City,S13002976,S14000084,S12000049,S12000049
+2024,2024,Anderston/City/Yorkhill,Glasgow North,Glasgow City,Glasgow City,S13002976,S14000085,S12000049,S12000049
+2024,2024,Anderston/City/Yorkhill,Glasgow North East,Glasgow City,Glasgow City,S13002976,S14000086,S12000049,S12000049
+2024,2024,Hillhead,Glasgow North,Glasgow City,Glasgow City,S13002977,S14000085,S12000049,S12000049
+2024,2024,Victoria Park,Glasgow West,Glasgow City,Glasgow City,S13002978,S14000089,S12000049,S12000049
+2024,2024,Garscadden/Scotstounhill,Glasgow West,Glasgow City,Glasgow City,S13002979,S14000089,S12000049,S12000049
+2024,2024,Garscadden/Scotstounhill,West Dunbartonshire,Glasgow City,Glasgow City,S13002979,S14000106,S12000049,S12000049
+2024,2024,Drumchapel/Anniesland,Glasgow West,Glasgow City,Glasgow City,S13002980,S14000089,S12000049,S12000049
+2024,2024,Maryhill,Glasgow North,Glasgow City,Glasgow City,S13002981,S14000085,S12000049,S12000049
+2024,2024,Canal,Glasgow North,Glasgow City,Glasgow City,S13002982,S14000085,S12000049,S12000049
+2024,2024,Springburn/Robroyston,Glasgow North East,Glasgow City,Glasgow City,S13002983,S14000086,S12000049,S12000049
+2024,2024,East Centre,Glasgow North East,Glasgow City,Glasgow City,S13002984,S14000086,S12000049,S12000049
+2024,2024,Shettleston,Glasgow East,Glasgow City,Glasgow City,S13002985,S14000084,S12000049,S12000049
+2024,2024,Baillieston,Glasgow East,Glasgow City,Glasgow City,S13002986,S14000084,S12000049,S12000049
+2024,2024,Baillieston,Glasgow North East,Glasgow City,Glasgow City,S13002986,S14000086,S12000049,S12000049
+2024,2024,Dennistoun,Glasgow North East,Glasgow City,Glasgow City,S13002988,S14000086,S12000049,S12000049
+2024,2024,Partick East/Kelvindale,Glasgow North,Glasgow City,Glasgow City,S13002989,S14000085,S12000049,S12000049
+2024,2024,"Huntly, Strathbogie and Howe of Alford",West Aberdeenshire and Kincardine,Aberdeenshire,Aberdeenshire,S13002861,S14000111,S12000034,S12000034
+2024,2024,"Aboyne, Upper Deeside and Donside",West Aberdeenshire and Kincardine,Aberdeenshire,Aberdeenshire,S13002862,S14000111,S12000034,S12000034
+2024,2024,Banchory and Mid Deeside,West Aberdeenshire and Kincardine,Aberdeenshire,Aberdeenshire,S13002863,S14000111,S12000034,S12000034
+2024,2024,North Kincardine,West Aberdeenshire and Kincardine,Aberdeenshire,Aberdeenshire,S13002864,S14000111,S12000034,S12000034
+2024,2024,Stonehaven and Lower Deeside,West Aberdeenshire and Kincardine,Aberdeenshire,Aberdeenshire,S13002865,S14000111,S12000034,S12000034
+2024,2024,Mearns,West Aberdeenshire and Kincardine,Aberdeenshire,Aberdeenshire,S13002866,S14000111,S12000034,S12000034
+2024,2024,South Kintyre,"Argyll, Bute and South Lochaber",Argyll and Bute,Argyll and Bute,S13002516,S14000067,S12000035,S12000035
+2024,2024,Kintyre and the Islands,"Argyll, Bute and South Lochaber",Argyll and Bute,Argyll and Bute,S13002517,S14000067,S12000035,S12000035
+2024,2024,Mid Argyll,"Argyll, Bute and South Lochaber",Argyll and Bute,Argyll and Bute,S13002518,S14000067,S12000035,S12000035
+2024,2024,Oban South and the Isles,"Argyll, Bute and South Lochaber",Argyll and Bute,Argyll and Bute,S13002519,S14000067,S12000035,S12000035
+2024,2024,Oban North and Lorn,"Argyll, Bute and South Lochaber",Argyll and Bute,Argyll and Bute,S13002520,S14000067,S12000035,S12000035
+2024,2024,Cowal,"Argyll, Bute and South Lochaber",Argyll and Bute,Argyll and Bute,S13002521,S14000067,S12000035,S12000035
+2024,2024,Dunoon,"Argyll, Bute and South Lochaber",Argyll and Bute,Argyll and Bute,S13002522,S14000067,S12000035,S12000035
+2024,2024,Isle of Bute,"Argyll, Bute and South Lochaber",Argyll and Bute,Argyll and Bute,S13002523,S14000067,S12000035,S12000035
+2024,2024,Lomond North,"Argyll, Bute and South Lochaber",Argyll and Bute,Argyll and Bute,S13002524,S14000067,S12000035,S12000035
+2024,2024,Helensburgh Central,"Argyll, Bute and South Lochaber",Argyll and Bute,Argyll and Bute,S13002525,S14000067,S12000035,S12000035
+2024,2024,Helensburgh and Lomond South,"Argyll, Bute and South Lochaber",Argyll and Bute,Argyll and Bute,S13002526,S14000067,S12000035,S12000035
+2024,2024,Almond,Edinburgh North and Leith,City of Edinburgh,City of Edinburgh,S13002919,S14000079,S12000036,S12000036
+2024,2024,Almond,Edinburgh South West,City of Edinburgh,City of Edinburgh,S13002919,S14000081,S12000036,S12000036
+2024,2024,Almond,Edinburgh West,City of Edinburgh,City of Edinburgh,S13002919,S14000082,S12000036,S12000036
+2024,2024,Pentland Hills,Edinburgh South West,City of Edinburgh,City of Edinburgh,S13002920,S14000081,S12000036,S12000036
+2024,2024,Pentland Hills,Edinburgh West,City of Edinburgh,City of Edinburgh,S13002920,S14000082,S12000036,S12000036
+2024,2024,Drum Brae/Gyle,Edinburgh South West,City of Edinburgh,City of Edinburgh,S13002921,S14000081,S12000036,S12000036
+2024,2024,Drum Brae/Gyle,Edinburgh West,City of Edinburgh,City of Edinburgh,S13002921,S14000082,S12000036,S12000036
+2024,2024,Forth,Edinburgh North and Leith,City of Edinburgh,City of Edinburgh,S13002922,S14000079,S12000036,S12000036
+2024,2024,Inverleith,Edinburgh North and Leith,City of Edinburgh,City of Edinburgh,S13002923,S14000079,S12000036,S12000036
+2024,2024,Inverleith,Edinburgh West,City of Edinburgh,City of Edinburgh,S13002923,S14000082,S12000036,S12000036
+2024,2024,Partick East/Kelvindale,Glasgow West,Glasgow City,Glasgow City,S13002989,S14000089,S12000049,S12000049
+2024,2024,Waunfawr,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001565,W07000096,W06000002,W06000002
+2024,2024,Y Bala,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001566,W07000096,W06000002,W06000002
+2024,2024,Y Bontnewydd,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001567,W07000096,W06000002,W06000002
+2024,2024,Y Faenol,Bangor Aberconwy,Gwynedd,Gwynedd,W05001568,W07000083,W06000002,W06000002
+2024,2024,Y Groeslon,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001569,W07000096,W06000002,W06000002
+2024,2024,Yr Eifl,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001570,W07000096,W06000002,W06000002
+2024,2024,Betws-yn-Rhos,Bangor Aberconwy,Conwy,Conwy,W05001403,W07000083,W06000003,W06000003
+2024,2024,Betws-y-Coed and Trefriw,Bangor Aberconwy,Conwy,Conwy,W05001404,W07000083,W06000003,W06000003
+2024,2024,Bryn,Bangor Aberconwy,Conwy,Conwy,W05001405,W07000083,W06000003,W06000003
+2024,2024,Caerhun,Bangor Aberconwy,Conwy,Conwy,W05001406,W07000083,W06000003,W06000003
+2024,2024,Colwyn,Clwyd North,Conwy,Conwy,W05001407,W07000095,W06000003,W06000003
+2024,2024,Conwy,Bangor Aberconwy,Conwy,Conwy,W05001408,W07000083,W06000003,W06000003
+2024,2024,Craig-y-don,Bangor Aberconwy,Conwy,Conwy,W05001409,W07000083,W06000003,W06000003
+2024,2024,Deganwy,Bangor Aberconwy,Conwy,Conwy,W05001410,W07000083,W06000003,W06000003
+2024,2024,Eglwys-bach a Llangernyw,Bangor Aberconwy,Conwy,Conwy,W05001411,W07000083,W06000003,W06000003
+2024,2024,Eirias,Clwyd North,Conwy,Conwy,W05001412,W07000095,W06000003,W06000003
+2024,2024,Gele and Llanddulas,Clwyd North,Conwy,Conwy,W05001413,W07000095,W06000003,W06000003
+2024,2024,Glyn,Clwyd North,Conwy,Conwy,W05001414,W07000095,W06000003,W06000003
+2024,2024,Glyn y Marl,Bangor Aberconwy,Conwy,Conwy,W05001415,W07000083,W06000003,W06000003
+2024,2024,Gogarth Mostyn,Bangor Aberconwy,Conwy,Conwy,W05001416,W07000083,W06000003,W06000003
+2024,2024,Kinmel Bay,Clwyd North,Conwy,Conwy,W05001417,W07000095,W06000003,W06000003
+2024,2024,Llandrillo-yn-Rhos,Clwyd North,Conwy,Conwy,W05001418,W07000095,W06000003,W06000003
+2024,2024,Llanrwst a Llanddoged,Bangor Aberconwy,Conwy,Conwy,W05001419,W07000083,W06000003,W06000003
+2024,2024,Llansanffraid,Bangor Aberconwy,Conwy,Conwy,W05001420,W07000083,W06000003,W06000003
+2024,2024,Llansannan,Bangor Aberconwy,Conwy,Conwy,W05001421,W07000083,W06000003,W06000003
+2024,2024,Llysfaen,Clwyd North,Conwy,Conwy,W05001422,W07000095,W06000003,W06000003
+2024,2024,Mochdre,Clwyd North,Conwy,Conwy,W05001423,W07000095,W06000003,W06000003
+2024,2024,Pandy,Bangor Aberconwy,Conwy,Conwy,W05001424,W07000083,W06000003,W06000003
+2024,2024,Penmaenmawr,Bangor Aberconwy,Conwy,Conwy,W05001425,W07000083,W06000003,W06000003
+2024,2024,Penrhyn,Bangor Aberconwy,Conwy,Conwy,W05001426,W07000083,W06000003,W06000003
+2024,2024,Pen-sarn Pentre Mawr,Clwyd North,Conwy,Conwy,W05001427,W07000095,W06000003,W06000003
+2024,2024,Rhiw,Clwyd North,Conwy,Conwy,W05001428,W07000095,W06000003,W06000003
+2024,2024,Towyn,Clwyd North,Conwy,Conwy,W05001429,W07000095,W06000003,W06000003
+2024,2024,Tudno,Bangor Aberconwy,Conwy,Conwy,W05001430,W07000083,W06000003,W06000003
+2024,2024,Uwch Aled,Bangor Aberconwy,Conwy,Conwy,W05001431,W07000083,W06000003,W06000003
+2024,2024,Uwch Conwy,Bangor Aberconwy,Conwy,Conwy,W05001432,W07000083,W06000003,W06000003
+2024,2024,Alyn Valley,Clwyd East,Denbighshire,Denbighshire,W05001332,W07000094,W06000004,W06000004
+2024,2024,Bodelwyddan,Clwyd North,Denbighshire,Denbighshire,W05001333,W07000095,W06000004,W06000004
+2024,2024,Denbigh Caledfryn Henllan,Clwyd North,Denbighshire,Denbighshire,W05001334,W07000095,W06000004,W06000004
+2024,2024,Denbigh Lower,Clwyd North,Denbighshire,Denbighshire,W05001335,W07000095,W06000004,W06000004
+2024,2024,Dyserth,Clwyd East,Denbighshire,Denbighshire,W05001336,W07000094,W06000004,W06000004
+2024,2024,Edeirnion,Dwyfor Meirionnydd,Denbighshire,Denbighshire,W05001337,W07000096,W06000004,W06000004
+2024,2024,Efenechdyd,Bangor Aberconwy,Denbighshire,Denbighshire,W05001338,W07000083,W06000004,W06000004
+2024,2024,Llandyrnog,Clwyd East,Denbighshire,Denbighshire,W05001339,W07000094,W06000004,W06000004
+2024,2024,Llanfair Dyffryn Clwyd Gwyddelwern,Clwyd East,Denbighshire,Denbighshire,W05001340,W07000094,W06000004,W06000004
+2024,2024,Llangollen,Clwyd East,Denbighshire,Denbighshire,W05001341,W07000094,W06000004,W06000004
+2024,2024,Llanrhaeadr-yng-Nghinmeirch,Bangor Aberconwy,Denbighshire,Denbighshire,W05001342,W07000083,W06000004,W06000004
+2024,2024,Moel Famau,Clwyd East,Denbighshire,Denbighshire,W05001343,W07000094,W06000004,W06000004
+2024,2024,Prestatyn Central,Clwyd East,Denbighshire,Denbighshire,W05001344,W07000094,W06000004,W06000004
+2024,2024,Prestatyn East,Clwyd East,Denbighshire,Denbighshire,W05001345,W07000094,W06000004,W06000004
+2024,2024,North East,Glasgow North East,Glasgow City,Glasgow City,S13003133,S14000086,S12000049,S12000049
+2024,2024,The Havens,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001490,W07000100,W06000009,W06000009
+2024,2024,Bro Dysynni,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001515,W07000096,W06000002,W06000002
+2024,2024,Crymych and Mynachlog-ddu,Ceredigion Preseli,Pembrokeshire,Pembrokeshire,W05001440,W07000093,W06000009,W06000009
+2024,2024,Mold West,Clwyd East,Flintshire,Flintshire,W05001606,W07000094,W06000005,W06000005
+2024,2024,East Williamston,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001441,W07000100,W06000009,W06000009
+2024,2024,Fishguard: North East,Ceredigion Preseli,Pembrokeshire,Pembrokeshire,W05001442,W07000093,W06000009,W06000009
+2024,2024,Fishguard: North West,Ceredigion Preseli,Pembrokeshire,Pembrokeshire,W05001443,W07000093,W06000009,W06000009
+2024,2024,Goodwick,Ceredigion Preseli,Pembrokeshire,Pembrokeshire,W05001444,W07000093,W06000009,W06000009
+2024,2024,Haverfordwest: Castle,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001445,W07000100,W06000009,W06000009
+2024,2024,Haverfordwest: Garth,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001446,W07000100,W06000009,W06000009
+2024,2024,Haverfordwest: Portfield,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001447,W07000100,W06000009,W06000009
+2024,2024,Haverfordwest: Prendergast,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001448,W07000100,W06000009,W06000009
+2024,2024,Haverfordwest: Priory,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001449,W07000100,W06000009,W06000009
+2024,2024,Hundleton,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001450,W07000100,W06000009,W06000009
+2024,2024,Johnston,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001451,W07000100,W06000009,W06000009
+2024,2024,Queensway,Wrexham,Wrexham,Wrexham,W05001753,W07000111,W06000006,W06000006
+2024,2024,Prestatyn Meliden,Clwyd East,Denbighshire,Denbighshire,W05001346,W07000094,W06000004,W06000004
+2024,2024,Kilgetty and Begelly,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001452,W07000100,W06000009,W06000009
+2024,2024,Lampeter Velfrey,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001453,W07000100,W06000009,W06000009
+2024,2024,Lamphey,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001454,W07000100,W06000009,W06000009
+2024,2024,Letterston,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001455,W07000100,W06000009,W06000009
+2024,2024,Llangwm,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001456,W07000100,W06000009,W06000009
+2024,2024,Llanrhian,Ceredigion Preseli,Pembrokeshire,Pembrokeshire,W05001457,W07000093,W06000009,W06000009
+2024,2024,Maenclochog,Ceredigion Preseli,Pembrokeshire,Pembrokeshire,W05001458,W07000093,W06000009,W06000009
+2024,2024,Manorbier and Penally,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001459,W07000100,W06000009,W06000009
+2024,2024,Martletwy,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001460,W07000100,W06000009,W06000009
+2024,2024,Merlin's Bridge,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001461,W07000100,W06000009,W06000009
+2024,2024,Milford: Central,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001462,W07000100,W06000009,W06000009
+2024,2024,Milford: East,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001463,W07000100,W06000009,W06000009
+2024,2024,Milford: Hakin,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001464,W07000100,W06000009,W06000009
+2024,2024,Milford: Hubberston,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001465,W07000100,W06000009,W06000009
+2024,2024,Milford: North,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001466,W07000100,W06000009,W06000009
+2024,2024,Milford: West,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001467,W07000100,W06000009,W06000009
+2024,2024,Narberth: Urban,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001468,W07000100,W06000009,W06000009
+2024,2024,Narberth: Rural,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001469,W07000100,W06000009,W06000009
+2024,2024,Newport and Dinas,Ceredigion Preseli,Pembrokeshire,Pembrokeshire,W05001470,W07000093,W06000009,W06000009
+2024,2024,Neyland: East,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001471,W07000100,W06000009,W06000009
+2024,2024,Neyland: West,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001472,W07000100,W06000009,W06000009
+2024,2024,Mostyn,Clwyd East,Flintshire,Flintshire,W05001607,W07000094,W06000005,W06000005
+2024,2024,Wiston,Ceredigion Preseli,Pembrokeshire,Pembrokeshire,W05001491,W07000093,W06000009,W06000009
+2024,2024,Kilsyth,Cumbernauld and Kirkintilloch,North Lanarkshire,North Lanarkshire,S13003042,S14000072,S12000050,S12000050
+2024,2024,Cadnant,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001516,W07000096,W06000002,W06000002
+2024,2024,Pembroke Dock: Bufferland,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001473,W07000100,W06000009,W06000009
+2024,2024,Pembroke Dock: Bush,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001474,W07000100,W06000009,W06000009
+2024,2024,Pembroke Dock: Central,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001475,W07000100,W06000009,W06000009
+2024,2024,Pembroke Dock: Market,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001476,W07000100,W06000009,W06000009
+2024,2024,Pembroke Dock: Pennar,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001477,W07000100,W06000009,W06000009
+2024,2024,Pembroke: Monkton and St Mary South,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001478,W07000100,W06000009,W06000009
+2024,2024,Pembroke: St Mary North,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001479,W07000100,W06000009,W06000009
+2024,2024,Pembroke: St Michael,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001480,W07000100,W06000009,W06000009
+2024,2024,Rudbaxton and Spittal,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001481,W07000100,W06000009,W06000009
+2024,2024,Saundersfoot South,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001482,W07000100,W06000009,W06000009
+2024,2024,Solva,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001483,W07000100,W06000009,W06000009
+2024,2024,St David's,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001484,W07000100,W06000009,W06000009
+2024,2024,St Dogmaels,Ceredigion Preseli,Pembrokeshire,Pembrokeshire,W05001485,W07000093,W06000009,W06000009
+2024,2024,St Florence and St Mary Out Liberty,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001486,W07000100,W06000009,W06000009
+2024,2024,St Ishmael's,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001487,W07000100,W06000009,W06000009
+2024,2024,Tenby: North,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001488,W07000100,W06000009,W06000009
+2024,2024,Tenby: South,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001489,W07000100,W06000009,W06000009
+2024,2024,Northop,Clwyd East,Flintshire,Flintshire,W05001608,W07000094,W06000005,W06000005
+2024,2024,Pen-y-ffordd,Alyn and Deeside,Flintshire,Flintshire,W05001609,W07000082,W06000005,W06000005
+2024,2024,Queensferry and Sealand,Alyn and Deeside,Flintshire,Flintshire,W05001610,W07000082,W06000005,W06000005
+2024,2024,Saltney Ferry,Alyn and Deeside,Flintshire,Flintshire,W05001611,W07000082,W06000005,W06000005
+2024,2024,Shotton East and Shotton Higher,Alyn and Deeside,Flintshire,Flintshire,W05001612,W07000082,W06000005,W06000005
+2024,2024,Shotton West,Alyn and Deeside,Flintshire,Flintshire,W05001613,W07000082,W06000005,W06000005
+2024,2024,Treuddyn,Alyn and Deeside,Flintshire,Flintshire,W05001614,W07000082,W06000005,W06000005
+2024,2024,Whitford,Clwyd East,Flintshire,Flintshire,W05001615,W07000094,W06000005,W06000005
+2024,2024,Acrefair North,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001713,W07000102,W06000006,W06000006
+2024,2024,Acton and Maesydre,Wrexham,Wrexham,Wrexham,W05001714,W07000111,W06000006,W06000006
+2024,2024,Bangor Is-y-Coed,Wrexham,Wrexham,Wrexham,W05001715,W07000111,W06000006,W06000006
+2024,2024,Wiston,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001491,W07000100,W06000009,W06000009
+2024,2024,Prestatyn North,Clwyd East,Denbighshire,Denbighshire,W05001347,W07000094,W06000004,W06000004
+2024,2024,Abergwili,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001177,W07000087,W06000010,W06000010
+2024,2024,Ammanford,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001178,W07000087,W06000010,W06000010
+2024,2024,Prestatyn South West,Clwyd East,Denbighshire,Denbighshire,W05001348,W07000094,W06000004,W06000004
+2024,2024,Betws,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001179,W07000087,W06000010,W06000010
+2024,2024,Rhuddlan,Clwyd North,Denbighshire,Denbighshire,W05001349,W07000095,W06000004,W06000004
+2024,2024,Bigyn,Llanelli,Carmarthenshire,Carmarthenshire,W05001180,W07000098,W06000010,W06000010
+2024,2024,Rhyl East,Clwyd North,Denbighshire,Denbighshire,W05001350,W07000095,W06000004,W06000004
+2024,2024,Burry Port,Llanelli,Carmarthenshire,Carmarthenshire,W05001181,W07000098,W06000010,W06000010
+2024,2024,Rhyl South,Clwyd North,Denbighshire,Denbighshire,W05001351,W07000095,W06000004,W06000004
+2024,2024,Bynea,Llanelli,Carmarthenshire,Carmarthenshire,W05001182,W07000098,W06000010,W06000010
+2024,2024,Rhyl South West,Clwyd North,Denbighshire,Denbighshire,W05001352,W07000095,W06000004,W06000004
+2024,2024,Carmarthen Town North and South,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001183,W07000087,W06000010,W06000010
+2024,2024,Rhyl Trellewelyn,Clwyd North,Denbighshire,Denbighshire,W05001353,W07000095,W06000004,W06000004
+2024,2024,Carmarthen Town West,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001184,W07000087,W06000010,W06000010
+2024,2024,Rhyl Tŷ Newydd,Clwyd North,Denbighshire,Denbighshire,W05001354,W07000095,W06000004,W06000004
+2024,2024,Cenarth and Llangeler,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001185,W07000087,W06000010,W06000010
+2024,2024,Rhyl West,Clwyd North,Denbighshire,Denbighshire,W05001355,W07000095,W06000004,W06000004
+2024,2024,Cumbernauld North,Cumbernauld and Kirkintilloch,North Lanarkshire,North Lanarkshire,S13003043,S14000072,S12000050,S12000050
+2024,2024,Ruthin,Clwyd East,Denbighshire,Denbighshire,W05001356,W07000094,W06000004,W06000004
+2024,2024,St Asaph East,Clwyd North,Denbighshire,Denbighshire,W05001357,W07000095,W06000004,W06000004
+2024,2024,St Asaph West,Clwyd North,Denbighshire,Denbighshire,W05001358,W07000095,W06000004,W06000004
+2024,2024,Trefnant,Clwyd North,Denbighshire,Denbighshire,W05001359,W07000095,W06000004,W06000004
+2024,2024,Canol Bangor,Bangor Aberconwy,Gwynedd,Gwynedd,W05001517,W07000083,W06000002,W06000002
+2024,2024,Tremeirchion,Clwyd East,Denbighshire,Denbighshire,W05001360,W07000094,W06000004,W06000004
+2024,2024,Argoed and New Brighton,Clwyd East,Flintshire,Flintshire,W05001571,W07000094,W06000005,W06000005
+2024,2024,Bagillt,Alyn and Deeside,Flintshire,Flintshire,W05001572,W07000082,W06000005,W06000005
+2024,2024,Broughton North East,Alyn and Deeside,Flintshire,Flintshire,W05001573,W07000082,W06000005,W06000005
+2024,2024,Broughton South,Alyn and Deeside,Flintshire,Flintshire,W05001574,W07000082,W06000005,W06000005
+2024,2024,Brynford and Halkyn,Clwyd East,Flintshire,Flintshire,W05001575,W07000094,W06000005,W06000005
+2024,2024,Buckley: Bistre East,Alyn and Deeside,Flintshire,Flintshire,W05001576,W07000082,W06000005,W06000005
+2024,2024,Buckley: Bistre West,Alyn and Deeside,Flintshire,Flintshire,W05001577,W07000082,W06000005,W06000005
+2024,2024,Buckley: Mountain,Alyn and Deeside,Flintshire,Flintshire,W05001578,W07000082,W06000005,W06000005
+2024,2024,Buckley: Pentrobin,Alyn and Deeside,Flintshire,Flintshire,W05001579,W07000082,W06000005,W06000005
+2024,2024,Caergwrle,Alyn and Deeside,Flintshire,Flintshire,W05001580,W07000082,W06000005,W06000005
+2024,2024,Caerwys,Clwyd East,Flintshire,Flintshire,W05001581,W07000094,W06000005,W06000005
+2024,2024,Cilcain,Clwyd East,Flintshire,Flintshire,W05001582,W07000094,W06000005,W06000005
+2024,2024,Connah's Quay Central,Alyn and Deeside,Flintshire,Flintshire,W05001583,W07000082,W06000005,W06000005
+2024,2024,Connah's Quay: Golftyn,Alyn and Deeside,Flintshire,Flintshire,W05001584,W07000082,W06000005,W06000005
+2024,2024,Connah's Quay South,Alyn and Deeside,Flintshire,Flintshire,W05001585,W07000082,W06000005,W06000005
+2024,2024,Connah's Quay: Wepre,Alyn and Deeside,Flintshire,Flintshire,W05001586,W07000082,W06000005,W06000005
+2024,2024,Flint: Castle,Alyn and Deeside,Flintshire,Flintshire,W05001587,W07000082,W06000005,W06000005
+2024,2024,Flint: Coleshill and Trelawny,Alyn and Deeside,Flintshire,Flintshire,W05001588,W07000082,W06000005,W06000005
+2024,2024,Flint: Oakenholt,Alyn and Deeside,Flintshire,Flintshire,W05001589,W07000082,W06000005,W06000005
+2024,2024,Greenfield,Clwyd East,Flintshire,Flintshire,W05001590,W07000094,W06000005,W06000005
+2024,2024,Gwernaffield and Gwernymynydd,Clwyd East,Flintshire,Flintshire,W05001591,W07000094,W06000005,W06000005
+2024,2024,Hawarden: Aston,Alyn and Deeside,Flintshire,Flintshire,W05001592,W07000082,W06000005,W06000005
+2024,2024,Hawarden: Ewloe,Alyn and Deeside,Flintshire,Flintshire,W05001593,W07000082,W06000005,W06000005
+2024,2024,Hawarden: Mancot,Alyn and Deeside,Flintshire,Flintshire,W05001594,W07000082,W06000005,W06000005
+2024,2024,Higher Kinnerton,Alyn and Deeside,Flintshire,Flintshire,W05001595,W07000082,W06000005,W06000005
+2024,2024,Holywell Central,Clwyd East,Flintshire,Flintshire,W05001596,W07000094,W06000005,W06000005
+2024,2024,Holywell East,Clwyd East,Flintshire,Flintshire,W05001597,W07000094,W06000005,W06000005
+2024,2024,Holywell West,Clwyd East,Flintshire,Flintshire,W05001598,W07000094,W06000005,W06000005
+2024,2024,Hope,Alyn and Deeside,Flintshire,Flintshire,W05001599,W07000082,W06000005,W06000005
+2024,2024,Leeswood,Clwyd East,Flintshire,Flintshire,W05001600,W07000094,W06000005,W06000005
+2024,2024,Llanasa and Trelawnyd,Clwyd East,Flintshire,Flintshire,W05001601,W07000094,W06000005,W06000005
+2024,2024,Llanfynydd,Alyn and Deeside,Flintshire,Flintshire,W05001602,W07000082,W06000005,W06000005
+2024,2024,Mold: Broncoed,Clwyd East,Flintshire,Flintshire,W05001603,W07000094,W06000005,W06000005
+2024,2024,Mold East,Clwyd East,Flintshire,Flintshire,W05001604,W07000094,W06000005,W06000005
+2024,2024,Mold South,Clwyd East,Flintshire,Flintshire,W05001605,W07000094,W06000005,W06000005
+2024,2024,Borras Park,Wrexham,Wrexham,Wrexham,W05001716,W07000111,W06000006,W06000006
+2024,2024,Rhos,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001754,W07000102,W06000006,W06000006
+2024,2024,Canol Bethesda,Bangor Aberconwy,Gwynedd,Gwynedd,W05001518,W07000083,W06000002,W06000002
+2024,2024,Canol Tref Caernarfon,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001519,W07000096,W06000002,W06000002
+2024,2024,Clynnog,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001520,W07000096,W06000002,W06000002
+2024,2024,Corris a Mawddwy,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001521,W07000096,W06000002,W06000002
+2024,2024,Criccieth,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001522,W07000096,W06000002,W06000002
+2024,2024,Cwm-y-glo,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001523,W07000096,W06000002,W06000002
+2024,2024,De Dolgellau,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001524,W07000096,W06000002,W06000002
+2024,2024,De Pwllheli,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001525,W07000096,W06000002,W06000002
+2024,2024,Deiniolen,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001526,W07000096,W06000002,W06000002
+2024,2024,Dewi,Bangor Aberconwy,Gwynedd,Gwynedd,W05001527,W07000083,W06000002,W06000002
+2024,2024,Diffwys a Maenofferen,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001528,W07000096,W06000002,W06000002
+2024,2024,Dolbenmaen,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001529,W07000096,W06000002,W06000002
+2024,2024,Dwyrain Bangor,Bangor Aberconwy,Gwynedd,Gwynedd,W05001530,W07000083,W06000002,W06000002
+2024,2024,Dwyrain Porthmadog,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001531,W07000096,W06000002,W06000002
+2024,2024,Dyffryn Ardudwy,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001532,W07000096,W06000002,W06000002
+2024,2024,Efailnewydd a Buan,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001533,W07000096,W06000002,W06000002
+2024,2024,Gerlan,Bangor Aberconwy,Gwynedd,Gwynedd,W05001534,W07000083,W06000002,W06000002
+2024,2024,Glaslyn,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001535,W07000096,W06000002,W06000002
+2024,2024,Glyder,Bangor Aberconwy,Gwynedd,Gwynedd,W05001536,W07000083,W06000002,W06000002
+2024,2024,Gogledd Dolgellau,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001537,W07000096,W06000002,W06000002
+2024,2024,Gogledd Pwllheli,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001538,W07000096,W06000002,W06000002
+2024,2024,Gorllewin Porthmadog,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001539,W07000096,W06000002,W06000002
+2024,2024,Gorllewin Tywyn,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001540,W07000096,W06000002,W06000002
+2024,2024,Harlech a Llanbedr,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001541,W07000096,W06000002,W06000002
+2024,2024,Hendre,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001542,W07000096,W06000002,W06000002
+2024,2024,Llanbedrog gyda Mynytho,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001543,W07000096,W06000002,W06000002
+2024,2024,Llanberis,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001544,W07000096,W06000002,W06000002
+2024,2024,Llandderfel,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001545,W07000096,W06000002,W06000002
+2024,2024,Llanllyfni,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001546,W07000096,W06000002,W06000002
+2024,2024,Llanrug,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001547,W07000096,W06000002,W06000002
+2024,2024,Llanuwchllyn,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001548,W07000096,W06000002,W06000002
+2024,2024,Llanwnda,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001549,W07000096,W06000002,W06000002
+2024,2024,Rhosnesni,Wrexham,Wrexham,Wrexham,W05001755,W07000111,W06000006,W06000006
+2024,2024,Cilycwm,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001186,W07000087,W06000010,W06000010
+2024,2024,Bronington and Hanmer,Wrexham,Wrexham,Wrexham,W05001717,W07000111,W06000006,W06000006
+2024,2024,Llanystumdwy,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001550,W07000096,W06000002,W06000002
+2024,2024,Menai,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001551,W07000096,W06000002,W06000002
+2024,2024,Morfa Nefyn a Thudweiliog,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001552,W07000096,W06000002,W06000002
+2024,2024,Morfa Tywyn,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001553,W07000096,W06000002,W06000002
+2024,2024,Nefyn,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001554,W07000096,W06000002,W06000002
+2024,2024,Peblig,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001555,W07000096,W06000002,W06000002
+2024,2024,Pen draw Llŷn,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001556,W07000096,W06000002,W06000002
+2024,2024,Penisa'r-waun,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001557,W07000096,W06000002,W06000002
+2024,2024,Penrhyndeudraeth,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001558,W07000096,W06000002,W06000002
+2024,2024,Pen-y-groes,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001559,W07000096,W06000002,W06000002
+2024,2024,Rachub,Bangor Aberconwy,Gwynedd,Gwynedd,W05001560,W07000083,W06000002,W06000002
+2024,2024,Teigl,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001561,W07000096,W06000002,W06000002
+2024,2024,Trawsfynydd,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001562,W07000096,W06000002,W06000002
+2024,2024,Tre-garth a Mynydd Llandygái,Bangor Aberconwy,Gwynedd,Gwynedd,W05001563,W07000083,W06000002,W06000002
+2024,2024,Tryfan,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001564,W07000096,W06000002,W06000002
+2024,2024,Cumbernauld South,Cumbernauld and Kirkintilloch,North Lanarkshire,North Lanarkshire,S13003044,S14000072,S12000050,S12000050
+2024,2024,Brymbo,Wrexham,Wrexham,Wrexham,W05001718,W07000111,W06000006,W06000006
+2024,2024,Bryn Cefn,Wrexham,Wrexham,Wrexham,W05001719,W07000111,W06000006,W06000006
+2024,2024,Brynyffynnon,Wrexham,Wrexham,Wrexham,W05001720,W07000111,W06000006,W06000006
+2024,2024,Cartrefle,Wrexham,Wrexham,Wrexham,W05001721,W07000111,W06000006,W06000006
+2024,2024,Cefn East,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001722,W07000102,W06000006,W06000006
+2024,2024,Cefn West,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001723,W07000102,W06000006,W06000006
+2024,2024,Chirk North,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001724,W07000102,W06000006,W06000006
+2024,2024,Chirk South,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001725,W07000102,W06000006,W06000006
+2024,2024,Coedpoeth,Wrexham,Wrexham,Wrexham,W05001726,W07000111,W06000006,W06000006
+2024,2024,Dyffryn Ceiriog,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001727,W07000102,W06000006,W06000006
+2024,2024,Erddig,Wrexham,Wrexham,Wrexham,W05001728,W07000111,W06000006,W06000006
+2024,2024,Esclusham,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001729,W07000102,W06000006,W06000006
+2024,2024,Cumbernauld East,Cumbernauld and Kirkintilloch,North Lanarkshire,North Lanarkshire,S13003045,S14000072,S12000050,S12000050
+2024,2024,Rossett,Wrexham,Wrexham,Wrexham,W05001756,W07000111,W06000006,W06000006
+2024,2024,"Gartcosh, Glenboig and Moodiesburn",Coatbridge and Bellshill,North Lanarkshire,North Lanarkshire,S13003047,S14000070,S12000050,S12000050
+2024,2024,Coatbridge North,Coatbridge and Bellshill,North Lanarkshire,North Lanarkshire,S13003048,S14000070,S12000050,S12000050
+2024,2024,Ruabon,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001757,W07000102,W06000006,W06000006
+2024,2024,Airdrie North,Airdrie and Shotts,North Lanarkshire,North Lanarkshire,S13003049,S14000063,S12000050,S12000050
+2024,2024,Smithfield,Wrexham,Wrexham,Wrexham,W05001758,W07000111,W06000006,W06000006
+2024,2024,Airdrie Central,Airdrie and Shotts,North Lanarkshire,North Lanarkshire,S13003050,S14000063,S12000050,S12000050
+2024,2024,Stansty,Wrexham,Wrexham,Wrexham,W05001759,W07000111,W06000006,W06000006
+2024,2024,Airdrie Central,Coatbridge and Bellshill,North Lanarkshire,North Lanarkshire,S13003050,S14000070,S12000050,S12000050
+2024,2024,Whitegate,Wrexham,Wrexham,Wrexham,W05001760,W07000111,W06000006,W06000006
+2024,2024,Coatbridge West,Coatbridge and Bellshill,North Lanarkshire,North Lanarkshire,S13003051,S14000070,S12000050,S12000050
+2024,2024,Wynnstay,Wrexham,Wrexham,Wrexham,W05001761,W07000111,W06000006,W06000006
+2024,2024,Coatbridge South,Coatbridge and Bellshill,North Lanarkshire,North Lanarkshire,S13003052,S14000070,S12000050,S12000050
+2024,2024,Aberaeron and Aberarth,Ceredigion Preseli,Ceredigion,Ceredigion,W05001298,W07000093,W06000008,W06000008
+2024,2024,Airdrie South,Airdrie and Shotts,North Lanarkshire,North Lanarkshire,S13003053,S14000063,S12000050,S12000050
+2024,2024,Aberporth and Y Ferwig,Ceredigion Preseli,Ceredigion,Ceredigion,W05001299,W07000093,W06000008,W06000008
+2024,2024,Fortissat,Airdrie and Shotts,North Lanarkshire,North Lanarkshire,S13003054,S14000063,S12000050,S12000050
+2024,2024,Aberystwyth Morfa a Glais,Ceredigion Preseli,Ceredigion,Ceredigion,W05001300,W07000093,W06000008,W06000008
+2024,2024,Thorniewood,Coatbridge and Bellshill,North Lanarkshire,North Lanarkshire,S13003055,S14000070,S12000050,S12000050
+2024,2024,Aberystwyth Penparcau,Ceredigion Preseli,Ceredigion,Ceredigion,W05001301,W07000093,W06000008,W06000008
+2024,2024,Bellshill,Coatbridge and Bellshill,North Lanarkshire,North Lanarkshire,S13003056,S14000070,S12000050,S12000050
+2024,2024,Aberystwyth Rheidol,Ceredigion Preseli,Ceredigion,Ceredigion,W05001302,W07000093,W06000008,W06000008
+2024,2024,Mossend and Holytown,Airdrie and Shotts,North Lanarkshire,North Lanarkshire,S13003057,S14000063,S12000050,S12000050
+2024,2024,Beulah and Llangoedmor,Ceredigion Preseli,Ceredigion,Ceredigion,W05001303,W07000093,W06000008,W06000008
+2024,2024,Mossend and Holytown,Coatbridge and Bellshill,North Lanarkshire,North Lanarkshire,S13003057,S14000070,S12000050,S12000050
+2024,2024,Borth,Ceredigion Preseli,Ceredigion,Ceredigion,W05001304,W07000093,W06000008,W06000008
+2024,2024,Motherwell West,"Motherwell, Wishaw and Carluke",North Lanarkshire,North Lanarkshire,S13003058,S14000099,S12000050,S12000050
+2024,2024,Ceulan a Maesmawr,Ceredigion Preseli,Ceredigion,Ceredigion,W05001305,W07000093,W06000008,W06000008
+2024,2024,Motherwell North,Airdrie and Shotts,North Lanarkshire,North Lanarkshire,S13003059,S14000063,S12000050,S12000050
+2024,2024,Motherwell North,"Motherwell, Wishaw and Carluke",North Lanarkshire,North Lanarkshire,S13003059,S14000099,S12000050,S12000050
+2024,2024,Motherwell South East and Ravenscraig,"Motherwell, Wishaw and Carluke",North Lanarkshire,North Lanarkshire,S13003060,S14000099,S12000050,S12000050
+2024,2024,Murdostoun,Airdrie and Shotts,North Lanarkshire,North Lanarkshire,S13003061,S14000063,S12000050,S12000050
+2024,2024,Murdostoun,"Motherwell, Wishaw and Carluke",North Lanarkshire,North Lanarkshire,S13003061,S14000099,S12000050,S12000050
+2024,2024,Wishaw,"Motherwell, Wishaw and Carluke",North Lanarkshire,North Lanarkshire,S13003062,S14000099,S12000050,S12000050
+2024,2024,"Stepps, Chryston and Muirhead",Cumbernauld and Kirkintilloch,North Lanarkshire,North Lanarkshire,S13003134,S14000072,S12000050,S12000050
+2024,2024,Aethwy,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001492,W07000112,W06000001,W06000001
+2024,2024,Bodowyr,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001493,W07000112,W06000001,W06000001
+2024,2024,Bro Aberffraw,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001494,W07000112,W06000001,W06000001
+2024,2024,Bro'r Llynnoedd,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001495,W07000112,W06000001,W06000001
+2024,2024,Canolbarth Môn,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001496,W07000112,W06000001,W06000001
+2024,2024,Cefni,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001497,W07000112,W06000001,W06000001
+2024,2024,Crigyll,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001498,W07000112,W06000001,W06000001
+2024,2024,Lligwy,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001499,W07000112,W06000001,W06000001
+2024,2024,Parc a'r Mynydd,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001500,W07000112,W06000001,W06000001
+2024,2024,Seiriol,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001501,W07000112,W06000001,W06000001
+2024,2024,Ciliau Aeron,Ceredigion Preseli,Ceredigion,Ceredigion,W05001306,W07000093,W06000008,W06000008
+2024,2024,Talybolion,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001502,W07000112,W06000001,W06000001
+2024,2024,Faenor,Ceredigion Preseli,Ceredigion,Ceredigion,W05001307,W07000093,W06000008,W06000008
+2024,2024,Cwarter Bach,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001187,W07000087,W06000010,W06000010
+2024,2024,Tref Cybi,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001503,W07000112,W06000001,W06000001
+2024,2024,Lampeter,Ceredigion Preseli,Ceredigion,Ceredigion,W05001308,W07000093,W06000008,W06000008
+2024,2024,Garden Village,Wrexham,Wrexham,Wrexham,W05001730,W07000111,W06000006,W06000006
+2024,2024,Cynwyl Elfed,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001188,W07000087,W06000010,W06000010
+2024,2024,Gresford East and West,Wrexham,Wrexham,Wrexham,W05001731,W07000111,W06000006,W06000006
+2024,2024,Dafen and Felinfoel,Llanelli,Carmarthenshire,Carmarthenshire,W05001189,W07000098,W06000010,W06000010
+2024,2024,Grosvenor,Wrexham,Wrexham,Wrexham,W05001732,W07000111,W06000006,W06000006
+2024,2024,Elli,Llanelli,Carmarthenshire,Carmarthenshire,W05001190,W07000098,W06000010,W06000010
+2024,2024,Gwenfro,Wrexham,Wrexham,Wrexham,W05001733,W07000111,W06000006,W06000006
+2024,2024,Garnant,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001191,W07000087,W06000010,W06000010
+2024,2024,Twrcelyn,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001504,W07000112,W06000001,W06000001
+2024,2024,Gwersyllt East,Wrexham,Wrexham,Wrexham,W05001734,W07000111,W06000006,W06000006
+2024,2024,Glanamman,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001192,W07000087,W06000010,W06000010
+2024,2024,Llannarth,Ceredigion Preseli,Ceredigion,Ceredigion,W05001309,W07000093,W06000008,W06000008
+2024,2024,Ynys Gybi,Ynys Môn,Isle of Anglesey,Isle of Anglesey,W05001505,W07000112,W06000001,W06000001
+2024,2024,Llanbadarn Fawr,Ceredigion Preseli,Ceredigion,Ceredigion,W05001310,W07000093,W06000008,W06000008
+2024,2024,Aberdyfi,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001506,W07000096,W06000002,W06000002
+2024,2024,Glanymor,Llanelli,Carmarthenshire,Carmarthenshire,W05001193,W07000098,W06000010,W06000010
+2024,2024,Llandyfriog,Ceredigion Preseli,Ceredigion,Ceredigion,W05001311,W07000093,W06000008,W06000008
+2024,2024,Gwersyllt North,Wrexham,Wrexham,Wrexham,W05001735,W07000111,W06000006,W06000006
+2024,2024,Abererch,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001507,W07000096,W06000002,W06000002
+2024,2024,Glyn,Llanelli,Carmarthenshire,Carmarthenshire,W05001194,W07000098,W06000010,W06000010
+2024,2024,Llandysilio and Llangrannog,Ceredigion Preseli,Ceredigion,Ceredigion,W05001312,W07000093,W06000008,W06000008
+2024,2024,Gwersyllt South,Wrexham,Wrexham,Wrexham,W05001736,W07000111,W06000006,W06000006
+2024,2024,Abermaw,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001508,W07000096,W06000002,W06000002
+2024,2024,Gorslas,Llanelli,Carmarthenshire,Carmarthenshire,W05001195,W07000098,W06000010,W06000010
+2024,2024,Llandysul North and Troedyraur,Ceredigion Preseli,Ceredigion,Ceredigion,W05001313,W07000093,W06000008,W06000008
+2024,2024,Gwersyllt West,Wrexham,Wrexham,Wrexham,W05001737,W07000111,W06000006,W06000006
+2024,2024,Abersoch gyda Llanengan,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001509,W07000096,W06000002,W06000002
+2024,2024,Hendy,Llanelli,Carmarthenshire,Carmarthenshire,W05001196,W07000098,W06000010,W06000010
+2024,2024,Llandysul South,Ceredigion Preseli,Ceredigion,Ceredigion,W05001314,W07000093,W06000008,W06000008
+2024,2024,Hermitage,Wrexham,Wrexham,Wrexham,W05001738,W07000111,W06000006,W06000006
+2024,2024,Arllechwedd,Bangor Aberconwy,Gwynedd,Gwynedd,W05001510,W07000083,W06000002,W06000002
+2024,2024,Hengoed,Llanelli,Carmarthenshire,Carmarthenshire,W05001197,W07000098,W06000010,W06000010
+2024,2024,Llanfarian,Ceredigion Preseli,Ceredigion,Ceredigion,W05001315,W07000093,W06000008,W06000008
+2024,2024,Holt,Wrexham,Wrexham,Wrexham,W05001739,W07000111,W06000006,W06000006
+2024,2024,Little Acton,Wrexham,Wrexham,Wrexham,W05001740,W07000111,W06000006,W06000006
+2024,2024,Arthog a Llangelynnin,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001511,W07000096,W06000002,W06000002
+2024,2024,Llangollen Rural,Clwyd East,Wrexham,Wrexham,W05001741,W07000094,W06000006,W06000006
+2024,2024,Llanfihangel Ystrad,Ceredigion Preseli,Ceredigion,Ceredigion,W05001316,W07000093,W06000008,W06000008
+2024,2024,Bethel a'r Felinheli,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001512,W07000096,W06000002,W06000002
+2024,2024,Llay,Wrexham,Wrexham,Wrexham,W05001742,W07000111,W06000006,W06000006
+2024,2024,Kidwelly and St Ishmael,Llanelli,Carmarthenshire,Carmarthenshire,W05001198,W07000098,W06000010,W06000010
+2024,2024,Llangeitho,Ceredigion Preseli,Ceredigion,Ceredigion,W05001317,W07000093,W06000008,W06000008
+2024,2024,Laugharne Township,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001199,W07000087,W06000010,W06000010
+2024,2024,Llangybi,Ceredigion Preseli,Ceredigion,Ceredigion,W05001318,W07000093,W06000008,W06000008
+2024,2024,Llanboidy,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001200,W07000087,W06000010,W06000010
+2024,2024,Llanrhystyd,Ceredigion Preseli,Ceredigion,Ceredigion,W05001319,W07000093,W06000008,W06000008
+2024,2024,Llanddarog,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001201,W07000087,W06000010,W06000010
+2024,2024,Llansanffraid,Ceredigion Preseli,Ceredigion,Ceredigion,W05001320,W07000093,W06000008,W06000008
+2024,2024,Llandeilo,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001202,W07000087,W06000010,W06000010
+2024,2024,Llanwenog,Ceredigion Preseli,Ceredigion,Ceredigion,W05001321,W07000093,W06000008,W06000008
+2024,2024,Llandovery,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001203,W07000087,W06000010,W06000010
+2024,2024,Lledrod,Ceredigion Preseli,Ceredigion,Ceredigion,W05001322,W07000093,W06000008,W06000008
+2024,2024,Llandybie,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001204,W07000087,W06000010,W06000010
+2024,2024,Melindwr,Ceredigion Preseli,Ceredigion,Ceredigion,W05001323,W07000093,W06000008,W06000008
+2024,2024,Llanegwad,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001205,W07000087,W06000010,W06000010
+2024,2024,Mwldan,Ceredigion Preseli,Ceredigion,Ceredigion,W05001324,W07000093,W06000008,W06000008
+2024,2024,Llanfihangel Aberbythych,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001206,W07000087,W06000010,W06000010
+2024,2024,New Quay and Llanllwchaearn,Ceredigion Preseli,Ceredigion,Ceredigion,W05001325,W07000093,W06000008,W06000008
+2024,2024,Marchwiel,Wrexham,Wrexham,Wrexham,W05001743,W07000111,W06000006,W06000006
+2024,2024,Llanfihangel-ar-Arth,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001207,W07000087,W06000010,W06000010
+2024,2024,Penbryn,Ceredigion Preseli,Ceredigion,Ceredigion,W05001326,W07000093,W06000008,W06000008
+2024,2024,Llangadog,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001208,W07000087,W06000010,W06000010
+2024,2024,Marford and Hoseley,Wrexham,Wrexham,Wrexham,W05001744,W07000111,W06000006,W06000006
+2024,2024,Minera,Wrexham,Wrexham,Wrexham,W05001745,W07000111,W06000006,W06000006
+2024,2024,Bowydd a'r Rhiw,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001513,W07000096,W06000002,W06000002
+2024,2024,New Broughton,Wrexham,Wrexham,Wrexham,W05001746,W07000111,W06000006,W06000006
+2024,2024,Brithdir and Llanfachreth/Ganllwyd/Llanelltyd,Dwyfor Meirionnydd,Gwynedd,Gwynedd,W05001514,W07000096,W06000002,W06000002
+2024,2024,Llangennech,Llanelli,Carmarthenshire,Carmarthenshire,W05001209,W07000098,W06000010,W06000010
+2024,2024,Offa,Wrexham,Wrexham,Wrexham,W05001747,W07000111,W06000006,W06000006
+2024,2024,Teifi,Ceredigion Preseli,Ceredigion,Ceredigion,W05001327,W07000093,W06000008,W06000008
+2024,2024,Llangunnor,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001210,W07000087,W06000010,W06000010
+2024,2024,Overton and Maelor South,Wrexham,Wrexham,Wrexham,W05001748,W07000111,W06000006,W06000006
+2024,2024,Tirymynach,Ceredigion Preseli,Ceredigion,Ceredigion,W05001328,W07000093,W06000008,W06000008
+2024,2024,Llangyndeyrn,Llanelli,Carmarthenshire,Carmarthenshire,W05001211,W07000098,W06000010,W06000010
+2024,2024,Trefeurig,Ceredigion Preseli,Ceredigion,Ceredigion,W05001329,W07000093,W06000008,W06000008
+2024,2024,Pant and Johnstown,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001749,W07000102,W06000006,W06000006
+2024,2024,Llannon,Llanelli,Carmarthenshire,Carmarthenshire,W05001212,W07000098,W06000010,W06000010
+2024,2024,Penycae,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001750,W07000102,W06000006,W06000006
+2024,2024,Llanybydder,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001213,W07000087,W06000010,W06000010
+2024,2024,Penycae and Ruabon South,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001751,W07000102,W06000006,W06000006
+2024,2024,Lliedi,Llanelli,Carmarthenshire,Carmarthenshire,W05001214,W07000098,W06000010,W06000010
+2024,2024,Ponciau,Montgomeryshire and Glyndwr,Wrexham,Wrexham,W05001752,W07000102,W06000006,W06000006
+2024,2024,Llwynhendy,Llanelli,Carmarthenshire,Carmarthenshire,W05001215,W07000098,W06000010,W06000010
+2024,2024,Manordeilo and Salem,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001216,W07000087,W06000010,W06000010
+2024,2024,Pembrey,Llanelli,Carmarthenshire,Carmarthenshire,W05001217,W07000098,W06000010,W06000010
+2024,2024,Penygroes,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001218,W07000087,W06000010,W06000010
+2024,2024,Pontyberem,Llanelli,Carmarthenshire,Carmarthenshire,W05001219,W07000098,W06000010,W06000010
+2024,2024,Saron,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001220,W07000087,W06000010,W06000010
+2024,2024,St Clears and Llansteffan,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001221,W07000087,W06000010,W06000010
+2024,2024,Swiss Valley,Llanelli,Carmarthenshire,Carmarthenshire,W05001222,W07000098,W06000010,W06000010
+2024,2024,Trelech,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001223,W07000087,W06000010,W06000010
+2024,2024,Tregaron and Ystrad Fflur,Ceredigion Preseli,Ceredigion,Ceredigion,W05001330,W07000093,W06000008,W06000008
+2024,2024,Ystwyth,Ceredigion Preseli,Ceredigion,Ceredigion,W05001331,W07000093,W06000008,W06000008
+2024,2024,Amroth and Saundersfoot North,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001433,W07000100,W06000009,W06000009
+2024,2024,Boncath and Clydau,Ceredigion Preseli,Pembrokeshire,Pembrokeshire,W05001434,W07000093,W06000009,W06000009
+2024,2024,Burton,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001435,W07000100,W06000009,W06000009
+2024,2024,Bro Gwaun,Ceredigion Preseli,Pembrokeshire,Pembrokeshire,W05001436,W07000093,W06000009,W06000009
+2024,2024,Camrose,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001437,W07000100,W06000009,W06000009
+2024,2024,Carew and Jeffreyston,Mid and South Pembrokeshire,Pembrokeshire,Pembrokeshire,W05001438,W07000100,W06000009,W06000009
+2024,2024,Cilgerran and Eglwyswrw,Ceredigion Preseli,Pembrokeshire,Pembrokeshire,W05001439,W07000093,W06000009,W06000009
+2024,2024,Trimsaran,Llanelli,Carmarthenshire,Carmarthenshire,W05001224,W07000098,W06000010,W06000010
+2024,2024,Tycroes,Llanelli,Carmarthenshire,Carmarthenshire,W05001225,W07000098,W06000010,W06000010
+2024,2024,Tyisha,Llanelli,Carmarthenshire,Carmarthenshire,W05001226,W07000098,W06000010,W06000010
+2024,2024,Whitland,Caerfyrddin,Carmarthenshire,Carmarthenshire,W05001227,W07000087,W06000010,W06000010
+2024,2024,Bishopston,Gower,Swansea,Swansea,W05001039,W07000097,W06000011,W06000011
+2024,2024,Bôn-y-maen,Neath and Swansea East,Swansea,Swansea,W05001040,W07000103,W06000011,W06000011
+2024,2024,Castle,Swansea West,Swansea,Swansea,W05001041,W07000108,W06000011,W06000011
+2024,2024,Clydach,Gower,Swansea,Swansea,W05001042,W07000097,W06000011,W06000011
+2024,2024,Clydach,Neath and Swansea East,Swansea,Swansea,W05001042,W07000103,W06000011,W06000011
+2024,2024,Cockett,Gower,Swansea,Swansea,W05001043,W07000097,W06000011,W06000011
+2024,2024,Cwmbwrla,Swansea West,Swansea,Swansea,W05001044,W07000108,W06000011,W06000011
+2024,2024,Dunvant and Killay,Gower,Swansea,Swansea,W05001045,W07000097,W06000011,W06000011
+2024,2024,Fairwood,Gower,Swansea,Swansea,W05001046,W07000097,W06000011,W06000011
+2024,2024,Gorseinon and Penyrheol,Gower,Swansea,Swansea,W05001047,W07000097,W06000011,W06000011
+2024,2024,Gower,Gower,Swansea,Swansea,W05001048,W07000097,W06000011,W06000011
+2024,2024,Gowerton,Gower,Swansea,Swansea,W05001049,W07000097,W06000011,W06000011
+2024,2024,Landore,Swansea West,Swansea,Swansea,W05001050,W07000108,W06000011,W06000011
+2024,2024,Llangyfelach,Gower,Swansea,Swansea,W05001051,W07000097,W06000011,W06000011
+2024,2024,Llansamlet,Neath and Swansea East,Swansea,Swansea,W05001052,W07000103,W06000011,W06000011
+2024,2024,Llwchwr,Gower,Swansea,Swansea,W05001053,W07000097,W06000011,W06000011
+2024,2024,Mayals,Gower,Swansea,Swansea,W05001054,W07000097,W06000011,W06000011
+2024,2024,Morriston,Swansea West,Swansea,Swansea,W05001055,W07000108,W06000011,W06000011
+2024,2024,Mumbles,Gower,Swansea,Swansea,W05001056,W07000097,W06000011,W06000011
+2024,2024,Mynydd-bach,Swansea West,Swansea,Swansea,W05001057,W07000108,W06000011,W06000011
+2024,2024,Pen-clawdd,Gower,Swansea,Swansea,W05001058,W07000097,W06000011,W06000011
+2024,2024,Penderry,Swansea West,Swansea,Swansea,W05001059,W07000108,W06000011,W06000011
+2024,2024,Penllergaer,Gower,Swansea,Swansea,W05001060,W07000097,W06000011,W06000011
+2024,2024,Pennard,Gower,Swansea,Swansea,W05001061,W07000097,W06000011,W06000011
+2024,2024,Pontarddulais,Gower,Swansea,Swansea,W05001062,W07000097,W06000011,W06000011
+2024,2024,Pontlliw and Tircoed,Gower,Swansea,Swansea,W05001063,W07000097,W06000011,W06000011
+2024,2024,Sketty,Swansea West,Swansea,Swansea,W05001064,W07000108,W06000011,W06000011
+2024,2024,Llandow,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001391,W07000110,W06000014,W06000014
+2024,2024,St Thomas,Neath and Swansea East,Swansea,Swansea,W05001065,W07000103,W06000011,W06000011
+2024,2024,Townhill,Swansea West,Swansea,Swansea,W05001066,W07000108,W06000011,W06000011
+2024,2024,Uplands,Swansea West,Swansea,Swansea,W05001067,W07000108,W06000011,W06000011
+2024,2024,Waterfront,Neath and Swansea East,Swansea,Swansea,W05001068,W07000103,W06000011,W06000011
+2024,2024,Waterfront,Swansea West,Swansea,Swansea,W05001068,W07000108,W06000011,W06000011
+2024,2024,Waunarlwydd,Gower,Swansea,Swansea,W05001069,W07000097,W06000011,W06000011
+2024,2024,West Cross,Gower,Swansea,Swansea,W05001070,W07000097,W06000011,W06000011
+2024,2024,Aberavon,Aberafan Maesteg,Neath Port Talbot,Neath Port Talbot,W05001679,W07000081,W06000012,W06000012
+2024,2024,Aberdulais,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001680,W07000103,W06000012,W06000012
+2024,2024,Allt-wen,"Brecon, Radnor and Cwm Tawe",Neath Port Talbot,Neath Port Talbot,W05001681,W07000085,W06000012,W06000012
+2024,2024,Baglan,Aberafan Maesteg,Neath Port Talbot,Neath Port Talbot,W05001682,W07000081,W06000012,W06000012
+2024,2024,Blaengwrach and Glynneath West,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001683,W07000103,W06000012,W06000012
+2024,2024,Briton Ferry East,Aberafan Maesteg,Neath Port Talbot,Neath Port Talbot,W05001684,W07000081,W06000012,W06000012
+2024,2024,Briton Ferry West,Aberafan Maesteg,Neath Port Talbot,Neath Port Talbot,W05001685,W07000081,W06000012,W06000012
+2024,2024,Bryn and Cwmavon,Aberafan Maesteg,Neath Port Talbot,Neath Port Talbot,W05001686,W07000081,W06000012,W06000012
+2024,2024,Bryn-coch North,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001687,W07000103,W06000012,W06000012
+2024,2024,Bryn-coch South,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001688,W07000103,W06000012,W06000012
+2024,2024,Cadoxton,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001689,W07000103,W06000012,W06000012
+2024,2024,Cimla and Pelenna,Aberafan Maesteg,Neath Port Talbot,Neath Port Talbot,W05001690,W07000081,W06000012,W06000012
+2024,2024,Cimla and Pelenna,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001690,W07000103,W06000012,W06000012
+2024,2024,Coedffranc Central,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001691,W07000103,W06000012,W06000012
+2024,2024,Coedffranc North,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001692,W07000103,W06000012,W06000012
+2024,2024,Coedffranc West,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001693,W07000103,W06000012,W06000012
+2024,2024,"Crynant, Onllwyn and Seven Sisters",Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001694,W07000103,W06000012,W06000012
+2024,2024,Cwmllynfell and Ystalyfera,"Brecon, Radnor and Cwm Tawe",Neath Port Talbot,Neath Port Talbot,W05001695,W07000085,W06000012,W06000012
+2024,2024,Cymer and Glyncorrwg,Aberafan Maesteg,Neath Port Talbot,Neath Port Talbot,W05001696,W07000081,W06000012,W06000012
+2024,2024,Dyffryn,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001697,W07000103,W06000012,W06000012
+2024,2024,Llantwit Major,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001392,W07000110,W06000014,W06000014
+2024,2024,Peterston-super-Ely,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001393,W07000110,W06000014,W06000014
+2024,2024,Plymouth,Cardiff South and Penarth,Vale of Glamorgan,Vale of Glamorgan,W05001394,W07000091,W06000014,W06000014
+2024,2024,Rhoose,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001395,W07000110,W06000014,W06000014
+2024,2024,St Athan,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001396,W07000110,W06000014,W06000014
+2024,2024,St Bride's Major,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001397,W07000110,W06000014,W06000014
+2024,2024,St Nicholas and Llancarfan,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001398,W07000110,W06000014,W06000014
+2024,2024,St Augustine's,Cardiff South and Penarth,Vale of Glamorgan,Vale of Glamorgan,W05001399,W07000091,W06000014,W06000014
+2024,2024,Llangybi Fawr,Monmouthshire,Monmouthshire,Monmouthshire,W05001780,W07000101,W06000021,W06000021
+2024,2024,Stanwell,Cardiff South and Penarth,Vale of Glamorgan,Vale of Glamorgan,W05001400,W07000091,W06000014,W06000014
+2024,2024,Sully,Cardiff South and Penarth,Vale of Glamorgan,Vale of Glamorgan,W05001401,W07000091,W06000014,W06000014
+2024,2024,Wenvoe,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001402,W07000110,W06000014,W06000014
+2024,2024,Llantilio Crossenny,Monmouthshire,Monmouthshire,Monmouthshire,W05001781,W07000101,W06000021,W06000021
+2024,2024,Adamsdown,Cardiff East,Cardiff,Cardiff,W05001270,W07000089,W06000015,W06000015
+2024,2024,Butetown,Cardiff South and Penarth,Cardiff,Cardiff,W05001271,W07000091,W06000015,W06000015
+2024,2024,Magor East with Undy,Monmouthshire,Monmouthshire,Monmouthshire,W05001782,W07000101,W06000021,W06000021
+2024,2024,Glynneath Central and East,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001698,W07000103,W06000012,W06000012
+2024,2024,Godre'r Graig,"Brecon, Radnor and Cwm Tawe",Neath Port Talbot,Neath Port Talbot,W05001699,W07000085,W06000012,W06000012
+2024,2024,Gwaun-Cae-Gurwen and Lower Brynamman,"Brecon, Radnor and Cwm Tawe",Neath Port Talbot,Neath Port Talbot,W05001700,W07000085,W06000012,W06000012
+2024,2024,Gwynfi and Croeserw,Aberafan Maesteg,Neath Port Talbot,Neath Port Talbot,W05001701,W07000081,W06000012,W06000012
+2024,2024,Margam and Tai-bach,Aberafan Maesteg,Neath Port Talbot,Neath Port Talbot,W05001702,W07000081,W06000012,W06000012
+2024,2024,Neath East,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001703,W07000103,W06000012,W06000012
+2024,2024,Neath North,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001704,W07000103,W06000012,W06000012
+2024,2024,Neath South,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001705,W07000103,W06000012,W06000012
+2024,2024,Pontardawe,"Brecon, Radnor and Cwm Tawe",Neath Port Talbot,Neath Port Talbot,W05001706,W07000085,W06000012,W06000012
+2024,2024,Port Talbot,Aberafan Maesteg,Neath Port Talbot,Neath Port Talbot,W05001707,W07000081,W06000012,W06000012
+2024,2024,Resolven and Tonna,Neath and Swansea East,Neath Port Talbot,Neath Port Talbot,W05001708,W07000103,W06000012,W06000012
+2024,2024,Rhos,"Brecon, Radnor and Cwm Tawe",Neath Port Talbot,Neath Port Talbot,W05001709,W07000085,W06000012,W06000012
+2024,2024,Sandfields East,Aberafan Maesteg,Neath Port Talbot,Neath Port Talbot,W05001710,W07000081,W06000012,W06000012
+2024,2024,Sandfields West,Aberafan Maesteg,Neath Port Talbot,Neath Port Talbot,W05001711,W07000081,W06000012,W06000012
+2024,2024,Trebanos,"Brecon, Radnor and Cwm Tawe",Neath Port Talbot,Neath Port Talbot,W05001712,W07000085,W06000012,W06000012
+2024,2024,Aberkenfig,Bridgend,Bridgend,Bridgend,W05001228,W07000086,W06000013,W06000013
+2024,2024,Blackmill,Rhondda and Ogmore,Bridgend,Bridgend,W05001229,W07000107,W06000013,W06000013
+2024,2024,Brackla East and Coychurch Lower,Bridgend,Bridgend,Bridgend,W05001230,W07000086,W06000013,W06000013
+2024,2024,Brackla East Central,Bridgend,Bridgend,Bridgend,W05001231,W07000086,W06000013,W06000013
+2024,2024,Brackla West,Bridgend,Bridgend,Bridgend,W05001232,W07000086,W06000013,W06000013
+2024,2024,Brackla West Central,Bridgend,Bridgend,Bridgend,W05001233,W07000086,W06000013,W06000013
+2024,2024,Bridgend Central,Bridgend,Bridgend,Bridgend,W05001234,W07000086,W06000013,W06000013
+2024,2024,"Bryntirion, Laleston and Merthyr Mawr",Bridgend,Bridgend,Bridgend,W05001235,W07000086,W06000013,W06000013
+2024,2024,Caerau,Aberafan Maesteg,Bridgend,Bridgend,W05001236,W07000081,W06000013,W06000013
+2024,2024,Cefn-glas,Bridgend,Bridgend,Bridgend,W05001237,W07000086,W06000013,W06000013
+2024,2024,Coity Higher,Bridgend,Bridgend,Bridgend,W05001238,W07000086,W06000013,W06000013
+2024,2024,Cornelly,Aberafan Maesteg,Bridgend,Bridgend,W05001239,W07000081,W06000013,W06000013
+2024,2024,Garw Valley,Rhondda and Ogmore,Bridgend,Bridgend,W05001240,W07000107,W06000013,W06000013
+2024,2024,Llangynwyd,Aberafan Maesteg,Bridgend,Bridgend,W05001241,W07000081,W06000013,W06000013
+2024,2024,Maesteg East,Aberafan Maesteg,Bridgend,Bridgend,W05001242,W07000081,W06000013,W06000013
+2024,2024,Maesteg West,Aberafan Maesteg,Bridgend,Bridgend,W05001243,W07000081,W06000013,W06000013
+2024,2024,Nant-y-moel,Rhondda and Ogmore,Bridgend,Bridgend,W05001244,W07000107,W06000013,W06000013
+2024,2024,Newton,Bridgend,Bridgend,Bridgend,W05001245,W07000086,W06000013,W06000013
+2024,2024,Nottage,Bridgend,Bridgend,Bridgend,W05001246,W07000086,W06000013,W06000013
+2024,2024,Ogmore Vale,Rhondda and Ogmore,Bridgend,Bridgend,W05001247,W07000107,W06000013,W06000013
+2024,2024,Oldcastle,Bridgend,Bridgend,Bridgend,W05001248,W07000086,W06000013,W06000013
+2024,2024,Magor West,Monmouthshire,Monmouthshire,Monmouthshire,W05001783,W07000101,W06000021,W06000021
+2024,2024,Caerau,Cardiff West,Cardiff,Cardiff,W05001272,W07000092,W06000015,W06000015
+2024,2024,Mardy,Monmouthshire,Monmouthshire,Monmouthshire,W05001784,W07000101,W06000021,W06000021
+2024,2024,Canton,Cardiff West,Cardiff,Cardiff,W05001273,W07000092,W06000015,W06000015
+2024,2024,Mitchel Troy and Trellech United,Monmouthshire,Monmouthshire,Monmouthshire,W05001785,W07000101,W06000021,W06000021
+2024,2024,Pencoed and Penprysg,Bridgend,Bridgend,Bridgend,W05001249,W07000086,W06000013,W06000013
+2024,2024,Glasbury,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001132,W07000085,W06000023,W06000023
+2024,2024,Cathays,Cardiff South and Penarth,Cardiff,Cardiff,W05001274,W07000091,W06000015,W06000015
+2024,2024,Mount Pleasant,Monmouthshire,Monmouthshire,Monmouthshire,W05001786,W07000101,W06000021,W06000021
+2024,2024,Pen-y-fai,Bridgend,Bridgend,Bridgend,W05001250,W07000086,W06000013,W06000013
+2024,2024,"Hirwaun, Penderyn and Rhigos",Merthyr Tydfil and Aberdare,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001087,W07000099,W06000016,W06000016
+2024,2024,Guilsfield,Montgomeryshire and Glyndwr,Powys,Powys,W05001133,W07000102,W06000023,W06000023
+2024,2024,Cyncoed,Cardiff East,Cardiff,Cardiff,W05001275,W07000089,W06000015,W06000015
+2024,2024,Osbaston,Monmouthshire,Monmouthshire,Monmouthshire,W05001787,W07000101,W06000021,W06000021
+2024,2024,Porthcawl East Central,Bridgend,Bridgend,Bridgend,W05001251,W07000086,W06000013,W06000013
+2024,2024,Risca West,Newport West and Islwyn,Caerphilly,Caerphilly,W05001672,W07000105,W06000018,W06000018
+2024,2024,Llanharry,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001088,W07000106,W06000016,W06000016
+2024,2024,Gwernyfed,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001134,W07000085,W06000023,W06000023
+2024,2024,Ely,Cardiff West,Cardiff,Cardiff,W05001276,W07000092,W06000015,W06000015
+2024,2024,Overmonnow,Monmouthshire,Monmouthshire,Monmouthshire,W05001788,W07000101,W06000021,W06000021
+2024,2024,Porthcawl West Central,Bridgend,Bridgend,Bridgend,W05001252,W07000086,W06000013,W06000013
+2024,2024,St Cattwg,Caerphilly,Caerphilly,Caerphilly,W05001673,W07000088,W06000018,W06000018
+2024,2024,Llantrisant and Talbot Green,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001089,W07000106,W06000016,W06000016
+2024,2024,Hay,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001135,W07000085,W06000023,W06000023
+2024,2024,Fairwater,Cardiff West,Cardiff,Cardiff,W05001277,W07000092,W06000015,W06000015
+2024,2024,Park,Monmouthshire,Monmouthshire,Monmouthshire,W05001789,W07000101,W06000021,W06000021
+2024,2024,"Pyle, Kenfig Hill and Cefn Cribwr",Aberafan Maesteg,Bridgend,Bridgend,W05001253,W07000081,W06000013,W06000013
+2024,2024,St Martins,Caerphilly,Caerphilly,Caerphilly,W05001674,W07000088,W06000018,W06000018
+2024,2024,Llantwit Fardre,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001090,W07000106,W06000016,W06000016
+2024,2024,Ithon Valley,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001136,W07000085,W06000023,W06000023
+2024,2024,Gabalfa,Cardiff North,Cardiff,Cardiff,W05001278,W07000090,W06000015,W06000015
+2024,2024,Pen Y Fal,Monmouthshire,Monmouthshire,Monmouthshire,W05001790,W07000101,W06000021,W06000021
+2024,2024,"Pyle, Kenfig Hill and Cefn Cribwr",Bridgend,Bridgend,Bridgend,W05001253,W07000086,W06000013,W06000013
+2024,2024,Grangetown,Cardiff South and Penarth,Cardiff,Cardiff,W05001279,W07000091,W06000015,W06000015
+2024,2024,Portskewett,Monmouthshire,Monmouthshire,Monmouthshire,W05001791,W07000101,W06000021,W06000021
+2024,2024,Kerry,Montgomeryshire and Glyndwr,Powys,Powys,W05001137,W07000102,W06000023,W06000023
+2024,2024,Llwyn-y-pia,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001091,W07000107,W06000016,W06000016
+2024,2024,Twyn Carno,Blaenau Gwent and Rhymney,Caerphilly,Caerphilly,W05001675,W07000084,W06000018,W06000018
+2024,2024,Raglan,Monmouthshire,Monmouthshire,Monmouthshire,W05001792,W07000101,W06000021,W06000021
+2024,2024,Van,Caerphilly,Caerphilly,Caerphilly,W05001676,W07000088,W06000018,W06000018
+2024,2024,Rogiet,Monmouthshire,Monmouthshire,Monmouthshire,W05001793,W07000101,W06000021,W06000021
+2024,2024,Ynysddu,Caerphilly,Caerphilly,Caerphilly,W05001677,W07000088,W06000018,W06000018
+2024,2024,Mountain Ash,Merthyr Tydfil and Aberdare,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001092,W07000099,W06000016,W06000016
+2024,2024,Severn,Monmouthshire,Monmouthshire,Monmouthshire,W05001794,W07000101,W06000021,W06000021
+2024,2024,Rest Bay,Bridgend,Bridgend,Bridgend,W05001254,W07000086,W06000013,W06000013
+2024,2024,Ystrad Mynach,Caerphilly,Caerphilly,Caerphilly,W05001678,W07000088,W06000018,W06000018
+2024,2024,Mountain Ash,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001092,W07000106,W06000016,W06000016
+2024,2024,Knighton with Beguildy,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001138,W07000085,W06000023,W06000023
+2024,2024,Heath,Cardiff North,Cardiff,Cardiff,W05001280,W07000090,W06000015,W06000015
+2024,2024,Shirenewton,Monmouthshire,Monmouthshire,Monmouthshire,W05001795,W07000101,W06000021,W06000021
+2024,2024,St Bride's Minor and Ynysawdre,Bridgend,Bridgend,Bridgend,W05001255,W07000086,W06000013,W06000013
+2024,2024,Abertillery and Six Bells,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001256,W07000084,W06000019,W06000019
+2024,2024,Penrhiw-ceibr,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001093,W07000106,W06000016,W06000016
+2024,2024,Llanafanfawr with Garth,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001139,W07000085,W06000023,W06000023
+2024,2024,Lisvane and Thornhill,Cardiff North,Cardiff,Cardiff,W05001281,W07000090,W06000015,W06000015
+2024,2024,St Arvans,Monmouthshire,Monmouthshire,Monmouthshire,W05001796,W07000101,W06000021,W06000021
+2024,2024,Beaufort,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001257,W07000084,W06000019,W06000019
+2024,2024,Pentre,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001094,W07000107,W06000016,W06000016
+2024,2024,Llanbrynmair,Montgomeryshire and Glyndwr,Powys,Powys,W05001140,W07000102,W06000023,W06000023
+2024,2024,Llandaff,Cardiff West,Cardiff,Cardiff,W05001282,W07000092,W06000015,W06000015
+2024,2024,Llandinam with Dolfor,Montgomeryshire and Glyndwr,Powys,Powys,W05001141,W07000102,W06000023,W06000023
+2024,2024,Pen-y-graig,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001095,W07000107,W06000016,W06000016
+2024,2024,Blaina,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001258,W07000084,W06000019,W06000019
+2024,2024,St Kingsmark,Monmouthshire,Monmouthshire,Monmouthshire,W05001797,W07000101,W06000021,W06000021
+2024,2024,Baruc,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001379,W07000110,W06000014,W06000014
+2024,2024,Brynmawr,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001259,W07000084,W06000019,W06000019
+2024,2024,Buttrills,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001380,W07000110,W06000014,W06000014
+2024,2024,Cadoc,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001381,W07000110,W06000014,W06000014
+2024,2024,Cwm,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001260,W07000084,W06000019,W06000019
+2024,2024,Castleland,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001382,W07000110,W06000014,W06000014
+2024,2024,Cwmtillery,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001261,W07000084,W06000019,W06000019
+2024,2024,Cornerswell,Cardiff South and Penarth,Vale of Glamorgan,Vale of Glamorgan,W05001383,W07000091,W06000014,W06000014
+2024,2024,Ebbw Vale North,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001262,W07000084,W06000019,W06000019
+2024,2024,Court,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001384,W07000110,W06000014,W06000014
+2024,2024,Ebbw Vale South,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001263,W07000084,W06000019,W06000019
+2024,2024,Cowbridge,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001385,W07000110,W06000014,W06000014
+2024,2024,Georgetown,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001264,W07000084,W06000019,W06000019
+2024,2024,Dinas Powys,Cardiff South and Penarth,Vale of Glamorgan,Vale of Glamorgan,W05001386,W07000091,W06000014,W06000014
+2024,2024,Llanhilleth,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001265,W07000084,W06000019,W06000019
+2024,2024,Nantyglo,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001266,W07000084,W06000019,W06000019
+2024,2024,Rassau and Garnlydan,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001267,W07000084,W06000019,W06000019
+2024,2024,Sirhowy,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001268,W07000084,W06000019,W06000019
+2024,2024,Tredegar,Blaenau Gwent and Rhymney,Blaenau Gwent,Blaenau Gwent,W05001269,W07000084,W06000019,W06000019
+2024,2024,Abersychan,Torfaen,Torfaen,Torfaen,W05001361,W07000109,W06000020,W06000020
+2024,2024,Blaenavon,Torfaen,Torfaen,Torfaen,W05001362,W07000109,W06000020,W06000020
+2024,2024,Coed Eva,Torfaen,Torfaen,Torfaen,W05001363,W07000109,W06000020,W06000020
+2024,2024,Croesyceiliog,Torfaen,Torfaen,Torfaen,W05001364,W07000109,W06000020,W06000020
+2024,2024,Fairwater,Torfaen,Torfaen,Torfaen,W05001365,W07000109,W06000020,W06000020
+2024,2024,Greenmeadow,Torfaen,Torfaen,Torfaen,W05001366,W07000109,W06000020,W06000020
+2024,2024,Llanfrechfa and Ponthir,Torfaen,Torfaen,Torfaen,W05001367,W07000109,W06000020,W06000020
+2024,2024,Llantarnam,Torfaen,Torfaen,Torfaen,W05001368,W07000109,W06000020,W06000020
+2024,2024,Llanyrafon,Torfaen,Torfaen,Torfaen,W05001369,W07000109,W06000020,W06000020
+2024,2024,New Inn,Torfaen,Torfaen,Torfaen,W05001370,W07000109,W06000020,W06000020
+2024,2024,Panteg,Torfaen,Torfaen,Torfaen,W05001371,W07000109,W06000020,W06000020
+2024,2024,Pontnewydd,Torfaen,Torfaen,Torfaen,W05001372,W07000109,W06000020,W06000020
+2024,2024,Pontnewynydd and Snatchwood,Torfaen,Torfaen,Torfaen,W05001373,W07000109,W06000020,W06000020
+2024,2024,Pontypool Fawr,Torfaen,Torfaen,Torfaen,W05001374,W07000109,W06000020,W06000020
+2024,2024,St. Dials,Torfaen,Torfaen,Torfaen,W05001375,W07000109,W06000020,W06000020
+2024,2024,Trevethin and Penygarn,Torfaen,Torfaen,Torfaen,W05001376,W07000109,W06000020,W06000020
+2024,2024,Two Locks,Torfaen,Torfaen,Torfaen,W05001377,W07000109,W06000020,W06000020
+2024,2024,Upper Cwmbran,Torfaen,Torfaen,Torfaen,W05001378,W07000109,W06000020,W06000020
+2024,2024,Bulwark and Thornwell,Monmouthshire,Monmouthshire,Monmouthshire,W05001762,W07000101,W06000021,W06000021
+2024,2024,Caerwent,Monmouthshire,Monmouthshire,Monmouthshire,W05001763,W07000101,W06000021,W06000021
+2024,2024,Caldicot Castle,Monmouthshire,Monmouthshire,Monmouthshire,W05001764,W07000101,W06000021,W06000021
+2024,2024,Caldicot Cross,Monmouthshire,Monmouthshire,Monmouthshire,W05001765,W07000101,W06000021,W06000021
+2024,2024,Town,Monmouthshire,Monmouthshire,Monmouthshire,W05001798,W07000101,W06000021,W06000021
+2024,2024,Llandaff North,Cardiff North,Cardiff,Cardiff,W05001283,W07000090,W06000015,W06000015
+2024,2024,Llandrindod North,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001142,W07000085,W06000023,W06000023
+2024,2024,Pen-y-waun,Merthyr Tydfil and Aberdare,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001096,W07000099,W06000016,W06000016
+2024,2024,Cantref,Monmouthshire,Monmouthshire,Monmouthshire,W05001766,W07000101,W06000021,W06000021
+2024,2024,Chepstow Castle and Larkfield,Monmouthshire,Monmouthshire,Monmouthshire,W05001767,W07000101,W06000021,W06000021
+2024,2024,Croesonen,Monmouthshire,Monmouthshire,Monmouthshire,W05001768,W07000101,W06000021,W06000021
+2024,2024,Crucorney,Monmouthshire,Monmouthshire,Monmouthshire,W05001769,W07000101,W06000021,W06000021
+2024,2024,Devauden,Monmouthshire,Monmouthshire,Monmouthshire,W05001770,W07000101,W06000021,W06000021
+2024,2024,Dewstow,Monmouthshire,Monmouthshire,Monmouthshire,W05001771,W07000101,W06000021,W06000021
+2024,2024,Drybridge,Monmouthshire,Monmouthshire,Monmouthshire,W05001772,W07000101,W06000021,W06000021
+2024,2024,Gobion Fawr,Monmouthshire,Monmouthshire,Monmouthshire,W05001773,W07000101,W06000021,W06000021
+2024,2024,Goetre Fawr,Monmouthshire,Monmouthshire,Monmouthshire,W05001774,W07000101,W06000021,W06000021
+2024,2024,Grofield,Monmouthshire,Monmouthshire,Monmouthshire,W05001775,W07000101,W06000021,W06000021
+2024,2024,Lansdown,Monmouthshire,Monmouthshire,Monmouthshire,W05001776,W07000101,W06000021,W06000021
+2024,2024,Llanbadoc and Usk,Monmouthshire,Monmouthshire,Monmouthshire,W05001777,W07000101,W06000021,W06000021
+2024,2024,Llanelly,Monmouthshire,Monmouthshire,Monmouthshire,W05001778,W07000101,W06000021,W06000021
+2024,2024,Llanfoist Fawr and Govilon,Monmouthshire,Monmouthshire,Monmouthshire,W05001779,W07000101,W06000021,W06000021
+2024,2024,West End,Monmouthshire,Monmouthshire,Monmouthshire,W05001799,W07000101,W06000021,W06000021
+2024,2024,Wyesham,Monmouthshire,Monmouthshire,Monmouthshire,W05001800,W07000101,W06000021,W06000021
+2024,2024,Allt-yr-yn,Newport West and Islwyn,Newport,Newport,W05001627,W07000105,W06000022,W06000022
+2024,2024,Alway,Newport East,Newport,Newport,W05001628,W07000104,W06000022,W06000022
+2024,2024,Beechwood,Newport East,Newport,Newport,W05001629,W07000104,W06000022,W06000022
+2024,2024,Bettws,Newport East,Newport,Newport,W05001630,W07000104,W06000022,W06000022
+2024,2024,Bishton and Langstone,Newport East,Newport,Newport,W05001631,W07000104,W06000022,W06000022
+2024,2024,Caerleon,Newport East,Newport,Newport,W05001632,W07000104,W06000022,W06000022
+2024,2024,Gaer,Newport West and Islwyn,Newport,Newport,W05001633,W07000105,W06000022,W06000022
+2024,2024,Graig,Newport West and Islwyn,Newport,Newport,W05001634,W07000105,W06000022,W06000022
+2024,2024,Lliswerry,Newport East,Newport,Newport,W05001635,W07000104,W06000022,W06000022
+2024,2024,Llanwern,Newport East,Newport,Newport,W05001636,W07000104,W06000022,W06000022
+2024,2024,Llanishen,Cardiff North,Cardiff,Cardiff,W05001284,W07000090,W06000015,W06000015
+2024,2024,Llanrumney,Cardiff East,Cardiff,Cardiff,W05001285,W07000089,W06000015,W06000015
+2024,2024,Pentwyn,Cardiff East,Cardiff,Cardiff,W05001286,W07000089,W06000015,W06000015
+2024,2024,Pentyrch and St Fagans,Cardiff West,Cardiff,Cardiff,W05001287,W07000092,W06000015,W06000015
+2024,2024,Penylan,Cardiff East,Cardiff,Cardiff,W05001288,W07000089,W06000015,W06000015
+2024,2024,Plasnewydd,Cardiff East,Cardiff,Cardiff,W05001289,W07000089,W06000015,W06000015
+2024,2024,Malpas,Newport East,Newport,Newport,W05001637,W07000104,W06000022,W06000022
+2024,2024,Dyfan,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001387,W07000110,W06000014,W06000014
+2024,2024,Pontprennau and Old St Mellons,Cardiff North,Cardiff,Cardiff,W05001290,W07000090,W06000015,W06000015
+2024,2024,Gibbonsdown,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001388,W07000110,W06000014,W06000014
+2024,2024,Radyr,Cardiff West,Cardiff,Cardiff,W05001291,W07000092,W06000015,W06000015
+2024,2024,Illtyd,Vale of Glamorgan,Vale of Glamorgan,Vale of Glamorgan,W05001389,W07000110,W06000014,W06000014
+2024,2024,Pontyclun Central,Cardiff West,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001097,W07000092,W06000016,W06000016
+2024,2024,Pillgwenlly,Newport East,Newport,Newport,W05001638,W07000104,W06000022,W06000022
+2024,2024,Llandrindod South,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001143,W07000085,W06000023,W06000023
+2024,2024,Rhiwbina,Cardiff North,Cardiff,Cardiff,W05001292,W07000090,W06000015,W06000015
+2024,2024,Llandough,Cardiff South and Penarth,Vale of Glamorgan,Vale of Glamorgan,W05001390,W07000091,W06000014,W06000014
+2024,2024,Pontyclun East,Cardiff West,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001098,W07000092,W06000016,W06000016
+2024,2024,Ringland,Newport East,Newport,Newport,W05001639,W07000104,W06000022,W06000022
+2024,2024,Llandrinio,Montgomeryshire and Glyndwr,Powys,Powys,W05001144,W07000102,W06000023,W06000023
+2024,2024,Riverside,Cardiff West,Cardiff,Cardiff,W05001293,W07000092,W06000015,W06000015
+2024,2024,Pontyclun West,Cardiff West,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001099,W07000092,W06000016,W06000016
+2024,2024,Rogerstone East,Newport West and Islwyn,Newport,Newport,W05001640,W07000105,W06000022,W06000022
+2024,2024,Llandysilio,Montgomeryshire and Glyndwr,Powys,Powys,W05001145,W07000102,W06000023,W06000023
+2024,2024,Rumney,Cardiff East,Cardiff,Cardiff,W05001294,W07000089,W06000015,W06000015
+2024,2024,Pontyclun West,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001099,W07000106,W06000016,W06000016
+2024,2024,Rogerstone North,Newport West and Islwyn,Newport,Newport,W05001641,W07000105,W06000022,W06000022
+2024,2024,Llanelwedd,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001146,W07000085,W06000023,W06000023
+2024,2024,Llanfair Caereinion and Llanerfyl,Montgomeryshire and Glyndwr,Powys,Powys,W05001147,W07000102,W06000023,W06000023
+2024,2024,Llanfyllin,Montgomeryshire and Glyndwr,Powys,Powys,W05001148,W07000102,W06000023,W06000023
+2024,2024,Llangattock and Llangynidr,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001149,W07000085,W06000023,W06000023
+2024,2024,Llangors with Bwlch,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001150,W07000085,W06000023,W06000023
+2024,2024,Llangunllo with Norton,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001151,W07000085,W06000023,W06000023
+2024,2024,Llangyniew and Meifod,Montgomeryshire and Glyndwr,Powys,Powys,W05001152,W07000102,W06000023,W06000023
+2024,2024,Llanidloes,Montgomeryshire and Glyndwr,Powys,Powys,W05001153,W07000102,W06000023,W06000023
+2024,2024,Llanrhaeadr-ym-Mochnant and Llansilin,Montgomeryshire and Glyndwr,Powys,Powys,W05001154,W07000102,W06000023,W06000023
+2024,2024,Llansantffraid,Montgomeryshire and Glyndwr,Powys,Powys,W05001155,W07000102,W06000023,W06000023
+2024,2024,Llanwrtyd Wells,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001156,W07000085,W06000023,W06000023
+2024,2024,Llanyre with Nantmel,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001157,W07000085,W06000023,W06000023
+2024,2024,Machynlleth,Montgomeryshire and Glyndwr,Powys,Powys,W05001158,W07000102,W06000023,W06000023
+2024,2024,Maescar and Llywel,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001159,W07000085,W06000023,W06000023
+2024,2024,Newtown Central and South,Montgomeryshire and Glyndwr,Powys,Powys,W05001160,W07000102,W06000023,W06000023
+2024,2024,Newtown East,Montgomeryshire and Glyndwr,Powys,Powys,W05001161,W07000102,W06000023,W06000023
+2024,2024,Newtown North,Montgomeryshire and Glyndwr,Powys,Powys,W05001162,W07000102,W06000023,W06000023
+2024,2024,Newtown West,Montgomeryshire and Glyndwr,Powys,Powys,W05001163,W07000102,W06000023,W06000023
+2024,2024,Old Radnor,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001164,W07000085,W06000023,W06000023
+2024,2024,Presteigne,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001165,W07000085,W06000023,W06000023
+2024,2024,Rhayader,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001166,W07000085,W06000023,W06000023
+2024,2024,Rhiwcynon,Montgomeryshire and Glyndwr,Powys,Powys,W05001167,W07000102,W06000023,W06000023
+2024,2024,Talgarth,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001168,W07000085,W06000023,W06000023
+2024,2024,Talybont-on-Usk,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001169,W07000085,W06000023,W06000023
+2024,2024,Tawe Uchaf,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001170,W07000085,W06000023,W06000023
+2024,2024,Trelystan and Trewern,Montgomeryshire and Glyndwr,Powys,Powys,W05001171,W07000102,W06000023,W06000023
+2024,2024,Welshpool Castle,Montgomeryshire and Glyndwr,Powys,Powys,W05001172,W07000102,W06000023,W06000023
+2024,2024,Welshpool Gungrog,Montgomeryshire and Glyndwr,Powys,Powys,W05001173,W07000102,W06000023,W06000023
+2024,2024,Welshpool Llanerchyddol,Montgomeryshire and Glyndwr,Powys,Powys,W05001174,W07000102,W06000023,W06000023
+2024,2024,Ynyscedwyn,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001175,W07000085,W06000023,W06000023
+2024,2024,Yscir with Honddu Isaf and Llanddew,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001176,W07000085,W06000023,W06000023
+2024,2024,Bedlinog and Trelewis,Merthyr Tydfil and Aberdare,Merthyr Tydfil,Merthyr Tydfil,W05001616,W07000099,W06000024,W06000024
+2024,2024,Cyfarthfa,Merthyr Tydfil and Aberdare,Merthyr Tydfil,Merthyr Tydfil,W05001617,W07000099,W06000024,W06000024
+2024,2024,Dowlais and Pant,Merthyr Tydfil and Aberdare,Merthyr Tydfil,Merthyr Tydfil,W05001618,W07000099,W06000024,W06000024
+2024,2024,Gurnos,Merthyr Tydfil and Aberdare,Merthyr Tydfil,Merthyr Tydfil,W05001619,W07000099,W06000024,W06000024
+2024,2024,Merthyr Vale,Merthyr Tydfil and Aberdare,Merthyr Tydfil,Merthyr Tydfil,W05001620,W07000099,W06000024,W06000024
+2024,2024,Park,Merthyr Tydfil and Aberdare,Merthyr Tydfil,Merthyr Tydfil,W05001621,W07000099,W06000024,W06000024
+2024,2024,Penydarren,Merthyr Tydfil and Aberdare,Merthyr Tydfil,Merthyr Tydfil,W05001622,W07000099,W06000024,W06000024
+2024,2024,Plymouth,Merthyr Tydfil and Aberdare,Merthyr Tydfil,Merthyr Tydfil,W05001623,W07000099,W06000024,W06000024
+2024,2024,Town,Merthyr Tydfil and Aberdare,Merthyr Tydfil,Merthyr Tydfil,W05001624,W07000099,W06000024,W06000024
+2024,2024,Treharris,Merthyr Tydfil and Aberdare,Merthyr Tydfil,Merthyr Tydfil,W05001625,W07000099,W06000024,W06000024
+2024,2024,Vaynor,Merthyr Tydfil and Aberdare,Merthyr Tydfil,Merthyr Tydfil,W05001626,W07000099,W06000024,W06000024
+2024,2024,Rogerstone West,Newport West and Islwyn,Newport,Newport,W05001642,W07000105,W06000022,W06000022
+2024,2024,Shaftesbury,Newport East,Newport,Newport,W05001643,W07000104,W06000022,W06000022
+2024,2024,St Julians,Newport East,Newport,Newport,W05001644,W07000104,W06000022,W06000022
+2024,2024,Stow Hill,Newport East,Newport,Newport,W05001645,W07000104,W06000022,W06000022
+2024,2024,Splott,Cardiff South and Penarth,Cardiff,Cardiff,W05001295,W07000091,W06000015,W06000015
+2024,2024,Tredegar Park and Marshfield,Newport West and Islwyn,Newport,Newport,W05001646,W07000105,W06000022,W06000022
+2024,2024,Trowbridge,Cardiff East,Cardiff,Cardiff,W05001296,W07000089,W06000015,W06000015
+2024,2024,Pontypridd Town,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001100,W07000106,W06000016,W06000016
+2024,2024,Porth,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001101,W07000107,W06000016,W06000016
+2024,2024,Rhydfelen Central,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001102,W07000106,W06000016,W06000016
+2024,2024,Taff's Well,Cardiff North,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001103,W07000090,W06000016,W06000016
+2024,2024,Ton-teg,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001104,W07000106,W06000016,W06000016
+2024,2024,Tonypandy,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001105,W07000107,W06000016,W06000016
+2024,2024,Tonyrefail East,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001106,W07000107,W06000016,W06000016
+2024,2024,Victoria,Newport East,Newport,Newport,W05001647,W07000104,W06000022,W06000022
+2024,2024,Tonyrefail West,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001107,W07000107,W06000016,W06000016
+2024,2024,Trallwng,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001108,W07000106,W06000016,W06000016
+2024,2024,Aber-craf and Ystradgynlais,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001117,W07000085,W06000023,W06000023
+2024,2024,Trealaw,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001109,W07000107,W06000016,W06000016
+2024,2024,"Banwy, Llanfihangel and Llanwddyn",Montgomeryshire and Glyndwr,Powys,Powys,W05001118,W07000102,W06000023,W06000023
+2024,2024,Treforest,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001110,W07000106,W06000016,W06000016
+2024,2024,Berriew and Castle Caereinion,Montgomeryshire and Glyndwr,Powys,Powys,W05001119,W07000102,W06000023,W06000023
+2024,2024,Treherbert,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001111,W07000107,W06000016,W06000016
+2024,2024,Brecon East,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001120,W07000085,W06000023,W06000023
+2024,2024,Treorchy,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001112,W07000107,W06000016,W06000016
+2024,2024,Brecon West,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001121,W07000085,W06000023,W06000023
+2024,2024,Tylorstown and Ynyshir,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001113,W07000107,W06000016,W06000016
+2024,2024,Bronllys and Felin-fach,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001122,W07000085,W06000023,W06000023
+2024,2024,Whitchurch and Tongwynlais,Cardiff North,Cardiff,Cardiff,W05001297,W07000090,W06000015,W06000015
+2024,2024,Upper Rhydfelen and Glyn-taf,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001114,W07000106,W06000016,W06000016
+2024,2024,Aberaman,Merthyr Tydfil and Aberdare,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001071,W07000099,W06000016,W06000016
+2024,2024,Builth,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001123,W07000085,W06000023,W06000023
+2024,2024,Ynysybwl,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001115,W07000106,W06000016,W06000016
+2024,2024,Abercynon,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001072,W07000106,W06000016,W06000016
+2024,2024,Caersws,Montgomeryshire and Glyndwr,Powys,Powys,W05001124,W07000102,W06000023,W06000023
+2024,2024,Ystrad,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001116,W07000107,W06000016,W06000016
+2024,2024,Aberdare East,Merthyr Tydfil and Aberdare,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001073,W07000099,W06000016,W06000016
+2024,2024,Churchstoke,Montgomeryshire and Glyndwr,Powys,Powys,W05001125,W07000102,W06000023,W06000023
+2024,2024,Aber Valley,Caerphilly,Caerphilly,Caerphilly,W05001648,W07000088,W06000018,W06000018
+2024,2024,Aberdare West and Llwydcoed,Merthyr Tydfil and Aberdare,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001074,W07000099,W06000016,W06000016
+2024,2024,Crickhowell with Cwmdu and Tretower,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001126,W07000085,W06000023,W06000023
+2024,2024,Aberbargoed and Bargoed,Blaenau Gwent and Rhymney,Caerphilly,Caerphilly,W05001649,W07000084,W06000018,W06000018
+2024,2024,Beddau and Tyn-y-nant,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001075,W07000106,W06000016,W06000016
+2024,2024,Cwm-twrch,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001127,W07000085,W06000023,W06000023
+2024,2024,Brynna and Llanharan,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001076,W07000106,W06000016,W06000016
+2024,2024,Abercarn,Newport West and Islwyn,Caerphilly,Caerphilly,W05001650,W07000105,W06000018,W06000018
+2024,2024,Disserth and Trecoed with Newbridge,"Brecon, Radnor and Cwm Tawe",Powys,Powys,W05001128,W07000085,W06000023,W06000023
+2024,2024,Church Village,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001077,W07000106,W06000016,W06000016
+2024,2024,Argoed,Newport West and Islwyn,Caerphilly,Caerphilly,W05001651,W07000105,W06000018,W06000018
+2024,2024,Dolforwyn,Montgomeryshire and Glyndwr,Powys,Powys,W05001129,W07000102,W06000023,W06000023
+2024,2024,Cilfynydd,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001078,W07000106,W06000016,W06000016
+2024,2024,Bedwas and Trethomas,Caerphilly,Caerphilly,Caerphilly,W05001652,W07000088,W06000018,W06000018
+2024,2024,Forden and Montgomery,Montgomeryshire and Glyndwr,Powys,Powys,W05001130,W07000102,W06000023,W06000023
+2024,2024,Cwm Clydach,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001079,W07000107,W06000016,W06000016
+2024,2024,Blackwood,Newport West and Islwyn,Caerphilly,Caerphilly,W05001653,W07000105,W06000018,W06000018
+2024,2024,Glantwymyn,Montgomeryshire and Glyndwr,Powys,Powys,W05001131,W07000102,W06000023,W06000023
+2024,2024,Cwmbach,Merthyr Tydfil and Aberdare,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001080,W07000099,W06000016,W06000016
+2024,2024,Cefn Fforest and Pengam,Caerphilly,Caerphilly,Caerphilly,W05001654,W07000088,W06000018,W06000018
+2024,2024,Cymer,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001081,W07000106,W06000016,W06000016
+2024,2024,Cefn Fforest and Pengam,Newport West and Islwyn,Caerphilly,Caerphilly,W05001654,W07000105,W06000018,W06000018
+2024,2024,Cymer,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001081,W07000107,W06000016,W06000016
+2024,2024,Crosskeys,Newport West and Islwyn,Caerphilly,Caerphilly,W05001655,W07000105,W06000018,W06000018
+2024,2024,Crumlin,Newport West and Islwyn,Caerphilly,Caerphilly,W05001656,W07000105,W06000018,W06000018
+2024,2024,Darran Valley,Blaenau Gwent and Rhymney,Caerphilly,Caerphilly,W05001657,W07000084,W06000018,W06000018
+2024,2024,Gilfach,Blaenau Gwent and Rhymney,Caerphilly,Caerphilly,W05001658,W07000084,W06000018,W06000018
+2024,2024,Hengoed,Caerphilly,Caerphilly,Caerphilly,W05001659,W07000088,W06000018,W06000018
+2024,2024,Llanbradach,Caerphilly,Caerphilly,Caerphilly,W05001660,W07000088,W06000018,W06000018
+2024,2024,Machen and Rudry,Caerphilly,Caerphilly,Caerphilly,W05001661,W07000088,W06000018,W06000018
+2024,2024,Maesycwmmer,Caerphilly,Caerphilly,Caerphilly,W05001662,W07000088,W06000018,W06000018
+2024,2024,Morgan Jones,Caerphilly,Caerphilly,Caerphilly,W05001663,W07000088,W06000018,W06000018
+2024,2024,Moriah and Pontlottyn,Blaenau Gwent and Rhymney,Caerphilly,Caerphilly,W05001664,W07000084,W06000018,W06000018
+2024,2024,Nelson,Caerphilly,Caerphilly,Caerphilly,W05001665,W07000088,W06000018,W06000018
+2024,2024,New Tredegar,Blaenau Gwent and Rhymney,Caerphilly,Caerphilly,W05001666,W07000084,W06000018,W06000018
+2024,2024,Newbridge,Newport West and Islwyn,Caerphilly,Caerphilly,W05001667,W07000105,W06000018,W06000018
+2024,2024,Penmaen,Newport West and Islwyn,Caerphilly,Caerphilly,W05001668,W07000105,W06000018,W06000018
+2024,2024,Penyrheol,Caerphilly,Caerphilly,Caerphilly,W05001669,W07000088,W06000018,W06000018
+2024,2024,Pontllanfraith,Caerphilly,Caerphilly,Caerphilly,W05001670,W07000088,W06000018,W06000018
+2024,2024,Risca East,Newport West and Islwyn,Caerphilly,Caerphilly,W05001671,W07000105,W06000018,W06000018
+2024,2024,Ferndale and Maerdy,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001082,W07000107,W06000016,W06000016
+2024,2024,Gilfach-goch,Rhondda and Ogmore,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001083,W07000107,W06000016,W06000016
+2024,2024,Glyn-coch,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001084,W07000106,W06000016,W06000016
+2024,2024,Graig and Pontypridd West,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001085,W07000106,W06000016,W06000016
+2024,2024,Hawthorn and Lower Rhydfelen,Pontypridd,Rhondda Cynon Taf,Rhondda Cynon Taf,W05001086,W07000106,W06000016,W06000016
 2021,2023,Burn Valley,Hartlepool,Hartlepool,Hartlepool,E05013038,E14000733,E06000001,E06000001
 2021,2023,De Bruce,Hartlepool,Hartlepool,Hartlepool,E05013039,E14000733,E06000001,E06000001
 2021,2023,Fens & Greatham,Hartlepool,Hartlepool,Hartlepool,E05013040,E14000733,E06000001,E06000001
@@ -8019,12 +16817,6 @@ first_available_year_included,most_recent_year_included,ward_name,pcon_name,lad_
 2017,2023,Inverclyde West,Inverclyde,Inverclyde,Inverclyde,S13003015,S14000038,S12000018,S12000018
 2017,2023,Inverclyde South West,Inverclyde,Inverclyde,Inverclyde,S13003016,S14000038,S12000018,S12000018
 2017,2023,Inverclyde South,Inverclyde,Inverclyde,Inverclyde,S13003017,S14000038,S12000018,S12000018
-2017,2023,Penicuik,Midlothian,Midlothian,Midlothian,S13003018,S14000045,S12000019,S12000019
-2017,2023,Bonnyrigg,Midlothian,Midlothian,Midlothian,S13003019,S14000045,S12000019,S12000019
-2017,2023,Dalkeith,Midlothian,Midlothian,Midlothian,S13003020,S14000045,S12000019,S12000019
-2017,2023,Midlothian West,Midlothian,Midlothian,Midlothian,S13003021,S14000045,S12000019,S12000019
-2017,2023,Midlothian East,Midlothian,Midlothian,Midlothian,S13003022,S14000045,S12000019,S12000019
-2017,2023,Midlothian South,Midlothian,Midlothian,Midlothian,S13003023,S14000045,S12000019,S12000019
 2017,2023,Speyside Glenlivet,Moray,Moray,Moray,S13003024,S14000046,S12000020,S12000020
 2017,2023,Keith and Cullen,Moray,Moray,Moray,S13003025,S14000046,S12000020,S12000020
 2017,2023,Buckie,Moray,Moray,Moray,S13003026,S14000046,S12000020,S12000020
@@ -8034,21 +16826,9 @@ first_available_year_included,most_recent_year_included,ward_name,pcon_name,lad_
 2017,2023,Elgin City South,Moray,Moray,Moray,S13003030,S14000046,S12000020,S12000020
 2017,2023,Forres,Moray,Moray,Moray,S13003031,S14000046,S12000020,S12000020
 2017,2023,Irvine West,Central Ayrshire,North Ayrshire,North Ayrshire,S13003032,S14000010,S12000021,S12000021
-2017,2023,Irvine West,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003032,S14000048,S12000021,S12000021
 2017,2023,Irvine East,Central Ayrshire,North Ayrshire,North Ayrshire,S13003033,S14000010,S12000021,S12000021
 2017,2023,Kilwinning,Central Ayrshire,North Ayrshire,North Ayrshire,S13003034,S14000010,S12000021,S12000021
-2017,2023,Kilwinning,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003034,S14000048,S12000021,S12000021
 2017,2023,Irvine South,Central Ayrshire,North Ayrshire,North Ayrshire,S13003041,S14000010,S12000021,S12000021
-2022,2023,Ardrossan,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003145,S14000048,S12000021,S12000021
-2022,2023,Arran,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003146,S14000048,S12000021,S12000021
-2022,2023,Garnock Valley,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003147,S14000048,S12000021,S12000021
-2022,2023,North Coast,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003148,S14000048,S12000021,S12000021
-2022,2023,Saltcoats and Stevenston,North Ayrshire and Arran,North Ayrshire,North Ayrshire,S13003149,S14000048,S12000021,S12000021
-2017,2023,Stromness and South Isles,Orkney and Shetland,Orkney Islands,Orkney Islands,S13002734,S14000051,S12000023,S12000023
-2017,2023,West Mainland,Orkney and Shetland,Orkney Islands,Orkney Islands,S13002735,S14000051,S12000023,S12000023
-2017,2023,North Isles,Orkney and Shetland,Orkney Islands,Orkney Islands,S13002737,S14000051,S12000023,S12000023
-2022,2023,"East Mainland, South Ronaldsay and Burray",Orkney and Shetland,Orkney Islands,Orkney Islands,S13003150,S14000051,S12000023,S12000023
-2022,2023,Kirkwall East,Orkney and Shetland,Orkney Islands,Orkney Islands,S13003151,S14000051,S12000023,S12000023
 2017,2023,Cambuslang West,"East Kilbride, Strathaven and Lesmahagow",South Lanarkshire,South Lanarkshire,S13003107,S14000019,S12000029,S12000029
 2017,2023,City Centre,Edinburgh East,City of Edinburgh,City of Edinburgh,S13002929,S14000022,S12000036,S12000036
 2017,2023,City Centre,Edinburgh North and Leith,City of Edinburgh,City of Edinburgh,S13002929,S14000023,S12000036,S12000036
@@ -8256,22 +17036,6 @@ first_available_year_included,most_recent_year_included,ward_name,pcon_name,lad_
 2017,2023,North Berwick Coastal,East Lothian,East Lothian,East Lothian,S13002911,S14000020,S12000010,S12000010
 2017,2023,Haddington and Lammermuir,East Lothian,East Lothian,East Lothian,S13002912,S14000020,S12000010,S12000010
 2017,2023,Dunbar and East Linton,East Lothian,East Lothian,East Lothian,S13002913,S14000020,S12000010,S12000010
-2017,2023,"Barrhead, Liboside and Uplawmoor",East Renfrewshire,East Renfrewshire,East Renfrewshire,S13002914,S14000021,S12000011,S12000011
-2017,2023,Newton Mearns North and Neilston,East Renfrewshire,East Renfrewshire,East Renfrewshire,S13002915,S14000021,S12000011,S12000011
-2017,2023,Giffnock and Thornliebank,East Renfrewshire,East Renfrewshire,East Renfrewshire,S13002916,S14000021,S12000011,S12000011
-2017,2023,"Clarkston, Netherlee and Williamwood",East Renfrewshire,East Renfrewshire,East Renfrewshire,S13002917,S14000021,S12000011,S12000011
-2017,2023,Newton Mearns South and Eaglesham,East Renfrewshire,East Renfrewshire,East Renfrewshire,S13002918,S14000021,S12000011,S12000011
-2017,2023,An Taobh Siar agus Nis,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13002608,S14000027,S12000013,S12000013
-2022,2023,Barraigh agus Bhatarsaigh,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003135,S14000027,S12000013,S12000013
-2022,2023,Loch a Tuath,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003136,S14000027,S12000013,S12000013
-2022,2023,Na Hearadh,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003137,S14000027,S12000013,S12000013
-2022,2023,Sgìr Ùige agus Càrlabhagh,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003138,S14000027,S12000013,S12000013
-2022,2023,Sgìre an Rubha,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003139,S14000027,S12000013,S12000013
-2022,2023,Sgìre nan Loch,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003140,S14000027,S12000013,S12000013
-2022,2023,Steòrnabhagh a Deas,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003141,S14000027,S12000013,S12000013
-2022,2023,Steòrnabhagh a Tuath,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003142,S14000027,S12000013,S12000013
-2022,2023,"Uibhist a Deas, Èirisgeigh agus Beinn na Faoghla",Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003143,S14000027,S12000013,S12000013
-2022,2023,Uibhist a Tuath,Na h-Eileanan an Iar,Na h-Eileanan Siar,Na h-Eileanan Siar,S13003144,S14000027,S12000013,S12000013
 2017,2023,Bo'ness and Blackness,Linlithgow and East Falkirk,Falkirk,Falkirk,S13002936,S14000043,S12000014,S12000014
 2017,2023,Grangemouth,Linlithgow and East Falkirk,Falkirk,Falkirk,S13002937,S14000043,S12000014,S12000014
 2017,2023,Denny and Banknock,Falkirk,Falkirk,Falkirk,S13002938,S14000028,S12000014,S12000014
@@ -8349,7 +17113,6 @@ first_available_year_included,most_recent_year_included,ward_name,pcon_name,lad_
 2017,2023,Ballochmyle,Kilmarnock and Loudoun,East Ayrshire,East Ayrshire,S13002898,S14000040,S12000008,S12000008
 2017,2023,Cumnock and New Cumnock,"Ayr, Carrick and Cumnock",East Ayrshire,East Ayrshire,S13002899,S14000006,S12000008,S12000008
 2017,2023,Cumnock and New Cumnock,Kilmarnock and Loudoun,East Ayrshire,East Ayrshire,S13002899,S14000040,S12000008,S12000008
-2022,2023,Kirkwall West and Orphir,Orkney and Shetland,Orkney Islands,Orkney Islands,S13003152,S14000051,S12000023,S12000023
 2017,2023,Tweeddale West,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002761,S14000008,S12000026,S12000026
 2017,2023,Tweeddale West,"Dumfriesshire, Clydesdale and Tweeddale",Scottish Borders,Scottish Borders,S13002761,S14000014,S12000026,S12000026
 2017,2023,Tweeddale East,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002762,S14000008,S12000026,S12000026
@@ -8364,13 +17127,6 @@ first_available_year_included,most_recent_year_included,ward_name,pcon_name,lad_
 2017,2023,Jedburgh and District,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002769,S14000008,S12000026,S12000026
 2017,2023,Hawick and Denholm,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002770,S14000008,S12000026,S12000026
 2017,2023,Hawick and Hermitage,"Berwickshire, Roxburgh and Selkirk",Scottish Borders,Scottish Borders,S13002771,S14000008,S12000026,S12000026
-2017,2023,North Isles,Orkney and Shetland,Shetland Islands,Shetland Islands,S13002772,S14000051,S12000027,S12000027
-2017,2023,Shetland North,Orkney and Shetland,Shetland Islands,Shetland Islands,S13002773,S14000051,S12000027,S12000027
-2022,2023,Lerwick North and Bressay,Orkney and Shetland,Shetland Islands,Shetland Islands,S13002777,S14000051,S12000027,S12000027
-2022,2023,Lerwick South,Orkney and Shetland,Shetland Islands,Shetland Islands,S13003153,S14000051,S12000027,S12000027
-2022,2023,Shetland Central,Orkney and Shetland,Shetland Islands,Shetland Islands,S13003154,S14000051,S12000027,S12000027
-2022,2023,Shetland South,Orkney and Shetland,Shetland Islands,Shetland Islands,S13003155,S14000051,S12000027,S12000027
-2022,2023,Shetland West,Orkney and Shetland,Shetland Islands,Shetland Islands,S13003156,S14000051,S12000027,S12000027
 2017,2023,Troon,Central Ayrshire,South Ayrshire,South Ayrshire,S13003087,S14000010,S12000028,S12000028
 2017,2023,Prestwick,Central Ayrshire,South Ayrshire,South Ayrshire,S13003088,S14000010,S12000028,S12000028
 2017,2023,Ayr North,"Ayr, Carrick and Cumnock",South Ayrshire,South Ayrshire,S13003089,S14000006,S12000028,S12000028


### PR DESCRIPTION
# Brief overview of changes

Add the 2024 version of the Ward - PCon - LAD - LA file

## Why are these changes being made?

ONS have recently published this, and we want to use this file as the basis for the lookups in the EduStat briefing tool

## Detailed description of changes

1. Moved data pre scripts into manual scripts for tidyness
2. Added a PR template in line with the one in dfeR
3. Updated lookup updates function to strip out _NMW columns for Welsh names
4. Updated the Ward - PCon - LAD - LA file, using the https://geoportal.statistics.gov.uk/datasets/62eb9df29a2f4521b5076a419ff9a47e_0/explore file ONS published on the 4th June.

## Additional information for reviewers

Have intentionally not gone ahead with the clean up of the other look ups yet as I think that should be separate, and will need to consider the custom locations we want to add in such as 'Unknown' and 'Outside of England' etc..

## Issue ticket number/s and link

Fixes #117, have raised #118 to cover follow up work.