### PR TITLE
remove whitespace from text around links on homepage

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -59,7 +59,7 @@ fluidPage(
           br(),
           br(),
           "The code for this app can be found on ",
-          a(href = "https://github.com/dfe-analytical-services/dfe-published-data-qa", "GitHub", target = "_blank", rel = "noopener noreferrer"),
+          a(href = "https://github.com/dfe-analytical-services/dfe-published-data-qa", "GitHub", target = "_blank", rel = "noopener noreferrer", .noWS = "after"),
           ".",
           br(),
           br(),
@@ -77,7 +77,7 @@ fluidPage(
           strong("Notes"),
           br(),
           "Currently this app works with files up to 500mb. If you have a file that is bigger than this, please contact us - ",
-          a(href = "mailto:statistics.development@education.gov.uk", "statistics.development@education.gov.uk."),
+          a(href = "mailto:statistics.development@education.gov.uk", "statistics.development@education.gov.uk", .noWS = "after"), ".",
           br(),
           "This app is constantly being developed, please let us know if you have any suggestions to improve it. If you experience any issues, please take screenshots and email them to us with as much information as possible.",
           hr()


### PR DESCRIPTION
Quick one to remove the whitespace where there's links that need to be followed by a full stop.