### PR TITLE
Update guidance URLs

### DIFF
--- a/R/fileValidation.r
+++ b/R/fileValidation.r
@@ -189,18 +189,18 @@ file_separator <- function(data, meta) {
     if ((grepl(",", data) == FALSE) && (grepl(",", meta) == FALSE)) {
       output <- list(
         "result" = "FAIL",
-        "message" = paste0("Neither of the data and metadata files appear to be using a comma delimited structure. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data_format' target='_blank'>guidance on how to save the files</a>", " if you are unsure.")
+        "message" = paste0("Neither of the data and metadata files appear to be using a comma delimited structure. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data-format' target='_blank'>guidance on data formats</a> and <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#how-to-export-data-with-utf-8-encoding' target='_blank'>guidance how to save data files in the right format</a>", " if you are unsure.")
       )
     } else {
       if (grepl(",", meta)) {
         output <- list(
           "result" = "FAIL",
-          "message" = paste0("The data file does not appear to be using a comma delimited structure. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data_format' target='_blank'>guidance on how to save the files</a>", " if you are unsure.")
+          "message" = paste0("The data file does not appear to be using a comma delimited structure. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data-format' target='_blank'>guidance on how to save the files</a>", " if you are unsure.")
         )
       } else {
         output <- list(
           "result" = "FAIL",
-          "message" = paste0("The metadata file does not appear to be using a comma delimited structure. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data_format' target='_blank'>guidance on how to save the files</a>", " if you are unsure.")
+          "message" = paste0("The metadata file does not appear to be using a comma delimited structure. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data-format' target='_blank'>guidance on how to save the files</a>", " if you are unsure.")
         )
       }
     }

--- a/R/fileValidation.r
+++ b/R/fileValidation.r
@@ -189,18 +189,18 @@ file_separator <- function(data, meta) {
     if ((grepl(",", data) == FALSE) && (grepl(",", meta) == FALSE)) {
       output <- list(
         "result" = "FAIL",
-        "message" = paste0("Neither of the data and metadata files appear to be using a comma delimited structure. <br> - See the ", "<a href='https://rsconnect/rsc/stats-production-guidance/ud.html#data_format' target='_blank'>guidance on how to save the files</a>", " if you are unsure.")
+        "message" = paste0("Neither of the data and metadata files appear to be using a comma delimited structure. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data_format' target='_blank'>guidance on how to save the files</a>", " if you are unsure.")
       )
     } else {
       if (grepl(",", meta)) {
         output <- list(
           "result" = "FAIL",
-          "message" = paste0("The data file does not appear to be using a comma delimited structure. <br> - See the ", "<a href='https://rsconnect/rsc/stats-production-guidance/ud.html#data_format' target='_blank'>guidance on how to save the files</a>", " if you are unsure.")
+          "message" = paste0("The data file does not appear to be using a comma delimited structure. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data_format' target='_blank'>guidance on how to save the files</a>", " if you are unsure.")
         )
       } else {
         output <- list(
           "result" = "FAIL",
-          "message" = paste0("The metadata file does not appear to be using a comma delimited structure. <br> - See the ", "<a href='https://rsconnect/rsc/stats-production-guidance/ud.html#data_format' target='_blank'>guidance on how to save the files</a>", " if you are unsure.")
+          "message" = paste0("The metadata file does not appear to be using a comma delimited structure. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data_format' target='_blank'>guidance on how to save the files</a>", " if you are unsure.")
         )
       }
     }

--- a/R/mainTests.r
+++ b/R/mainTests.r
@@ -141,7 +141,7 @@ variable_characteristic <- function(meta) {
       "message" = paste(
         "The fields characteristic and/or characteristic_group have been included in the data.",
         "These are not recommended for use with the EES Table Tool.",
-        "Please refer to the <a href='https://rsconnect/rsc/stats-production-guidance/ud.html#Introduction_to_filters'>guidance pages on filters</a>."
+        "Please refer to the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#Introduction_to_filters'>guidance pages on filters</a>."
       ),
       "result" = "ADVISORY"
     )
@@ -639,7 +639,7 @@ time_period <- function(data) {
   if (base_identifier %in% four_digit_identifiers) {
     if ((nrow(filter(time_length, digits == 4)) == nrow(time_length)) == FALSE) {
       output <- list(
-        "message" = paste0("The time_period length for '", paste(base_identifier), "' must always be a four digit number. <br> - Please check the ", "<a href='https://rsconnect/rsc/stats-production-guidance/ud.html#list_of_allowable_time_values' target='_blank'>guidance website</a> if you are unsure."),
+        "message" = paste0("The time_period length for '", paste(base_identifier), "' must always be a four digit number. <br> - Please check the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#list_of_allowable_time_values' target='_blank'>guidance website</a> if you are unsure."),
         "result" = "FAIL"
       )
     } else {
@@ -653,7 +653,7 @@ time_period <- function(data) {
   if (base_identifier %in% six_digit_identifiers) {
     if ((nrow(filter(time_length, digits == 6)) == nrow(time_length)) == FALSE) {
       output <- list(
-        "message" = paste0("The time_period length for '", paste(base_identifier), "' must always be a six digit number. <br> - Please check the ", "<a href='https://rsconnect/rsc/stats-production-guidance/ud.html#list_of_allowable_time_values' target='_blank'>guidance website</a> if you are unsure."),
+        "message" = paste0("The time_period length for '", paste(base_identifier), "' must always be a six digit number. <br> - Please check the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#list_of_allowable_time_values' target='_blank'>guidance website</a> if you are unsure."),
         "result" = "FAIL"
       )
     } else {
@@ -850,7 +850,7 @@ geography_level_completed <- function(data) {
       output <- list(
         "message" = paste0(
           "The following columns should be completed for all rows of the associated level that they refer to: <br> - '", paste0(incomplete_geographies, collapse = "', '"), "' . <br> - If you are unsure of the levels that they refer to, please check the ",
-          "<a href='https://rsconnect/rsc/stats-production-guidance/ud.html#allowable_geographic_levels' target='_blank'>allowable geographic values table</a>."
+          "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#allowable_geographic_levels' target='_blank'>allowable geographic values table</a>."
         ),
         "result" = "FAIL"
       )
@@ -2645,7 +2645,7 @@ ethnicity_values <- function(data) {
       "message" = paste0(
         "The ethnicity filter ", value_type, " '",
         paste(ethnicity_nonstandard, collapse = "', '"),
-        "' does not conform to the GSS standards. Please cross check against the <a href='https://rsconnect/rsc/stats-production-guidance/ud.html#Ethnicity'>published standards</a>."
+        "' does not conform to the GSS standards. Please cross check against the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#Ethnicity'>published standards</a>."
       ),
       "result" = "ADVISORY"
     )
@@ -2654,7 +2654,7 @@ ethnicity_values <- function(data) {
       "message" = paste0(
         "The following ethnicity filter ", value_type, "s do not conform to the GSS standards: <br> - '",
         paste(ethnicity_nonstandard, collapse = "', '"),
-        "'. <br> - Please cross check against the <a href='https://rsconnect/rsc/stats-production-guidance/ud.html#Ethnicity'>published standards</a>."
+        "'. <br> - Please cross check against the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#Ethnicity'>published standards</a>."
       ),
       "result" = "ADVISORY"
     )
@@ -2730,7 +2730,7 @@ ethnicity_characteristic_values <- function(data) {
         "message" = paste0(
           "The ethnicity filter value '",
           paste(ethnicity_nonstandard, collapse = "', '"),
-          "' does not conform to the GSS standards. Please cross check against the <a href='https://rsconnect/rsc/stats-production-guidance/ud.html#Ethnicity'>published standards</a>."
+          "' does not conform to the GSS standards. Please cross check against the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#Ethnicity'>published standards</a>."
         ),
         "result" = "ADVISORY"
       )
@@ -2739,7 +2739,7 @@ ethnicity_characteristic_values <- function(data) {
         "message" = paste0(
           "The following ethnicity filter values do not conform to the GSS standards: <br> - '",
           paste(ethnicity_nonstandard, collapse = "', '"),
-          "'. <br> - Please cross check against the <a href='https://rsconnect/rsc/stats-production-guidance/ud.html#Ethnicity'>published standards</a>."
+          "'. <br> - Please cross check against the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#Ethnicity'>published standards</a>."
         ),
         "result" = "ADVISORY"
       )

--- a/R/mainTests.r
+++ b/R/mainTests.r
@@ -141,7 +141,7 @@ variable_characteristic <- function(meta) {
       "message" = paste(
         "The fields characteristic and/or characteristic_group have been included in the data.",
         "These are not recommended for use with the EES Table Tool.",
-        "Please refer to the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#Introduction_to_filters'>guidance pages on filters</a>."
+        "Please refer to the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#introduction-to-filters'>guidance pages on filters</a>."
       ),
       "result" = "ADVISORY"
     )
@@ -639,7 +639,7 @@ time_period <- function(data) {
   if (base_identifier %in% four_digit_identifiers) {
     if ((nrow(filter(time_length, digits == 4)) == nrow(time_length)) == FALSE) {
       output <- list(
-        "message" = paste0("The time_period length for '", paste(base_identifier), "' must always be a four digit number. <br> - Please check the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#list_of_allowable_time_values' target='_blank'>guidance website</a> if you are unsure."),
+        "message" = paste0("The time_period length for '", paste(base_identifier), "' must always be a four digit number. <br> - Please check the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#list-of-allowable-time-values' target='_blank'>guidance website</a> if you are unsure."),
         "result" = "FAIL"
       )
     } else {
@@ -653,7 +653,7 @@ time_period <- function(data) {
   if (base_identifier %in% six_digit_identifiers) {
     if ((nrow(filter(time_length, digits == 6)) == nrow(time_length)) == FALSE) {
       output <- list(
-        "message" = paste0("The time_period length for '", paste(base_identifier), "' must always be a six digit number. <br> - Please check the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#list_of_allowable_time_values' target='_blank'>guidance website</a> if you are unsure."),
+        "message" = paste0("The time_period length for '", paste(base_identifier), "' must always be a six digit number. <br> - Please check the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#list-of-allowable-time-values' target='_blank'>guidance website</a> if you are unsure."),
         "result" = "FAIL"
       )
     } else {
@@ -850,7 +850,7 @@ geography_level_completed <- function(data) {
       output <- list(
         "message" = paste0(
           "The following columns should be completed for all rows of the associated level that they refer to: <br> - '", paste0(incomplete_geographies, collapse = "', '"), "' . <br> - If you are unsure of the levels that they refer to, please check the ",
-          "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#allowable_geographic_levels' target='_blank'>allowable geographic values table</a>."
+          "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#allowable-geographic-levels' target='_blank'>allowable geographic values table</a>."
         ),
         "result" = "FAIL"
       )
@@ -2645,7 +2645,7 @@ ethnicity_values <- function(data) {
       "message" = paste0(
         "The ethnicity filter ", value_type, " '",
         paste(ethnicity_nonstandard, collapse = "', '"),
-        "' does not conform to the GSS standards. Please cross check against the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#Ethnicity'>published standards</a>."
+        "' does not conform to the GSS standards. Please cross check against the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#ethnicity'>published standards</a>."
       ),
       "result" = "ADVISORY"
     )
@@ -2654,7 +2654,7 @@ ethnicity_values <- function(data) {
       "message" = paste0(
         "The following ethnicity filter ", value_type, "s do not conform to the GSS standards: <br> - '",
         paste(ethnicity_nonstandard, collapse = "', '"),
-        "'. <br> - Please cross check against the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#Ethnicity'>published standards</a>."
+        "'. <br> - Please cross check against the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#ethnicity'>published standards</a>."
       ),
       "result" = "ADVISORY"
     )
@@ -2730,7 +2730,7 @@ ethnicity_characteristic_values <- function(data) {
         "message" = paste0(
           "The ethnicity filter value '",
           paste(ethnicity_nonstandard, collapse = "', '"),
-          "' does not conform to the GSS standards. Please cross check against the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#Ethnicity'>published standards</a>."
+          "' does not conform to the GSS standards. Please cross check against the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#ethnicity'>published standards</a>."
         ),
         "result" = "ADVISORY"
       )
@@ -2739,7 +2739,7 @@ ethnicity_characteristic_values <- function(data) {
         "message" = paste0(
           "The following ethnicity filter values do not conform to the GSS standards: <br> - '",
           paste(ethnicity_nonstandard, collapse = "', '"),
-          "'. <br> - Please cross check against the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#Ethnicity'>published standards</a>."
+          "'. <br> - Please cross check against the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#ethnicity'>published standards</a>."
         ),
         "result" = "ADVISORY"
       )

--- a/R/preCheck2.r
+++ b/R/preCheck2.r
@@ -36,7 +36,7 @@ time_identifier_mix <- function(data) {
 
   if (any(is.na(factor(unique(data$time_identifier), base_level))) == TRUE) {
     output <- list(
-      "message" = paste0("The datafile is mixing incompatable time identifiers. <br> - Allowable values with '", paste(base_identifier), "' present, are: '", paste(base_level, collapse = "', '"), "'. <br> - See the <a href='https://rsconnect/rsc/stats-production-guidance/ud.html#list_of_allowable_time_values' target='_blank'>guidance on time values</a> if you are unsure."),
+      "message" = paste0("The datafile is mixing incompatable time identifiers. <br> - Allowable values with '", paste(base_identifier), "' present, are: '", paste(base_level, collapse = "', '"), "'. <br> - See the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#list_of_allowable_time_values' target='_blank'>guidance on time values</a> if you are unsure."),
       "result" = "FAIL"
     )
   } else {
@@ -259,18 +259,18 @@ utf8 <- function(data, meta) {
   } else {
     if (number_data_invalid > 0 && number_meta_invalid > 0) {
       output <- list(
-        "message" = paste0("Neither of the data and metadata files are using UTF-8 encoding. <br> - See the ", "<a href='https://rsconnect/rsc/stats-production-guidance/ud.html#data_format' target='_blank'>guidance on how to do this</a>", " if you are unsure."),
+        "message" = paste0("Neither of the data and metadata files are using UTF-8 encoding. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data_format' target='_blank'>guidance on how to do this</a>", " if you are unsure."),
         "result" = "FAIL"
       )
     } else {
       if (number_data_invalid > 0) {
         output <- list(
-          "message" = paste0("The data file is not using UTF-8 encoding. <br> - See the ", "<a href='https://rsconnect/rsc/stats-production-guidance/ud.html#data_format' target='_blank'>guidance on how to do this</a>", " if you are unsure."),
+          "message" = paste0("The data file is not using UTF-8 encoding. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data_format' target='_blank'>guidance on how to do this</a>", " if you are unsure."),
           "result" = "FAIL"
         )
       } else {
         output <- list(
-          "message" = paste0("The metadata file is not using UTF-8 encoding. <br> - See the ", "<a href='https://rsconnect/rsc/stats-production-guidance/ud.html#data_format' target='_blank'>guidance on how to do this</a>", " if you are unsure."),
+          "message" = paste0("The metadata file is not using UTF-8 encoding. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data_format' target='_blank'>guidance on how to do this</a>", " if you are unsure."),
           "result" = "FAIL"
         )
       }

--- a/R/preCheck2.r
+++ b/R/preCheck2.r
@@ -36,7 +36,7 @@ time_identifier_mix <- function(data) {
 
   if (any(is.na(factor(unique(data$time_identifier), base_level))) == TRUE) {
     output <- list(
-      "message" = paste0("The datafile is mixing incompatable time identifiers. <br> - Allowable values with '", paste(base_identifier), "' present, are: '", paste(base_level, collapse = "', '"), "'. <br> - See the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#list_of_allowable_time_values' target='_blank'>guidance on time values</a> if you are unsure."),
+      "message" = paste0("The datafile is mixing incompatable time identifiers. <br> - Allowable values with '", paste(base_identifier), "' present, are: '", paste(base_level, collapse = "', '"), "'. <br> - See the <a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#list-of-allowable-time-values' target='_blank'>guidance on time values</a> if you are unsure."),
       "result" = "FAIL"
     )
   } else {
@@ -259,18 +259,18 @@ utf8 <- function(data, meta) {
   } else {
     if (number_data_invalid > 0 && number_meta_invalid > 0) {
       output <- list(
-        "message" = paste0("Neither of the data and metadata files are using UTF-8 encoding. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data_format' target='_blank'>guidance on how to do this</a>", " if you are unsure."),
+        "message" = paste0("Neither of the data and metadata files are using UTF-8 encoding. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#list-of-allowable-time-values' target='_blank'>guidance on how to do this</a>", " if you are unsure."),
         "result" = "FAIL"
       )
     } else {
       if (number_data_invalid > 0) {
         output <- list(
-          "message" = paste0("The data file is not using UTF-8 encoding. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data_format' target='_blank'>guidance on how to do this</a>", " if you are unsure."),
+          "message" = paste0("The data file is not using UTF-8 encoding. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#list-of-allowable-time-values' target='_blank'>guidance on how to do this</a>", " if you are unsure."),
           "result" = "FAIL"
         )
       } else {
         output <- list(
-          "message" = paste0("The metadata file is not using UTF-8 encoding. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#data_format' target='_blank'>guidance on how to do this</a>", " if you are unsure."),
+          "message" = paste0("The metadata file is not using UTF-8 encoding. <br> - See the ", "<a href='https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#list-of-allowable-time-values' target='_blank'>guidance on how to do this</a>", " if you are unsure."),
           "result" = "FAIL"
         )
       }

--- a/manifest.json
+++ b/manifest.json
@@ -28,9 +28,10 @@
         "BugReports": "https://github.com/eddelbuettel/asioheaders/issues",
         "NeedsCompilation": "no",
         "Packaged": "2022-12-08 04:04:23 UTC; edd",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2022-12-08 08:12:34 UTC",
-        "Built": "R 4.4.0; ; 2024-04-23 00:26:54 UTC; windows"
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; ; 2024-04-25 18:45:03 UTC; windows"
       }
     },
     "BH": {
@@ -78,9 +79,9 @@
         "Packaged": "2024-04-03 14:36:50 UTC; yihui",
         "Author": "Yihui Xie [aut],\n  Joe Cheng [aut, cre],\n  Xianying Tan [aut],\n  JJ Allaire [ctb],\n  Maximilian Girlich [ctb],\n  Greg Freedman Ellis [ctb],\n  Johannes Rauh [ctb],\n  SpryMedia Limited [ctb, cph] (DataTables in htmlwidgets/lib),\n  Brian Reavis [ctb, cph] (selectize.js in htmlwidgets/lib),\n  Leon Gersen [ctb, cph] (noUiSlider in htmlwidgets/lib),\n  Bartek Szopka [ctb, cph] (jquery.highlight.js in htmlwidgets/lib),\n  Alex Pickering [ctb],\n  William Holmes [ctb],\n  Mikko Marttila [ctb],\n  Andres Quintero [ctb],\n  Stéphane Laurent [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Joe Cheng <joe@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-04-04 05:03:17 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 02:25:06 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 23:49:09 UTC; windows"
       }
     },
     "MASS": {
@@ -198,9 +199,10 @@
         "RoxygenNote": "7.2.1",
         "NeedsCompilation": "no",
         "Packaged": "2022-07-21 13:19:33 UTC; hb",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2022-07-21 16:20:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 01:13:31 UTC; windows"
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; ; 2024-04-25 19:48:03 UTC; windows"
       }
     },
     "R.methodsS3": {
@@ -223,9 +225,10 @@
         "BugReports": "https://github.com/HenrikBengtsson/R.methodsS3/issues",
         "NeedsCompilation": "no",
         "Packaged": "2022-06-13 18:23:35 UTC; hb",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2022-06-13 22:00:14 UTC",
-        "Built": "R 4.4.0; ; 2024-04-23 00:24:06 UTC; windows"
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; ; 2024-04-25 19:42:43 UTC; windows"
       }
     },
     "R.oo": {
@@ -248,9 +251,10 @@
         "BugReports": "https://github.com/HenrikBengtsson/R.oo/issues",
         "NeedsCompilation": "no",
         "Packaged": "2024-01-24 02:17:13 UTC; henrik",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-01-24 05:12:50 UTC",
-        "Built": "R 4.4.0; ; 2024-04-23 01:16:54 UTC; windows"
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; ; 2024-04-25 19:44:10 UTC; windows"
       }
     },
     "R.utils": {
@@ -273,9 +277,10 @@
         "BugReports": "https://github.com/HenrikBengtsson/R.utils/issues",
         "NeedsCompilation": "no",
         "Packaged": "2023-11-17 05:13:25 UTC; henrik",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-11-18 01:00:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 00:34:02 UTC; windows"
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; ; 2024-04-25 19:47:24 UTC; windows"
       }
     },
     "R6": {
@@ -297,9 +302,10 @@
         "Packaged": "2021-08-06 20:18:46 UTC; winston",
         "Author": "Winston Chang [aut, cre]",
         "Maintainer": "Winston Chang <winston@stdout.org>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2021-08-19 14:00:05 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 09:46:04 UTC; windows"
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; ; 2024-04-25 19:39:56 UTC; windows"
       }
     },
     "RColorBrewer": {
@@ -318,9 +324,10 @@
         "License": "Apache License 2.0",
         "Packaged": "2022-04-03 10:26:20 UTC; neuwirth",
         "NeedsCompilation": "no",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2022-04-03 19:20:13 UTC",
-        "Built": "R 4.4.0; ; 2024-04-23 00:23:59 UTC; windows"
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; ; 2024-04-25 19:44:24 UTC; windows"
       }
     },
     "Rcpp": {
@@ -375,7 +382,7 @@
         "Packaged": "2020-08-26 17:46:45.898451 UTC; edd",
         "Repository": "RSPM",
         "Date/Publication": "2020-08-27 11:40:21 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 21:57:52 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-07-18 05:07:15 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -401,9 +408,9 @@
         "Packaged": "2023-09-03 19:16:12 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>)",
         "Maintainer": "Jeroen Ooms <jeroen@berkeley.edu>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-09-03 20:00:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 01:13:17 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 20:09:11 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -450,9 +457,10 @@
         "URL": "http://www.rforge.net/base64enc",
         "NeedsCompilation": "yes",
         "Packaged": "2015-02-04 20:31:00 UTC; svnuser",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2015-07-28 08:03:37",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-23 00:24:00 UTC; windows",
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:47:47 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -536,9 +544,9 @@
         "Packaged": "2024-04-24 18:51:29 UTC; gaborcsardi",
         "Author": "Jim Hester [aut] (<https://orcid.org/0000-0002-2739-7082>),\n  Gábor Csárdi [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-04-24 19:20:07 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 00:33:45 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:45:27 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -570,9 +578,9 @@
         "Packaged": "2024-03-28 21:43:16 UTC; cpsievert",
         "Author": "Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Joe Cheng [aut],\n  Garrick Aden-Buie [aut] (<https://orcid.org/0000-0002-7111-0077>),\n  Posit Software, PBC [cph, fnd],\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Javi Aguilar [ctb, cph] (Bootstrap colorpicker library),\n  Thomas Park [ctb, cph] (Bootswatch library),\n  PayPal [ctb, cph] (Bootstrap accessibility plugin)",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-03-29 01:00:03 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 11:03:00 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 22:58:12 UTC; windows"
       }
     },
     "cachem": {
@@ -627,9 +635,9 @@
         "Packaged": "2024-03-25 12:10:25 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre, cph] (<https://orcid.org/0000-0001-7098-9676>),\n  Winston Chang [aut],\n  Posit Software, PBC [cph, fnd],\n  Ascent Digital Services [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-03-25 13:30:06 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 01:28:06 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 19:43:36 UTC; windows"
       }
     },
     "checkmate": {
@@ -658,9 +666,9 @@
         "Packaged": "2023-12-04 09:19:04 UTC; michel",
         "Author": "Michel Lang [cre, aut] (<https://orcid.org/0000-0001-9754-0393>),\n  Bernd Bischl [ctb],\n  Dénes Tóth [ctb] (<https://orcid.org/0000-0003-4262-3217>)",
         "Maintainer": "Michel Lang <michellang@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-12-04 10:20:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 00:32:54 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:53:58 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -688,9 +696,9 @@
         "Packaged": "2024-02-12 15:50:55 UTC; winston",
         "Author": "Winston Chang [aut, cre],\n  Barret Schloerke [aut] (<https://orcid.org/0000-0001-9986-114X>),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Winston Chang <winston@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-02-12 16:20:06 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 01:48:58 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 22:24:43 UTC; windows"
       }
     },
     "cli": {
@@ -746,9 +754,9 @@
         "Packaged": "2022-02-19 02:20:21 UTC; mlincoln",
         "Author": "Matthew Lincoln [aut, cre] (<https://orcid.org/0000-0002-4387-3384>),\n  Louis Maddox [ctb],\n  Steve Simpson [ctb],\n  Jennifer Bryan [ctb]",
         "Maintainer": "Matthew Lincoln <matthew.d.lincoln@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2022-02-22 00:58:45 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 00:33:09 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:14:35 UTC; windows"
       }
     },
     "codetools": {
@@ -796,9 +804,9 @@
         "Packaged": "2023-01-23 08:50:11 UTC; zeileis",
         "Author": "Ross Ihaka [aut],\n  Paul Murrell [aut] (<https://orcid.org/0000-0002-3224-8858>),\n  Kurt Hornik [aut] (<https://orcid.org/0000-0003-4198-9911>),\n  Jason C. Fisher [aut] (<https://orcid.org/0000-0001-9032-8912>),\n  Reto Stauffer [aut] (<https://orcid.org/0000-0002-3798-5507>),\n  Claus O. Wilke [aut] (<https://orcid.org/0000-0002-7470-9261>),\n  Claire D. McWhite [aut] (<https://orcid.org/0000-0001-7346-3047>),\n  Achim Zeileis [aut, cre] (<https://orcid.org/0000-0003-0918-3766>)",
         "Maintainer": "Achim Zeileis <Achim.Zeileis@R-project.org>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-01-23 11:40:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 09:46:05 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:57:17 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -823,9 +831,9 @@
         "Packaged": "2024-01-30 11:29:56 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  John MacFarlane [cph] (Author of cmark)",
         "Maintainer": "Jeroen Ooms <jeroen@berkeley.edu>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-01-30 12:40:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 00:32:53 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:46:49 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -882,9 +890,9 @@
         "Packaged": "2023-12-01 19:16:04 UTC; davis",
         "Author": "Davis Vaughan [aut, cre] (<https://orcid.org/0000-0003-4777-038X>),\n  Jim Hester [aut] (<https://orcid.org/0000-0002-2739-7082>),\n  Romain François [aut] (<https://orcid.org/0000-0002-2444-4226>),\n  Benjamin Kietzman [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Davis Vaughan <davis@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-12-02 13:20:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 09:46:03 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 19:52:43 UTC; windows"
       }
     },
     "crayon": {
@@ -934,9 +942,9 @@
         "Packaged": "2023-11-22 16:29:50 UTC; cpsievert",
         "Author": "Joe Cheng [aut],\n  Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Posit Software, PBC [cph, fnd],\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/www/shared/jquery-AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Brian Reavis [ctb, cph] (selectize.js library),\n  Kristopher Michael Kowal [ctb, cph] (es5-shim library),\n  es5-shim contributors [ctb, cph] (es5-shim library),\n  Denis Ineshin [ctb, cph] (ion.rangeSlider library),\n  Sami Samhuri [ctb, cph] (Javascript strftime library)",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-11-23 08:50:07 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 01:28:07 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:40:47 UTC; windows"
       }
     },
     "curl": {
@@ -963,9 +971,9 @@
         "Packaged": "2024-02-26 21:12:31 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Hadley Wickham [ctb],\n  RStudio [cph]",
         "Maintainer": "Jeroen Ooms <jeroen@berkeley.edu>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-03-01 23:22:46 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 00:33:03 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:51:31 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1022,9 +1030,9 @@
         "NeedsCompilation": "no",
         "Packaged": "2023-12-10 11:07:50 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre],\n  Kirill Müller [aut],\n  Jim Hester [aut],\n  Maëlle Salmon [ctb] (<https://orcid.org/0000-0002-2815-0399>),\n  Posit Software, PBC [cph, fnd]",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-12-10 11:40:08 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 01:13:19 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:05:06 UTC; windows"
       }
     },
     "dfeR": {
@@ -1050,7 +1058,7 @@
         "RoxygenNote": "7.3.1",
         "Author": "Cam Race [aut, cre],\n  Laura Selby [aut],\n  Adam Robinson [aut],\n  Jen Machin [ctb],\n  Rich Bielby [ctb] (<https://orcid.org/0000-0001-9070-9969>)",
         "Maintainer": "Cam Race <cameron.race@education.gov.uk>",
-        "Built": "R 4.4.1; ; 2024-06-28 14:17:34 UTC; windows",
+        "Built": "R 4.4.1; ; 2024-07-22 17:29:43 UTC; windows",
         "RemoteType": "github",
         "RemoteUsername": "dfe-analytical-services",
         "RemoteRepo": "dfeR",
@@ -1088,9 +1096,9 @@
         "Packaged": "2021-10-05 01:16:56 UTC; bg",
         "Author": "Brodie Gaslam [aut, cre],\n  Michael B. Allen [ctb, cph] (Original C implementation of Myers Diff\n    Algorithm)",
         "Maintainer": "Brodie Gaslam <brodie.gaslam@yahoo.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2021-10-05 07:10:17 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 00:33:50 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:50:36 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1171,9 +1179,9 @@
         "Packaged": "2023-11-16 21:48:56 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre] (<https://orcid.org/0000-0003-4757-117X>),\n  Romain François [aut] (<https://orcid.org/0000-0002-2444-4226>),\n  Lionel Henry [aut],\n  Kirill Müller [aut] (<https://orcid.org/0000-0002-1416-3412>),\n  Davis Vaughan [aut] (<https://orcid.org/0000-0003-4777-038X>),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-11-17 16:50:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 02:06:31 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 20:33:28 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1228,9 +1236,9 @@
         "Packaged": "2023-12-06 00:59:41 UTC; bg",
         "Author": "Brodie Gaslam [aut, cre],\n  Elliott Sales De Andrade [ctb],\n  R Core Team [cph] (UTF8 byte length calcs from src/util.c)",
         "Maintainer": "Brodie Gaslam <brodie.gaslam@yahoo.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-12-08 03:30:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 09:46:04 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:43:50 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1255,9 +1263,9 @@
         "Packaged": "2024-05-13 08:31:27 UTC; thomas",
         "Author": "Thomas Lin Pedersen [cre, aut]\n    (<https://orcid.org/0000-0002-5147-4711>),\n  Berendea Nicolae [aut] (Author of the ColorSpace C++ library),\n  Romain François [aut] (<https://orcid.org/0000-0002-2444-4226>),\n  Posit, PBC [cph, fnd]",
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-05-13 09:33:09 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 00:32:51 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-05-14 05:09:19 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1310,9 +1318,9 @@
         "Packaged": "2023-08-19 02:32:12 UTC; rich",
         "Author": "Richard Iannone [aut, cre] (<https://orcid.org/0000-0003-3925-190X>),\n  Christophe Dervieux [ctb] (<https://orcid.org/0000-0003-4474-2498>),\n  Winston Chang [ctb],\n  Dave Gandy [ctb, cph] (Font-Awesome font),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Richard Iannone <rich@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-08-19 04:52:40 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 10:43:24 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:24:42 UTC; windows"
       }
     },
     "fs": {
@@ -1343,9 +1351,9 @@
         "Packaged": "2024-04-25 11:57:22 UTC; gaborcsardi",
         "Author": "Jim Hester [aut],\n  Hadley Wickham [aut],\n  Gábor Csárdi [aut, cre],\n  libuv project contributors [cph] (libuv library),\n  Joyent, Inc. and other Node contributors [cph] (libuv library),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-04-25 12:50:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 00:32:53 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-26 18:46:59 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1372,9 +1380,9 @@
         "Packaged": "2022-07-05 14:52:13 UTC; davis",
         "Author": "Hadley Wickham [aut, cre],\n  Max Kuhn [aut],\n  Davis Vaughan [aut],\n  RStudio [cph]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2022-07-05 19:40:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 00:32:53 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 19:40:35 UTC; windows"
       }
     },
     "ggplot2": {
@@ -1461,9 +1469,10 @@
         "Packaged": "2024-03-07 23:38:30 UTC; henrik",
         "Author": "Henrik Bengtsson [aut, cre, cph],\n  Davis Vaughan [ctb]",
         "Maintainer": "Henrik Bengtsson <henrikb@braju.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-03-08 00:00:03 UTC",
-        "Built": "R 4.4.0; ; 2024-04-23 00:24:09 UTC; windows"
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; ; 2024-04-25 19:50:13 UTC; windows"
       }
     },
     "glue": {
@@ -1491,9 +1500,9 @@
         "Packaged": "2024-01-08 16:10:57 UTC; jenny",
         "Author": "Jim Hester [aut] (<https://orcid.org/0000-0002-2739-7082>),\n  Jennifer Bryan [aut, cre] (<https://orcid.org/0000-0002-6983-2759>),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-01-09 23:13:08 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 09:46:04 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:52:29 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1610,9 +1619,9 @@
         "Packaged": "2024-04-02 14:26:15 UTC; cpsievert",
         "Author": "Joe Cheng [aut],\n  Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Barret Schloerke [aut] (<https://orcid.org/0000-0001-9986-114X>),\n  Winston Chang [aut] (<https://orcid.org/0000-0002-1576-2126>),\n  Yihui Xie [aut],\n  Jeff Allen [aut],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-04-04 05:03:00 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 10:26:57 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 20:21:37 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1639,9 +1648,9 @@
         "Packaged": "2023-12-06 00:11:16 UTC; cpsievert",
         "Author": "Ramnath Vaidyanathan [aut, cph],\n  Yihui Xie [aut],\n  JJ Allaire [aut],\n  Joe Cheng [aut],\n  Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Kenton Russell [aut, cph],\n  Ellis Hughes [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-12-06 06:00:06 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 11:18:14 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 23:02:02 UTC; windows"
       }
     },
     "httpuv": {
@@ -1669,9 +1678,9 @@
         "Packaged": "2024-03-25 21:06:08 UTC; cpsievert",
         "Author": "Joe Cheng [aut],\n  Winston Chang [aut, cre],\n  Posit, PBC fnd [cph],\n  Hector Corrada Bravo [ctb],\n  Jeroen Ooms [ctb],\n  Andrzej Krzemienski [cph] (optional.hpp),\n  libuv project contributors [cph] (libuv library, see src/libuv/AUTHORS\n    file),\n  Joyent, Inc. and other Node contributors [cph] (libuv library, see\n    src/libuv/AUTHORS file; and http-parser library, see\n    src/http-parser/AUTHORS file),\n  Niels Provos [cph] (libuv subcomponent: tree.h),\n  Internet Systems Consortium, Inc. [cph] (libuv subcomponent: inet_pton\n    and inet_ntop, contained in src/libuv/src/inet.c),\n  Alexander Chemeris [cph] (libuv subcomponent: stdint-msvc2008.h (from\n    msinttypes)),\n  Google, Inc. [cph] (libuv subcomponent: pthread-fixes.c),\n  Sony Mobile Communcations AB [cph] (libuv subcomponent:\n    pthread-fixes.c),\n  Berkeley Software Design Inc. [cph] (libuv subcomponent:\n    android-ifaddrs.h, android-ifaddrs.c),\n  Kenneth MacKay [cph] (libuv subcomponent: android-ifaddrs.h,\n    android-ifaddrs.c),\n  Emergya (Cloud4all, FP7/2007-2013, grant agreement no 289016) [cph]\n    (libuv subcomponent: android-ifaddrs.h, android-ifaddrs.c),\n  Steve Reid [aut] (SHA-1 implementation),\n  James Brown [aut] (SHA-1 implementation),\n  Bob Trower [aut] (base64 implementation),\n  Alexander Peslyak [aut] (MD5 implementation),\n  Trantor Standard Systems [cph] (base64 implementation),\n  Igor Sysoev [cph] (http-parser)",
         "Maintainer": "Winston Chang <winston@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-03-26 05:50:06 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 01:46:14 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-07-18 09:02:06 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1698,9 +1707,9 @@
         "Packaged": "2023-08-15 02:56:56 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Posit, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-08-15 09:00:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 01:46:10 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:15:29 UTC; windows"
       }
     },
     "isoband": {
@@ -1727,9 +1736,9 @@
         "Packaged": "2022-12-19 20:10:02 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre] (<https://orcid.org/0000-0003-4757-117X>),\n  Claus O. Wilke [aut] (Original author,\n    <https://orcid.org/0000-0002-7470-9261>),\n  Thomas Lin Pedersen [aut] (<https://orcid.org/0000-0002-5147-4711>)",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2022-12-20 10:00:13 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 09:46:05 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:44:55 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1780,9 +1789,9 @@
         "Packaged": "2021-04-26 16:40:21 UTC; cpsievert",
         "Author": "Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Joe Cheng [aut],\n  RStudio [cph],\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/lib/jquery-AUTHORS.txt)",
         "Maintainer": "Carson Sievert <carson@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2021-04-26 17:10:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 10:43:24 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:49:43 UTC; windows"
       }
     },
     "jsonlite": {
@@ -1806,9 +1815,9 @@
         "NeedsCompilation": "yes",
         "Packaged": "2023-12-04 12:57:12 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Duncan Temple Lang [ctb],\n  Lloyd Hilaiel [cph] (author of bundled libyajl)",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-12-04 15:20:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 09:46:06 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:48:43 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1859,9 +1868,10 @@
         "NeedsCompilation": "no",
         "Imports": "stats, graphics",
         "Packaged": "2023-08-29 21:01:57 UTC; loki",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-08-29 22:20:02 UTC",
-        "Built": "R 4.4.0; ; 2024-04-23 00:24:00 UTC; windows"
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; ; 2024-04-25 19:45:42 UTC; windows"
       }
     },
     "later": {
@@ -1887,9 +1897,9 @@
         "Packaged": "2023-12-06 00:38:14 UTC; cpsievert",
         "Author": "Winston Chang [aut, cre],\n  Joe Cheng [aut],\n  Posit Software, PBC [cph],\n  Marcus Geelnard [ctb, cph] (TinyCThread library,\n    https://tinycthread.github.io/),\n  Evan Nemerson [ctb, cph] (TinyCThread library,\n    https://tinycthread.github.io/)",
         "Maintainer": "Winston Chang <winston@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-12-06 09:10:05 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 01:13:19 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-07-18 08:40:57 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1942,9 +1952,10 @@
         "Packaged": "2019-03-15 14:18:01 UTC; lionel",
         "Author": "Hadley Wickham [aut, cre],\n  RStudio [cph]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-03-15 17:50:07 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 00:32:53 UTC; windows",
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:45:08 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1972,9 +1983,9 @@
         "Packaged": "2023-11-06 16:07:36 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut] (<https://orcid.org/0000-0003-4757-117X>),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-11-07 10:10:10 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 10:26:57 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:06:30 UTC; windows"
       }
     },
     "lubridate": {
@@ -2036,9 +2047,9 @@
         "Packaged": "2022-03-29 09:34:37 UTC; lionel",
         "Author": "Stefan Milton Bache [aut, cph] (Original author and creator of\n    magrittr),\n  Hadley Wickham [aut],\n  Lionel Henry [cre],\n  RStudio [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2022-03-30 07:30:09 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 09:46:03 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:43:08 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2062,9 +2073,9 @@
         "Packaged": "2021-11-24 21:24:50 UTC; jhester",
         "Author": "Hadley Wickham [aut],\n  Jim Hester [aut],\n  Winston Chang [aut, cre],\n  Kirill Müller [aut],\n  Daniel Cook [aut],\n  Mark Edmondson [ctb]",
         "Maintainer": "Winston Chang <winston@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2021-11-26 16:11:10 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 10:43:27 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:09:40 UTC; windows"
       }
     },
     "mgcv": {
@@ -2112,9 +2123,9 @@
         "Packaged": "2021-09-28 02:06:04 UTC; yihui",
         "Author": "Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>),\n  Jeffrey Horner [ctb],\n  Beilei Bian [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2021-09-28 05:00:05 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-23 00:24:00 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:47:07 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2138,9 +2149,9 @@
         "BugReports": "https://github.com/cwickham/munsell/issues",
         "NeedsCompilation": "no",
         "Packaged": "2024-04-01 20:42:09 UTC; charlottewickham",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-04-01 23:40:10 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 10:26:56 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:02:30 UTC; windows"
       }
     },
     "nlme": {
@@ -2197,17 +2208,10 @@
         "Packaged": "2024-05-16 15:50:21 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Oliver Keyes [ctb]",
         "Maintainer": "Jeroen Ooms <jeroen@berkeley.edu>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-05-16 17:00:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 01:28:14 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemotePkgRef": "openssl",
-        "RemoteRef": "openssl",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "2.2.0"
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-05-17 04:04:28 UTC; windows",
+        "Archs": "x64"
       }
     },
     "packrat": {
@@ -2273,9 +2277,9 @@
         "Packaged": "2023-03-21 08:42:46 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (<https://orcid.org/0000-0002-1416-3412>),\n  Hadley Wickham [aut],\n  RStudio [cph]",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-03-22 08:10:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 11:02:52 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:17:40 UTC; windows"
       }
     },
     "pingr": {
@@ -2354,9 +2358,9 @@
         "Encoding": "UTF-8",
         "NeedsCompilation": "no",
         "Packaged": "2019-09-22 08:42:40 UTC; gaborcsardi",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-09-22 09:20:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 09:46:04 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:11:40 UTC; windows"
       }
     },
     "pkgload": {
@@ -2461,9 +2465,9 @@
         "Packaged": "2024-03-16 14:10:21 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre, cph] (<https://orcid.org/0000-0001-7098-9676>),\n  Winston Chang [aut],\n  Posit Software, PBC [cph, fnd],\n  Ascent Digital Services [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-03-16 14:50:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 01:13:19 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:42:07 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2520,9 +2524,9 @@
         "Packaged": "2024-04-04 20:02:05 UTC; jcheng",
         "Author": "Joe Cheng [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Joe Cheng <joe@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-04-05 15:00:06 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 01:28:05 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-07-18 09:00:54 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2582,9 +2586,9 @@
         "Packaged": "2023-08-08 16:13:31 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre] (<https://orcid.org/0000-0003-4757-117X>),\n  Lionel Henry [aut],\n  RStudio [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-08-10 08:20:07 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 11:03:05 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-06-22 04:55:20 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2611,9 +2615,9 @@
         "Packaged": "2021-01-28 22:29:57 UTC; hadley",
         "Author": "Hadley Wickham [trl, cre, cph],\n  RStudio [cph],\n  Sridhar Ratnakumar [aut],\n  Trent Mick [aut],\n  ActiveState [cph] (R/appdir.r, R/cache.r, R/data.r, R/log.r translated\n    from appdirs),\n  Eddy Petrisor [ctb],\n  Trevor Davis [trl, aut],\n  Gabor Csardi [ctb],\n  Gregory Jefferis [ctb]",
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2021-01-31 05:40:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 09:46:05 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:39:40 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2678,16 +2682,9 @@
         "Packaged": "2020-04-30 10:31:13 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre],\n  Matthew Lincoln [ctb]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2020-05-01 06:50:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 02:06:34 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "rematch2",
-        "RemoteRef": "rematch2",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "2.1.2"
+        "Built": "R 4.4.0; ; 2024-04-25 20:23:49 UTC; windows"
       }
     },
     "renv": {
@@ -2805,9 +2802,9 @@
         "Packaged": "2023-11-05 06:47:23 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (<https://orcid.org/0000-0002-1416-3412>)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-11-05 10:20:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 00:33:18 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 19:45:07 UTC; windows"
       }
     },
     "rsconnect": {
@@ -2897,9 +2894,9 @@
         "Packaged": "2024-03-15 21:58:01 UTC; cpsievert",
         "Author": "Joe Cheng [aut],\n  Timothy Mastny [aut],\n  Richard Iannone [aut] (<https://orcid.org/0000-0003-3925-190X>),\n  Barret Schloerke [aut] (<https://orcid.org/0000-0001-9986-114X>),\n  Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Christophe Dervieux [ctb] (<https://orcid.org/0000-0003-4474-2498>),\n  RStudio [cph, fnd],\n  Sass Open Source Foundation [ctb, cph] (LibSass library),\n  Greter Marcel [ctb, cph] (LibSass library),\n  Mifsud Michael [ctb, cph] (LibSass library),\n  Hampton Catlin [ctb, cph] (LibSass library),\n  Natalie Weizenbaum [ctb, cph] (LibSass library),\n  Chris Eppstein [ctb, cph] (LibSass library),\n  Adams Joseph [ctb, cph] (json.cpp),\n  Trifunovic Nemanja [ctb, cph] (utf8.h)",
         "Maintainer": "Carson Sievert <carson@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-03-15 22:30:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 10:43:29 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 20:26:56 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2927,9 +2924,9 @@
         "Packaged": "2023-11-27 20:27:59 UTC; thomas",
         "Author": "Hadley Wickham [aut],\n  Thomas Lin Pedersen [cre, aut]\n    (<https://orcid.org/0000-0002-5147-4711>),\n  Dana Seidel [aut],\n  Posit, PBC [cph, fnd]",
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-11-28 09:10:06 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 10:43:21 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:09:32 UTC; windows"
       }
     },
     "shiny": {
@@ -2958,9 +2955,9 @@
         "Packaged": "2024-04-02 14:16:09 UTC; cpsievert",
         "Author": "Winston Chang [aut, cre] (<https://orcid.org/0000-0002-1576-2126>),\n  Joe Cheng [aut],\n  JJ Allaire [aut],\n  Carson Sievert [aut] (<https://orcid.org/0000-0002-4958-2844>),\n  Barret Schloerke [aut] (<https://orcid.org/0000-0001-9986-114X>),\n  Yihui Xie [aut],\n  Jeff Allen [aut],\n  Jonathan McPherson [aut],\n  Alan Dipert [aut],\n  Barbara Borges [aut],\n  Posit Software, PBC [cph, fnd],\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/www/shared/jquery-AUTHORS.txt),\n  jQuery UI contributors [ctb, cph] (jQuery UI library; authors listed in\n    inst/www/shared/jqueryui/AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Prem Nawaz Khan [ctb] (Bootstrap accessibility plugin),\n  Victor Tsaran [ctb] (Bootstrap accessibility plugin),\n  Dennis Lembree [ctb] (Bootstrap accessibility plugin),\n  Srinivasu Chakravarthula [ctb] (Bootstrap accessibility plugin),\n  Cathy O'Connor [ctb] (Bootstrap accessibility plugin),\n  PayPal, Inc [cph] (Bootstrap accessibility plugin),\n  Stefan Petre [ctb, cph] (Bootstrap-datepicker library),\n  Andrew Rowls [ctb, cph] (Bootstrap-datepicker library),\n  Brian Reavis [ctb, cph] (selectize.js library),\n  Salmen Bejaoui [ctb, cph] (selectize-plugin-a11y library),\n  Denis Ineshin [ctb, cph] (ion.rangeSlider library),\n  Sami Samhuri [ctb, cph] (Javascript strftime library),\n  SpryMedia Limited [ctb, cph] (DataTables library),\n  John Fraser [ctb, cph] (showdown.js library),\n  John Gruber [ctb, cph] (showdown.js library),\n  Ivan Sagalaev [ctb, cph] (highlight.js library),\n  R Core Team [ctb, cph] (tar implementation from R)",
         "Maintainer": "Winston Chang <winston@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-04-02 17:22:03 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 01:58:08 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 23:32:07 UTC; windows"
       }
     },
     "shinyFeedback": {
@@ -3120,9 +3117,9 @@
         "Packaged": "2021-12-21 11:32:22 UTC; Dean-X1C",
         "Author": "Dean Attali [aut, cre] (<https://orcid.org/0000-0002-5645-3493>)",
         "Maintainer": "Dean Attali <daattali@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2021-12-23 10:10:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 02:06:40 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 21:01:34 UTC; windows"
       }
     },
     "shinytest2": {
@@ -3206,9 +3203,9 @@
         "Encoding": "UTF-8",
         "NeedsCompilation": "yes",
         "Packaged": "2023-01-31 18:03:04 UTC; kevin",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-02-01 10:10:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 00:32:54 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:48:01 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -3262,9 +3259,9 @@
         "NeedsCompilation": "yes",
         "Packaged": "2024-05-06 12:50:25 UTC; gagolews",
         "License_is_FOSS": "yes",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-05-06 15:00:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-05-06 23:50:54 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-05-07 04:34:26 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -3293,9 +3290,9 @@
         "Packaged": "2023-11-14 15:03:52 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre, cph],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-11-14 23:10:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 01:46:11 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:18:44 UTC; windows"
       }
     },
     "styler": {
@@ -3324,9 +3321,9 @@
         "Packaged": "2024-04-07 19:04:20 UTC; lorenz",
         "Author": "Kirill Müller [aut] (<https://orcid.org/0000-0002-1416-3412>),\n  Lorenz Walthert [cre, aut],\n  Indrajeet Patil [ctb] (<https://orcid.org/0000-0003-1995-6531>,\n    @patilindrajeets)",
         "Maintainer": "Lorenz Walthert <lorenz.walthert@icloud.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-04-07 23:00:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 01:47:19 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:32:42 UTC; windows"
       }
     },
     "sys": {
@@ -3350,9 +3347,9 @@
         "Packaged": "2023-05-22 21:45:03 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Gábor Csárdi [ctb]",
         "Maintainer": "Jeroen Ooms <jeroen@berkeley.edu>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-05-23 07:50:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 00:32:53 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 20:03:55 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -3417,9 +3414,9 @@
         "Packaged": "2023-03-19 09:23:10 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (<https://orcid.org/0000-0002-1416-3412>),\n  Hadley Wickham [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [ctb],\n  RStudio [cph, fnd]",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-03-20 06:30:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 11:11:47 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 20:22:42 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -3480,9 +3477,9 @@
         "Packaged": "2024-03-11 11:46:04 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-03-11 14:10:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 01:46:10 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 20:19:04 UTC; windows"
       }
     },
     "timechange": {
@@ -3598,9 +3595,9 @@
         "Packaged": "2023-10-22 13:43:19 UTC; kirill",
         "Author": "Patrick O. Perry [aut, cph],\n  Kirill Müller [cre],\n  Unicode, Inc. [cph, dtc] (Unicode Character Database)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-10-22 21:50:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 09:46:04 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:46:43 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -3620,9 +3617,10 @@
         "BugReports": "https://github.com/s-u/uuid",
         "NeedsCompilation": "yes",
         "Packaged": "2024-01-13 00:03:03 UTC; rforge",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-01-14 15:20:05 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-23 00:25:15 UTC; windows",
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:45:15 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -3651,9 +3649,9 @@
         "Packaged": "2023-12-01 16:27:12 UTC; davis",
         "Author": "Hadley Wickham [aut],\n  Lionel Henry [aut],\n  Davis Vaughan [aut, cre],\n  data.table team [cph] (Radix sort based on data.table's forder() and\n    their contribution to R's order()),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Davis Vaughan <davis@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-12-01 23:50:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-19 10:43:18 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 20:13:49 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -3679,9 +3677,9 @@
         "NeedsCompilation": "no",
         "Packaged": "2023-05-02 21:38:46 UTC; simon",
         "Author": "Simon Garnier [aut, cre],\n  Noam Ross [ctb, cph],\n  Bob Rudis [ctb, cph],\n  Marco Sciaini [ctb, cph],\n  Antônio Pedro Camargo [ctb, cph],\n  Cédric Scherer [ctb, cph]",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-05-02 23:50:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 09:46:04 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 19:47:00 UTC; windows"
       }
     },
     "vroom": {
@@ -3748,16 +3746,9 @@
         "Packaged": "2023-11-01 22:05:31 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-11-02 13:10:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 02:06:42 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "waldo",
-        "RemoteRef": "waldo",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.5.2"
+        "Built": "R 4.4.0; ; 2024-04-25 20:24:45 UTC; windows"
       }
     },
     "websocket": {
@@ -3783,9 +3774,9 @@
         "Packaged": "2021-08-18 19:46:25 UTC; barret",
         "Author": "Winston Chang [aut, cre],\n  Joe Cheng [aut],\n  Alan Dipert [aut],\n  Barbara Borges [aut],\n  RStudio [cph],\n  Peter Thorson [ctb, cph] (WebSocket++ library),\n  René Nyffenegger [ctb, cph] (Base 64 library),\n  Micael Hildenborg [ctb, cph] (SHA1 library),\n  Aladdin Enterprises [cph] (MD5 library),\n  Bjoern Hoehrmann [ctb, cph] (UTF8 Validation library)",
         "Maintainer": "Winston Chang <winston@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2021-08-18 20:30:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-06-25 01:29:40 UTC; windows",
+        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-07-18 09:00:53 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -3814,9 +3805,9 @@
         "Packaged": "2024-01-16 10:22:29 UTC; lionel",
         "Author": "Jim Hester [aut],\n  Lionel Henry [aut, cre],\n  Kirill Müller [aut],\n  Kevin Ushey [aut],\n  Hadley Wickham [aut],\n  Winston Chang [aut],\n  Jennifer Bryan [ctb],\n  Richard Cotton [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-01-16 14:20:02 UTC",
-        "Built": "R 4.4.1; ; 2024-06-19 09:46:04 UTC; windows"
+        "Built": "R 4.4.0; ; 2024-04-25 19:44:56 UTC; windows"
       }
     },
     "xfun": {
@@ -3864,12 +3855,13 @@
         "URL": "http://xtable.r-forge.r-project.org/",
         "Depends": "R (>= 2.10.0)",
         "License": "GPL (>= 2)",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "NeedsCompilation": "no",
         "Packaged": "2019-04-21 10:56:51 UTC; dsco036",
         "Author": "David B. Dahl [aut],\n  David Scott [aut, cre],\n  Charles Roosen [aut],\n  Arni Magnusson [aut],\n  Jonathan Swinton [aut],\n  Ajay Shah [ctb],\n  Arne Henningsen [ctb],\n  Benno Puetz [ctb],\n  Bernhard Pfaff [ctb],\n  Claudio Agostinelli [ctb],\n  Claudius Loehnert [ctb],\n  David Mitchell [ctb],\n  David Whiting [ctb],\n  Fernando da Rosa [ctb],\n  Guido Gay [ctb],\n  Guido Schulz [ctb],\n  Ian Fellows [ctb],\n  Jeff Laake [ctb],\n  John Walker [ctb],\n  Jun Yan [ctb],\n  Liviu Andronic [ctb],\n  Markus Loecher [ctb],\n  Martin Gubri [ctb],\n  Matthieu Stigler [ctb],\n  Robert Castelo [ctb],\n  Seth Falcon [ctb],\n  Stefan Edwards [ctb],\n  Sven Garbade [ctb],\n  Uwe Ligges [ctb]",
         "Date/Publication": "2019-04-21 12:20:03 UTC",
-        "Built": "R 4.4.1; ; 2024-06-25 00:32:54 UTC; windows"
+        "Encoding": "UTF-8",
+        "Built": "R 4.4.0; ; 2024-04-25 19:46:08 UTC; windows"
       }
     },
     "yaml": {
@@ -3911,7 +3903,7 @@
       "checksum": "e5b9343c9a0e43d83e02b339946591d1"
     },
     ".Rprofile": {
-      "checksum": "29eb354c8ea595b89b0992de6ed426ed"
+      "checksum": "fcf55ee906692b4450fb1b843ddf6e8c"
     },
     "azure-pipelines-dev.yml": {
       "checksum": "fc2ef843ff5024bcba25ff84eec05f4c"
@@ -3986,13 +3978,13 @@
       "checksum": "51052a72b54c2e4bdddfb52762638274"
     },
     "R/fileValidation.r": {
-      "checksum": "ee777c0ac14e8bae2c20d5b1d5dac85a"
+      "checksum": "2edf7f6336a1c4b86c7b586743d810d5"
     },
     "R/knownVariables.r": {
       "checksum": "7248277e0e99b5aee4e66bf9e8c69963"
     },
     "R/mainTests.r": {
-      "checksum": "dfc551602d67d06d1231fe7281fa680b"
+      "checksum": "c6f253cdfd25c3c1af1f2ee47bf3bd78"
     },
     "R/manual_scripts/debugging.R": {
       "checksum": "e56763afdf3659c7c47cfe0e3262e8cf"
@@ -4010,7 +4002,7 @@
       "checksum": "f0ee4cca72e9cdfcd6a11a92f6efc946"
     },
     "R/preCheck2.r": {
-      "checksum": "9a98f3e6a22cac4c8cc4c345fbecb791"
+      "checksum": "9a5c3b91f5d50ea329b367dcfe438df0"
     },
     "R/readFile.r": {
       "checksum": "23d3c726936fede5e8139667d4a4dd6a"
@@ -4025,7 +4017,7 @@
       "checksum": "4bcf543280b896eb5ee9ddc6a5668a09"
     },
     "server.R": {
-      "checksum": "cb4e5dcb2ce3478c42d9841568ea6455"
+      "checksum": "fc511efd8f68babc404da195adc376e4"
     },
     "tests/testthat.R": {
       "checksum": "12e9b09de5275bdc13bde6ae5a82f8b1"

--- a/manifest.json
+++ b/manifest.json
@@ -3903,7 +3903,7 @@
       "checksum": "e5b9343c9a0e43d83e02b339946591d1"
     },
     ".Rprofile": {
-      "checksum": "fcf55ee906692b4450fb1b843ddf6e8c"
+      "checksum": "ec8bbd4624ab1b090bdb8673b41d024a"
     },
     "azure-pipelines-dev.yml": {
       "checksum": "fc2ef843ff5024bcba25ff84eec05f4c"
@@ -3978,13 +3978,13 @@
       "checksum": "51052a72b54c2e4bdddfb52762638274"
     },
     "R/fileValidation.r": {
-      "checksum": "2edf7f6336a1c4b86c7b586743d810d5"
+      "checksum": "1c3a5b538aa71e2f377b4733e7c9a580"
     },
     "R/knownVariables.r": {
       "checksum": "7248277e0e99b5aee4e66bf9e8c69963"
     },
     "R/mainTests.r": {
-      "checksum": "c6f253cdfd25c3c1af1f2ee47bf3bd78"
+      "checksum": "6dda83d9475c4095792d073c57fb73a8"
     },
     "R/manual_scripts/debugging.R": {
       "checksum": "e56763afdf3659c7c47cfe0e3262e8cf"
@@ -4002,7 +4002,7 @@
       "checksum": "f0ee4cca72e9cdfcd6a11a92f6efc946"
     },
     "R/preCheck2.r": {
-      "checksum": "9a5c3b91f5d50ea329b367dcfe438df0"
+      "checksum": "e2d59f939910ad38e9867f7a41686f4c"
     },
     "R/readFile.r": {
       "checksum": "23d3c726936fede5e8139667d4a4dd6a"

--- a/server.R
+++ b/server.R
@@ -373,7 +373,7 @@ server <- function(input, output, session) {
             type = "success",
             tags$span(
               "Your files can now be uploaded to Explore Education Statistics, see our  ",
-              a(href = "https://rsconnect/rsc/stats-production-guidance/ees.html", "guidance on using EES", target = "_blank"),
+              a(href = "https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ees.html", "guidance on using EES", target = "_blank"),
               " for more information."
             ),
             html = TRUE


### PR DESCRIPTION
# Brief overview of changes

We give guidance links in a number of messages on our tests, have updated those to the analysts guide URL

## Why are these changes being made?

The rsconnect site hasn't been updated for years and was binned altogether earlier this year / last year (a while ago!).

## Detailed description of changes

Mass find and replace of the domain name for the new domain, all pages and sections have similar titles now so didn't change those.

## Additional information for reviewers

None

## Issue ticket number/s and link

None