### PR TITLE
remove 3 year timeseries test

### DIFF
--- a/.github/workflows/automatedTests.yaml
+++ b/.github/workflows/automatedTests.yaml
@@ -24,6 +24,14 @@ jobs:
           
       - name: Install git2r dependencies
         run: sudo apt-get install -y libgit2-dev
+
+      - name: Cache renv packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.RENV_PATHS_ROOT }}
+          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-renv-
       
       - uses: r-lib/actions/setup-renv@v2
           

--- a/.github/workflows/automatedTests.yaml
+++ b/.github/workflows/automatedTests.yaml
@@ -26,6 +26,7 @@ jobs:
         run: sudo apt-get install -y libgit2-dev
 
       - name: Cache renv packages
+        id: cache-renv
         uses: actions/cache@v4
         with:
           path: ${{ env.RENV_PATHS_ROOT }}

--- a/.github/workflows/automatedTests.yaml
+++ b/.github/workflows/automatedTests.yaml
@@ -29,7 +29,7 @@ jobs:
         id: cache-renv
         uses: actions/cache@v4
         with:
-          path: ${{ env.RENV_PATHS_ROOT }}
+          path: screener-renv-cache
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: |
             ${{ runner.os }}-renv-

--- a/R/mainTests.r
+++ b/R/mainTests.r
@@ -18,7 +18,6 @@ mainTests <- function(data_character, meta_character, datafile, metafile) {
       blanks_indicators(data_character, meta_character), # active test
       time_period(datafile), # active test
       time_period_six(datafile), # active test
-      three_years(datafile), # active test
       region_for_la(datafile), # active test
       region_for_lad(datafile), # active test
       geography_level_completed(datafile), # active test
@@ -702,25 +701,6 @@ time_period_six <- function(data) {
         "result" = "PASS"
       )
     }
-  }
-
-  return(output)
-}
-
-# three_years -------------------------------------
-# produce a warning if there are fewer than 3 years of data in the file
-
-three_years <- function(data) {
-  if (length(unique(data$time_period)) < 3) {
-    output <- list(
-      "message" = "The data file contains fewer than three different years of data. <br> - Where it exists, you should include at least 3 years of data in your file to meet upcoming changes in accessibility legislation.",
-      "result" = "ADVISORY"
-    )
-  } else {
-    output <- list(
-      "message" = "The data file contains at least three different years of data.",
-      "result" = "PASS"
-    )
   }
 
   return(output)

--- a/tests/testthat/_snaps/UI-01_example_files/example_files-002.json
+++ b/tests/testthat/_snaps/UI-01_example_files/example_files-002.json
@@ -214,7 +214,7 @@
     }
   },
   "export": {
-    "advisory": 1,
+    "advisory": 0,
     "ancillary": 1,
     "failed": 1,
     "ignored": 17,

--- a/tests/testthat/mainTests/three_years.csv
+++ b/tests/testthat/mainTests/three_years.csv
@@ -1,4 +1,0 @@
-time_period,time_identifier,geographic_level,country_code,country_name,school_type,num_schools,enrolments,sess_overall_percent,sess_authorised_percent,sess_unauthorised_percent,enrolments_pa_10_exact,enrolments_pa_10_exact_percent
-201718,Academic year,National,E92000001,England,Total,20121,6835059,4.20821,3.01996,1.18824,731047,10.69555
-201718,Academic year,National,E92000001,England,State-funded primary,16739,3885774,3.68934,2.69421,0.99512,357742,9.20645
-201718,Academic year,National,E92000001,England,State-funded secondary,3382,2949285,4.89899,3.45364,1.44535,373305,12.65747

--- a/tests/testthat/mainTests/three_years.meta.csv
+++ b/tests/testthat/mainTests/three_years.meta.csv
@@ -1,9 +1,0 @@
-col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
-num_schools,Indicator,Number of schools,Absence fields,,0,,
-enrolments,Indicator,Number of pupil enrolments,Absence fields,,0,,
-sess_overall_percent,Indicator,Overall absence rate,Absence fields,%,0,,
-sess_authorised_percent,Indicator,Authorised absence rate,Absence fields,%,1,,
-sess_unauthorised_percent,Indicator,Unauthorised absence rate,Absence fields,%,2,,
-enrolments_pa_10_exact,Indicator,Number of persistent absentees,Absence fields,,0,,
-enrolments_pa_10_exact_percent,Indicator,Percentage of persistent absentees,Absence fields,%,3,,
-school_type,Filter,School type,,,,Filter by school type,

--- a/tests/testthat/test-function-mainTests.R
+++ b/tests/testthat/test-function-mainTests.R
@@ -102,12 +102,6 @@ test_that("time_period_six", {
   expect_equal(testIndividualTest(pathStart, "time_period_six"), "FAIL")
 })
 
-# three_years -------------------------------------------------------------------------------------------------------
-
-test_that("three_years", {
-  expect_equal(testIndividualTest(pathStart, "three_years"), "ADVISORY")
-})
-
 # region_for_la -------------------------------------------------------------------------------------------------------
 
 test_that("region_for_la", {


### PR DESCRIPTION
This test was originally added at the start as we were trying to encourage all teams to have at least 3 years of data in EES to cover teams back to 2018 when the accessibility regulations came into force. The theory was, if they included a time-series of at least 3 years in a file, they were covering back to at least 2018.

This is now redundant (and has been for a while). To reduce excess code / processing, and also the risk of warning fatigue / blindness, I've now removed it.

Bonus:

I've also added caching back for the packages used in renv for the automated tests GitHub action. The path given doesn't work so doesn't save a cache, but seems to work well enough to allow the caching step to happen and it seems to find a general cache for that version of linux / R. Not entirely sure how or why, though it cut the time from 5 mins to 2 mins so seems to do the trick 🤷