### PR TITLE
Fixed R version to 4.4.1 for deploy script

### DIFF
--- a/.github/workflows/deployShinyApps.yaml
+++ b/.github/workflows/deployShinyApps.yaml
@@ -18,6 +18,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          r-version: 4.4.1
           
       - name: Install git2r dependencies
         run: sudo apt-get install -y libgit2-dev


### PR DESCRIPTION
# Brief overview of changes

ShinyApps.io still falls over if something is deployed using R 4.4.2 in the deploy script, so forcing the script to 4.4.1 instead.

This is what the error looks like:

```
Sourcing .Rprofile...
- The project is out-of-sync -- use `renv::status()` for details.
Preparing to deploy application...DONE
Uploading bundle for application: 4333174...DONE
Deploying bundle: 9381336 for application: 4333174 ...
Waiting for task: [14](https://github.com/dfe-analytical-services/dfe-published-data-qa/actions/runs/11897055775/job/33150407112#step:7:15)79874635
  building: Processing bundle: 9381336
  building: Parsing manifest
  error: Building image: 1[15](https://github.com/dfe-analytical-services/dfe-published-data-qa/actions/runs/11897055775/job/33150407112#step:7:16)11100
################################ Begin Task Log ################################ 
################################# End Task Log ################################# 
Error: Error: Unhandled Exception: child_task=1479874636 child_task_status=error: Unhandled Exception: Unsupported R version 4.4.2 for operating system jammy.
Execution halted
Error: Process completed with exit code 1.
```

It does sound like it's a specific issue to Ubuntu Jammy, but I tried switching to MacOS on another dashboard a while ago and just ended up with different errors instead.