### PR TITLE
add links to open geography portal in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,27 @@ The standard geographies used in this tool are sourced from (or developed with) 
 
 There's an R script in the `R/manual_scripts/` folder containing functions to update both the geography lookups. To use this, download the latest version of the file from the searches linked in the comments of that script, and then save a copy of that data in a new folder called `/data/downloaded_source_data/`. The functions will then append any new data from that CSV into the lookup files.
 
-#### Local skills improvement plan area (LSIP)
+* [Ward / PCon / LAD / LA lookup on Open Geography Portal (2024)](https://geoportal.statistics.gov.uk/datasets/62eb9df29a2f4521b5076a419ff9a47e_0/explore)
 
-These were developed in direct communications with the ONS ([ONS Geography e-mail](mailto:ONS.Geography@ons.gov.uk)) and they provided the basis for the code and name file used in this tool. At the time of writing, this has not been added to the open geography portal, although boundary files have been ([LSIP boundary map files](https://geoportal.statistics.gov.uk/search?collection=Dataset&sort=name&tags=all(BDY_LSIP%2CAUG_2023))).
+Local skills improvement plan area (LSIP) to LAD lookup was developed in direct communications with the ONS ([ONS Geography e-mail](mailto:ONS.Geography@ons.gov.uk)) and they provided the basis for the code and name file used in this tool. 
+
+* [LAD / LSIP lookup on Open Geography Portal (2023)](https://geoportal.statistics.gov.uk/datasets/effcab9660fd4375baaed44c2bd23719_0/explore?q=local%20skills%20lad)
+
+#### Boundary files
+
+Boundary files for use when mapping aren't available in this repo but are published on the Open Geography Portal. 
+
+* [Regions boundary map files](https://geoportal.statistics.gov.uk/search?q=BDY_RGN&sort=Title%7Ctitle%7Casc)
+
+* [Local authority boundary map files (Counties and Unitary Authorities)](https://geoportal.statistics.gov.uk/search?q=BDY_CTYUA&sort=Date%20Created%7Ccreated%7Cdesc)
+
+* [Local authority district boundary map files](https://geoportal.statistics.gov.uk/search?q=BDY_LAD&sort=Date%20Created%7Ccreated%7Cdesc)
+
+* [Westminster Constituency boundary map files](https://geoportal.statistics.gov.uk/search?q=BDY_PCON&sort=Date%20Created%7Ccreated%7Cdesc)
+
+* [Ward boundary map files](https://geoportal.statistics.gov.uk/search?q=BDY_WD&sort=Title%7Ctitle%7Casc)
+
+* [LSIP boundary map files](https://geoportal.statistics.gov.uk/search?collection=Dataset&sort=name&tags=all(BDY_LSIP%2CAUG_2023))
 
 ---
 


### PR DESCRIPTION
<!-- 
Hey, thanks for raising a PR! We're excited to see what you've done!
To help us review the changes, please complete each section in this template by replacing '...' with details to help the reviewers of this pull request. 
-->

# Brief overview of changes

Added links to relevant boundary files on the ONS Geography Portal

## Why are these changes being made?

Prompted by a discussion on #119, which I shortcutted to get the data update in faster. Aim is to give easy access links from the README as the portal can be difficult to navigate.

## Detailed description of changes

Not applicable.

## Additional information for reviewers

None.

## Issue ticket number/s and link

No related issues.