### PR TITLE
Fix bug with missing region name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3903,7 +3903,7 @@
       "checksum": "e5b9343c9a0e43d83e02b339946591d1"
     },
     ".Rprofile": {
-      "checksum": "41d1ba97c663e97c4c53ecd99ab13eb0"
+      "checksum": "48d983e0bfe75553a940019bee72a138"
     },
     "azure-pipelines-dev.yml": {
       "checksum": "fc2ef843ff5024bcba25ff84eec05f4c"
@@ -3984,7 +3984,7 @@
       "checksum": "7248277e0e99b5aee4e66bf9e8c69963"
     },
     "R/mainTests.r": {
-      "checksum": "6dda83d9475c4095792d073c57fb73a8"
+      "checksum": "58b52819cc963c2cdcbe70024a0307b7"
     },
     "R/manual_scripts/debugging.R": {
       "checksum": "e56763afdf3659c7c47cfe0e3262e8cf"

--- a/manifest.json
+++ b/manifest.json
@@ -3903,7 +3903,7 @@
       "checksum": "e5b9343c9a0e43d83e02b339946591d1"
     },
     ".Rprofile": {
-      "checksum": "ec8bbd4624ab1b090bdb8673b41d024a"
+      "checksum": "41d1ba97c663e97c4c53ecd99ab13eb0"
     },
     "azure-pipelines-dev.yml": {
       "checksum": "fc2ef843ff5024bcba25ff84eec05f4c"
@@ -4568,6 +4568,12 @@
     "tests/testthat/otherData/lad_within_la.meta.csv": {
       "checksum": "fb14aee7a7e0fb0671e5feb4c41af9bf"
     },
+    "tests/testthat/otherData/missing_region_name.csv": {
+      "checksum": "307a7ff183aa1eb50f567d2a3d7b6071"
+    },
+    "tests/testthat/otherData/missing_region_name.meta.csv": {
+      "checksum": "f7397c726426f2c1210b9062ddeb8ac5"
+    },
     "tests/testthat/otherData/multiple_stripped_filter_groups.csv": {
       "checksum": "93efa02917cba280b37a1b13083d2819"
     },
@@ -4899,7 +4905,7 @@
       "checksum": "41a423a4bc68e5ba6c20a11f06092471"
     },
     "tests/testthat/test-function-edge_cases.R": {
-      "checksum": "cc86859c0c8b5919e764d20fa8c72207"
+      "checksum": "f28bebce557004db15917ee71e2a4fab"
     },
     "tests/testthat/test-function-fileValidation.R": {
       "checksum": "302dd04b308471644c1a6574c3844c81"
@@ -4926,7 +4932,7 @@
       "checksum": "e1c273ef462a5f49a60df1e3a5e94fb6"
     },
     "tests/testthat/test-UI-03_additional_qa.R": {
-      "checksum": "4570dc372c5f2d83bb0039da58795e3e"
+      "checksum": "82a40f0765550189be42b19c4178ee66"
     },
     "ui.R": {
       "checksum": "52e49b75e9766a106c5653305d382d16"

--- a/tests/testthat/otherData/missing_region_name.csv
+++ b/tests/testthat/otherData/missing_region_name.csv
@@ -1,0 +1,4 @@
+﻿time_period,time_identifier,geographic_level,country_code,country_name,region_code,region,old_la_code,new_la_code,la_name,school_urn,school_laestab,school_name,number_dragons
+2024,Reporting year,School,E92000001,England,E12000001,North East,390,E08000037,Gateshead,108320,3901000,Bensham Grove Nursery School,25
+2024,Reporting year,School,E92000001,England,E12000001,North East,390,E08000037,Gateshead,108321,3902008,Carr Hill Community Primary School,12
+2024,Reporting year,School,E92000001,England,E12000001,North East,390,E08000037,Gateshead,108323,3902012,Kelvin Grove Community Primary School,13

--- a/tests/testthat/otherData/missing_region_name.meta.csv
+++ b/tests/testthat/otherData/missing_region_name.meta.csv
@@ -1,0 +1,2 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+number_dragons,Indicator,Count of imaginary dragons,,,,,

--- a/tests/testthat/test-UI-03_additional_qa.R
+++ b/tests/testthat/test-UI-03_additional_qa.R
@@ -56,6 +56,8 @@ test_that("Additional QA tabs", {
   app$set_inputs(outlier_indicator_parameter = "num_schools")
   app$set_inputs(submit_outlier = "click")
 
+  app$wait_for_idle(50) # this test seems weirdly flaky for unknown reasons
+
   app$expect_values(output = "table_outlier_list")
 
   # 9. Outlier check doesn't run with same time periods

--- a/tests/testthat/test-function-edge_cases.R
+++ b/tests/testthat/test-function-edge_cases.R
@@ -208,3 +208,7 @@ test_that("blank_meta_label_notNA_still_fails", {
 test_that("Can handle incorrect provider cols", {
   expect_no_error(screeningOutput <- testOther("../../tests/testthat/otherData/provider_col_incorrect.csv"))
 })
+
+test_that("Can handle missing region_name", {
+  expect_no_error(screeningOutput <- testOther("../../tests/testthat/otherData/missing_region_name.csv"))
+})


### PR DESCRIPTION
# Brief overview of changes

Fixed a bug that happened in files with only one region column present and no region rows.

## Why are these changes being made?

The app currently will error and then crash with no feedback to users, we want to do better than that and always give feedback on failing files.

Example when running the app locally on the main branch with the test files (same error in the prod logs) 
![image](https://github.com/user-attachments/assets/4a2f2a45-f847-429f-9d3f-bfa479654dcb)

## Detailed description of changes

- Added a test file that errors on the production site currently.
- Added a unit test to check there is no error when screening that file (this failed until I added the fix, and now it passes)
- Updated the `region_combinations()` test to only execute if both region_name and region_code columns are present
- Updated the `country_combinations()` test to remove the check for country_code being present as no file can get to the main checks stage without it

## Additional information for reviewers

The test I've fixed - `region_combinations()` doesn't need to fail if only one region column is present as another test `region_col_present()` checks for this already.

To make it easy to test, you can use the test data files I've added in this PR, try screening them against the current prod version - https://rsconnect/rsc/dfe-published-data-qa/, and then try doing the same on the dev environment (where this has deployed to after I opened the PR - https://rsconnect-pp/rsc/dev-dfe-published-data-qa/). You should see the app on prod will crash but it'll handle it neatly on the dev environment.

## Issue ticket number/s and link

No related issues