### PR TITLE
Added CME and EHE filters and indicators to Data Dictionary

### DIFF
--- a/data/data-dictionary.csv
+++ b/data/data-dictionary.csv
@@ -153,8 +153,6 @@ breakdown,Filter,Vision impairment,breakdown_topic,SEN primary need,VI,api-only,
 breakdown,Filter,White and Asian,breakdown_topic,Ethnicity,,api-only,Personal characteristics - Ethnicity
 breakdown,Filter,White and Black African,breakdown_topic,Ethnicity,,api-only,Personal characteristics - Ethnicity
 breakdown,Filter,White and Black Caribbean,breakdown_topic,Ethnicity,,api-only,Personal characteristics - Ethnicity
-breakdown,Filter,Male,breakdown_topic,Sex,,api-only,Personal characteristics
-breakdown,Filter,Female,breakdown_topic,Sex,,api-only,Personal characteristics
 breakdown,Filter,Unknown,breakdown_topic,Sex,,api-only,Personal characteristics
 breakdown,Filter,Reception,breakdown_topic,Year group,,api-only,Personal characteristics
 breakdown,Filter,Year 1,breakdown_topic,Year group,,api-only,Personal characteristics

--- a/data/data-dictionary.csv
+++ b/data/data-dictionary.csv
@@ -150,9 +150,6 @@ breakdown,Filter,Unknown,breakdown_topic,Free school meal eligibility,,api-only,
 breakdown,Filter,Unknown,breakdown_topic,SEN primary need,,api-only,Special educational needs
 breakdown,Filter,Unknown,breakdown_topic,SEN provision,,api-only,Personal characteristics
 breakdown,Filter,Vision impairment,breakdown_topic,SEN primary need,VI,api-only,Special educational needs
-breakdown,Filter,White and Asian,breakdown_topic,Ethnicity,,api-only,Personal characteristics - Ethnicity
-breakdown,Filter,White and Black African,breakdown_topic,Ethnicity,,api-only,Personal characteristics - Ethnicity
-breakdown,Filter,White and Black Caribbean,breakdown_topic,Ethnicity,,api-only,Personal characteristics - Ethnicity
 breakdown,Filter,Unknown,breakdown_topic,Sex,,api-only,Personal characteristics
 breakdown,Filter,Reception,breakdown_topic,Year group,,api-only,Personal characteristics
 breakdown,Filter,Year 1,breakdown_topic,Year group,,api-only,Personal characteristics
@@ -1406,7 +1403,7 @@ working_towards_pupil_count,Indicator,,,,,api-only,Attainment - Key stage 2
 working_towards_pupil_percent,Indicator,,,,,api-only,Attainment - Key stage 2
 child_count,Indicator,,,,,api-only,General
 child_percent,Indicator,,,,,api-only,General
-rate_per_100,Indicator,,,,,api-only,General
+child_rate_per_100,Indicator,,,,,api-only,General
 section_437_notice_issued_count,Indicator,,,,,api-only,Elective Home Education
 sao_order_issued_count,Indicator,,,,,api-only,Elective Home Education
 sao_order_revoked_count,Indicator,,,,,api-only,Elective Home Education

--- a/data/data-dictionary.csv
+++ b/data/data-dictionary.csv
@@ -1,4 +1,4 @@
-﻿col_name,col_type,filter_item,col_name_parent,filter_item_parent,cbds_code,item_error_flag,contexts
+col_name,col_type,filter_item,col_name_parent,filter_item_parent,cbds_code,item_error_flag,contexts
 age_group,Filter,19 to 24,age_youth_adult,19 plus,,api-only,Personal characteristics
 age_group,Filter,25 plus,age_youth_adult,19 plus,,api-only,Personal characteristics
 age_group,Filter,Total,age_youth_adult,19 plus,,api-only,Personal characteristics
@@ -934,6 +934,21 @@ years_open,Filter,Total,,,,api-only,Establishment characteristics
 young_carer,Filter,Not known to be a young carer,,,,api-only,Personal characteristics
 young_carer,Filter,Total,,,,api-only,Personal characteristics
 young_carer,Filter,Young carer,,,,api-only,Personal characteristics
+setting_prior_to_ehe,Filter,Early years setting,ehe_status,Started EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,No prior establishment,ehe_status,Started EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Local authority maintained,ehe_status,Started EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Academy,ehe_status,Started EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Free school,ehe_status,Started EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Independent,ehe_status,Started EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Special,ehe_status,Started EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Alternative provision,ehe_status,Started EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Pupil referral unit,ehe_status,Started EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Home educated outside the local authority,ehe_status,Started EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Elsewhere/Unknown,ehe_status,Started EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Total,ehe_status,Started EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Total,ehe_status,Returned to EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Total,ehe_status,Left the local authority in EHE during the year,,api-only,Elective Home Education
+setting_prior_to_ehe,Filter,Total,ehe_status,In EHE at any point during the year,,api-only,Elective Home Education
 absent_pupil_count,Indicator,,,,,api-only,Attainment - Key stage 2
 absent_pupil_percent,Indicator,,,,,api-only,Attainment - Key stage 2
 achievement_count,Indicator,,,,,api-only,Apprenticeships
@@ -1269,3 +1284,6 @@ working_towards_pupil_percent,Indicator,,,,,api-only,Attainment - Key stage 2
 child_count,Indicator,,,,,api-only,General
 child_percent,Indicator,,,,,api-only,General
 rate_per_100,Indicator,,,,,api-only,General
+section_437_notice_issued_count,Indicator,,,,,api-only,Elective Home Education
+sao_order_issued_count,Indicator,,,,,api-only,Elective Home Education
+sao_order_revoked_count,Indicator,,,,,api-only,Elective Home Education

--- a/data/data-dictionary.csv
+++ b/data/data-dictionary.csv
@@ -125,6 +125,50 @@ breakdown,Filter,Vision impairment,breakdown_topic,SEN primary need,VI,api-only,
 breakdown,Filter,White and Asian,breakdown_topic,Ethnicity,,api-only,Personal characteristics - Ethnicity
 breakdown,Filter,White and Black African,breakdown_topic,Ethnicity,,api-only,Personal characteristics - Ethnicity
 breakdown,Filter,White and Black Caribbean,breakdown_topic,Ethnicity,,api-only,Personal characteristics - Ethnicity
+breakdown,Filter,Male,breakdown_topic,Sex,,api-only,Personal characteristics
+breakdown,Filter,Female,breakdown_topic,Sex,,api-only,Personal characteristics
+breakdown,Filter,Unknown,breakdown_topic,Sex,,api-only,Personal characteristics
+breakdown,Filter,Reception,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Year 1,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Year 2,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Year 3,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Year 4,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Year 5,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Year 6,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Year 7,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Year 8,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Year 9,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Year 10,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Year 11,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Unknown,breakdown_topic,Year group,,api-only, Personal characteristics
+breakdown,Filter,Less than 2 weeks,breakdown_topic,Duration,,api-only, Children missing education
+breakdown,Filter,2 to 4 weeks,breakdown_topic,Duration,,api-only, Children missing education
+breakdown,Filter,4 to 8 weeks,breakdown_topic,Duration,,api-only, Children missing education
+breakdown,Filter,8 to 12 weeks,breakdown_topic,Duration,,api-only, Children missing education
+breakdown,Filter,12 to 26 weeks,breakdown_topic,Duration,,api-only, Children missing education
+breakdown,Filter,26 to 52 weeks,breakdown_topic,Duration,,api-only, Children missing education
+breakdown,Filter,Over 52 weeks,breakdown_topic,Duration,,api-only, Children missing education
+breakdown,Filter,Unknown,breakdown_topic,Duration,,api-only, Children missing education
+breakdown,Filter,Moved in from another local authority,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Moved in from another country,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,School application awaiting outcome,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Offered school place but not yet accepted,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Waiting school start,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Did not get school preference,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Unsuitable elective home education,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Difficulty accessing suitable school place,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,School dissatisfaction general,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,School dissatisfaction SEND,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Mental health,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Physical health,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Parental decision not to register at school,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Did not apply for school place at compulsory school age,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Challenging school attendance order,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Believed to have moved to another local authority,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Believed to have moved to another country,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Unknown,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Not recorded,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Other,breakdown_topic,Reason,,api-only, Children missing education
 cla_group,Filter,Children ceasing to be looked after during the year,,,,api-only,Children Looked After
 cla_group,Filter,Children looked after on 31 March,,,,api-only,Children Looked After
 cla_group,Filter,Children looked after on 31 March excluding unaccompanied asylum-seeking children,,,,api-only,Children Looked After
@@ -1222,3 +1266,6 @@ working_below_pupil_count,Indicator,,,,,api-only,Attainment - Key stage 2
 working_below_pupil_percent,Indicator,,,,,api-only,Attainment - Key stage 2
 working_towards_pupil_count,Indicator,,,,,api-only,Attainment - Key stage 2
 working_towards_pupil_percent,Indicator,,,,,api-only,Attainment - Key stage 2
+child_count,Indicator,,,,,api-only, General
+child_percent,Indicator,,,,,api-only, General
+rate_per_100,Indicator,,,,,api-only, General

--- a/data/data-dictionary.csv
+++ b/data/data-dictionary.csv
@@ -128,47 +128,47 @@ breakdown,Filter,White and Black Caribbean,breakdown_topic,Ethnicity,,api-only,P
 breakdown,Filter,Male,breakdown_topic,Sex,,api-only,Personal characteristics
 breakdown,Filter,Female,breakdown_topic,Sex,,api-only,Personal characteristics
 breakdown,Filter,Unknown,breakdown_topic,Sex,,api-only,Personal characteristics
-breakdown,Filter,Reception,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Year 1,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Year 2,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Year 3,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Year 4,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Year 5,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Year 6,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Year 7,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Year 8,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Year 9,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Year 10,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Year 11,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Unknown,breakdown_topic,Year group,,api-only, Personal characteristics
-breakdown,Filter,Less than 2 weeks,breakdown_topic,Duration,,api-only, Children missing education
-breakdown,Filter,2 to 4 weeks,breakdown_topic,Duration,,api-only, Children missing education
-breakdown,Filter,4 to 8 weeks,breakdown_topic,Duration,,api-only, Children missing education
-breakdown,Filter,8 to 12 weeks,breakdown_topic,Duration,,api-only, Children missing education
-breakdown,Filter,12 to 26 weeks,breakdown_topic,Duration,,api-only, Children missing education
-breakdown,Filter,26 to 52 weeks,breakdown_topic,Duration,,api-only, Children missing education
-breakdown,Filter,Over 52 weeks,breakdown_topic,Duration,,api-only, Children missing education
-breakdown,Filter,Unknown,breakdown_topic,Duration,,api-only, Children missing education
-breakdown,Filter,Moved in from another local authority,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Moved in from another country,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,School application awaiting outcome,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Offered school place but not yet accepted,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Waiting school start,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Did not get school preference,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Unsuitable elective home education,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Difficulty accessing suitable school place,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,School dissatisfaction general,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,School dissatisfaction SEND,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Mental health,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Physical health,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Parental decision not to register at school,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Did not apply for school place at compulsory school age,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Challenging school attendance order,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Believed to have moved to another local authority,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Believed to have moved to another country,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Unknown,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Not recorded,breakdown_topic,Reason,,api-only, Children missing education
-breakdown,Filter,Other,breakdown_topic,Reason,,api-only, Children missing education
+breakdown,Filter,Reception,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Year 1,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Year 2,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Year 3,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Year 4,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Year 5,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Year 6,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Year 7,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Year 8,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Year 9,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Year 10,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Year 11,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Unknown,breakdown_topic,Year group,,api-only,Personal characteristics
+breakdown,Filter,Less than 2 weeks,breakdown_topic,Duration,,api-only,Children missing education
+breakdown,Filter,2 to 4 weeks,breakdown_topic,Duration,,api-only,Children missing education
+breakdown,Filter,4 to 8 weeks,breakdown_topic,Duration,,api-only,Children missing education
+breakdown,Filter,8 to 12 weeks,breakdown_topic,Duration,,api-only,Children missing education
+breakdown,Filter,12 to 26 weeks,breakdown_topic,Duration,,api-only,Children missing education
+breakdown,Filter,26 to 52 weeks,breakdown_topic,Duration,,api-only,Children missing education
+breakdown,Filter,Over 52 weeks,breakdown_topic,Duration,,api-only,Children missing education
+breakdown,Filter,Unknown,breakdown_topic,Duration,,api-only,Children missing education
+breakdown,Filter,Moved in from another local authority,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Moved in from another country,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,School application awaiting outcome,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Offered school place but not yet accepted,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Waiting school start,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Did not get school preference,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Unsuitable elective home education,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Difficulty accessing suitable school place,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,School dissatisfaction general,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,School dissatisfaction SEND,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Mental health,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Physical health,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Parental decision not to register at school,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Did not apply for school place at compulsory school age,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Challenging school attendance order,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Believed to have moved to another local authority,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Believed to have moved to another country,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Unknown,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Not recorded,breakdown_topic,Reason,,api-only,Children missing education
+breakdown,Filter,Other,breakdown_topic,Reason,,api-only,Children missing education
 cla_group,Filter,Children ceasing to be looked after during the year,,,,api-only,Children Looked After
 cla_group,Filter,Children looked after on 31 March,,,,api-only,Children Looked After
 cla_group,Filter,Children looked after on 31 March excluding unaccompanied asylum-seeking children,,,,api-only,Children Looked After
@@ -1266,6 +1266,6 @@ working_below_pupil_count,Indicator,,,,,api-only,Attainment - Key stage 2
 working_below_pupil_percent,Indicator,,,,,api-only,Attainment - Key stage 2
 working_towards_pupil_count,Indicator,,,,,api-only,Attainment - Key stage 2
 working_towards_pupil_percent,Indicator,,,,,api-only,Attainment - Key stage 2
-child_count,Indicator,,,,,api-only, General
-child_percent,Indicator,,,,,api-only, General
-rate_per_100,Indicator,,,,,api-only, General
+child_count,Indicator,,,,,api-only,General
+child_percent,Indicator,,,,,api-only,General
+rate_per_100,Indicator,,,,,api-only,General

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "en_GB",
-  "platform": "4.4.1",
+  "platform": "4.5.2",
   "metadata": {
     "appmode": "shiny",
     "primary_rmd": null,
@@ -37,14 +37,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2025-04-15 10:50:01 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; ; 2025-04-16 04:51:16 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "AsioHeaders",
-        "RemotePkgRef": "AsioHeaders",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.30.2-1"
+        "Built": "R 4.5.0; ; 2025-04-16 04:55:11 UTC; windows"
       }
     },
     "DT": {
@@ -69,9 +62,9 @@
         "Packaged": "2025-09-02 13:12:27 UTC; garrick",
         "Author": "Yihui Xie [aut],\n  Joe Cheng [aut],\n  Xianying Tan [aut],\n  Garrick Aden-Buie [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-7111-0077>),\n  JJ Allaire [ctb],\n  Maximilian Girlich [ctb],\n  Greg Freedman Ellis [ctb],\n  Johannes Rauh [ctb],\n  SpryMedia Limited [ctb, cph] (DataTables in htmlwidgets/lib),\n  Brian Reavis [ctb, cph] (selectize.js in htmlwidgets/lib),\n  Leon Gersen [ctb, cph] (noUiSlider in htmlwidgets/lib),\n  Bartek Szopka [ctb, cph] (jquery.highlight.js in htmlwidgets/lib),\n  Alex Pickering [ctb],\n  William Holmes [ctb],\n  Mikko Marttila [ctb],\n  Andres Quintero [ctb],\n  Stéphane Laurent [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Garrick Aden-Buie <garrick@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-09-02 22:00:06 UTC",
-        "Built": "R 4.4.3; ; 2025-10-13 11:32:44 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-09-03 04:28:11 UTC; windows"
       }
     },
     "PKI": {
@@ -95,7 +88,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2025-08-19 08:30:19 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-08-20 04:40:59 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-08-20 04:41:37 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -119,16 +112,9 @@
         "Encoding": "UTF-8",
         "NeedsCompilation": "no",
         "Packaged": "2025-05-02 21:22:23 UTC; henrik",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-05-02 22:20:02 UTC",
-        "Built": "R 4.4.3; ; 2025-05-03 23:51:01 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "R.cache",
-        "RemotePkgRef": "R.cache",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.17.0"
+        "Built": "R 4.5.0; ; 2025-05-03 05:14:51 UTC; windows"
       }
     },
     "R.methodsS3": {
@@ -154,7 +140,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2022-06-13 22:00:14 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; ; 2024-04-25 19:42:43 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:07:39 UTC; windows"
       }
     },
     "R.oo": {
@@ -177,16 +163,10 @@
         "BugReports": "https://github.com/HenrikBengtsson/R.oo/issues",
         "NeedsCompilation": "no",
         "Packaged": "2025-05-02 20:29:15 UTC; henrik",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-05-02 21:00:05 UTC",
-        "Built": "R 4.4.3; ; 2025-05-03 23:50:46 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "R.oo",
-        "RemotePkgRef": "R.oo",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.27.1"
+        "Encoding": "UTF-8",
+        "Built": "R 4.5.0; ; 2025-05-03 05:13:53 UTC; windows"
       }
     },
     "R.utils": {
@@ -209,16 +189,10 @@
         "BugReports": "https://github.com/HenrikBengtsson/R.utils/issues",
         "NeedsCompilation": "no",
         "Packaged": "2025-02-24 19:44:20 UTC; henrik",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-02-24 21:20:02 UTC",
-        "Built": "R 4.4.2; ; 2025-02-26 14:07:37 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "R.utils",
-        "RemoteRef": "R.utils",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "source",
-        "RemoteSha": "2.13.0"
+        "Encoding": "UTF-8",
+        "Built": "R 4.5.0; ; 2025-04-06 06:10:08 UTC; windows"
       }
     },
     "R6": {
@@ -245,7 +219,7 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-02-15 00:50:02 UTC",
-        "Built": "R 4.4.0; ; 2025-02-15 04:28:41 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-04-06 06:09:51 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "R6",
         "RemoteRef": "R6",
@@ -274,7 +248,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2022-04-03 19:20:13 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; ; 2024-04-25 19:44:24 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-12-02 12:32:15 UTC; windows"
       }
     },
     "Rcpp": {
@@ -301,8 +275,15 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "RSPM",
         "Date/Publication": "2025-07-02 16:40:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-07-03 04:58:27 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-07-03 05:02:22 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "Rcpp",
+        "RemoteRef": "Rcpp",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.1.0"
       }
     },
     "RcppTOML": {
@@ -331,15 +312,8 @@
         "Repository": "RSPM",
         "Date/Publication": "2025-03-08 14:30:06 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-03-09 04:58:27 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemotePkgRef": "RcppTOML",
-        "RemoteRef": "RcppTOML",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.2.3"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2026-01-11 05:11:13 UTC; windows",
+        "Archs": "x64"
       }
     },
     "S7": {
@@ -369,9 +343,9 @@
         "Packaged": "2024-11-06 17:18:31 UTC; hadleywickham",
         "Author": "Object-Oriented Programming Working Group [cph],\n  Davis Vaughan [aut],\n  Jim Hester [aut] (<https://orcid.org/0000-0002-2739-7082>),\n  Tomasz Kalinowski [aut],\n  Will Landau [aut],\n  Michael Lawrence [aut],\n  Martin Maechler [aut] (<https://orcid.org/0000-0002-8685-9910>),\n  Luke Tierney [aut],\n  Hadley Wickham [aut, cre] (<https://orcid.org/0000-0003-4757-117X>)",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-11-07 12:50:02 UTC",
-        "Built": "R 4.4.3; x86_64-w64-mingw32; 2025-10-13 08:57:15 UTC; windows",
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-16 12:07:53 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -397,14 +371,14 @@
         "Packaged": "2024-10-03 14:12:09 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>)",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-10-04 07:20:03 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-10-04 23:51:17 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:08:49 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemotePkgRef": "askpass",
         "RemoteRef": "askpass",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.2.1"
@@ -433,8 +407,15 @@
         "Author": "Michel Lang [cre, aut] (<https://orcid.org/0000-0001-9754-0393>),\n  Duncan Murdoch [aut],\n  R Core Team [aut]",
         "Repository": "RSPM",
         "Date/Publication": "2024-05-23 12:30:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-05-24 04:43:58 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:32:17 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "backports",
+        "RemoteRef": "backports",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.5.0"
       }
     },
     "base64enc": {
@@ -456,8 +437,15 @@
         "Repository": "RSPM",
         "Date/Publication": "2015-07-28 08:03:37",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:47:47 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:08:45 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "base64enc",
+        "RemotePkgRef": "base64enc",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.1-3"
       }
     },
     "bit": {
@@ -485,7 +473,7 @@
         "Maintainer": "Michael Chirico <MichaelChirico4@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-03-06 10:50:01 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-03-07 04:33:27 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:11:04 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemotePkgRef": "bit",
@@ -520,16 +508,16 @@
         "Packaged": "2025-01-16 14:04:20 UTC; michael",
         "Author": "Michael Chirico [aut, cre],\n  Jens Oehlschlägel [aut],\n  Leonardo Silvestri [ctb],\n  Ofek Shilon [ctb]",
         "Maintainer": "Michael Chirico <michaelchirico4@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-01-16 16:00:07 UTC",
-        "Built": "R 4.4.2; x86_64-w64-mingw32; 2025-01-20 14:34:56 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:11:53 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemotePkgRef": "bit64",
         "RemoteRef": "bit64",
-        "RemoteRepos": "http://cran.rstudio.com",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "source",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "4.6.0-1"
       }
     },
@@ -557,7 +545,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-04-24 19:20:07 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:45:27 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:35:41 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -589,15 +577,15 @@
         "Packaged": "2025-01-30 22:04:52 UTC; garrick",
         "Author": "Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Joe Cheng [aut],\n  Garrick Aden-Buie [aut] (<https://orcid.org/0000-0002-7111-0077>),\n  Posit Software, PBC [cph, fnd],\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Javi Aguilar [ctb, cph] (Bootstrap colorpicker library),\n  Thomas Park [ctb, cph] (Bootswatch library),\n  PayPal [ctb, cph] (Bootstrap accessibility plugin)",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-01-30 23:20:02 UTC",
-        "Built": "R 4.4.2; ; 2025-02-03 10:34:00 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-04-06 06:18:52 UTC; windows",
         "RemoteType": "standard",
-        "RemotePkgRef": "bslib",
         "RemoteRef": "bslib",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemotePkgRef": "bslib",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "source",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.9.0"
       }
     },
@@ -625,8 +613,15 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2024-05-16 09:50:11 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-05-17 04:03:28 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:11:37 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "cachem",
+        "RemotePkgRef": "cachem",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.1.0"
       }
     },
     "callr": {
@@ -655,7 +650,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-03-25 13:30:06 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 19:43:36 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:11:37 UTC; windows"
       }
     },
     "checkmate": {
@@ -684,9 +679,9 @@
         "Packaged": "2025-08-18 13:58:18 UTC; michel",
         "Author": "Michel Lang [cre, aut] (ORCID: <https://orcid.org/0000-0001-9754-0393>),\n  Bernd Bischl [ctb],\n  Dénes Tóth [ctb] (ORCID: <https://orcid.org/0000-0003-4262-3217>)",
         "Maintainer": "Michel Lang <michellang@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-08-18 16:30:02 UTC",
-        "Built": "R 4.4.3; x86_64-w64-mingw32; 2025-10-13 08:57:56 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:32:46 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -717,9 +712,9 @@
         "Packaged": "2025-04-24 03:18:21 UTC; garrick",
         "Author": "Garrick Aden-Buie [aut, cre] (<https://orcid.org/0000-0002-7111-0077>),\n  Winston Chang [aut],\n  Barret Schloerke [aut] (<https://orcid.org/0000-0001-9986-114X>),\n  Posit Software, PBC [cph, fnd] (03wc8by49)",
         "Maintainer": "Garrick Aden-Buie <garrick@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-04-24 03:40:02 UTC",
-        "Built": "R 4.4.3; ; 2025-04-26 01:47:10 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-25 04:59:20 UTC; windows"
       }
     },
     "cli": {
@@ -747,11 +742,11 @@
         "Maintainer": "Gábor Csárdi <gabor@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-23 13:50:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-04-24 04:41:30 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-24 04:45:18 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "cli",
         "RemotePkgRef": "cli",
+        "RemoteRef": "cli",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
@@ -782,13 +777,13 @@
         "Packaged": "2022-02-19 02:20:21 UTC; mlincoln",
         "Author": "Matthew Lincoln [aut, cre] (<https://orcid.org/0000-0002-4387-3384>),\n  Louis Maddox [ctb],\n  Steve Simpson [ctb],\n  Jennifer Bryan [ctb]",
         "Maintainer": "Matthew Lincoln <matthew.d.lincoln@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2022-02-22 00:58:45 UTC",
-        "Built": "R 4.4.1; ; 2024-07-17 00:52:36 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-04-06 06:07:19 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "clipr",
         "RemoteRef": "clipr",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.8.0"
@@ -812,7 +807,7 @@
         "Packaged": "2024-03-31 18:18:09 UTC; luke",
         "Repository": "CRAN",
         "Date/Publication": "2024-03-31 20:10:06 UTC",
-        "Built": "R 4.4.1; ; 2024-06-14 08:33:57 UTC; windows"
+        "Built": "R 4.5.2; ; 2025-10-31 09:58:26 UTC; windows"
       }
     },
     "commonmark": {
@@ -838,15 +833,8 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-07-07 13:40:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-07-08 04:27:13 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "commonmark",
-        "RemotePkgRef": "commonmark",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "2.0.0"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:31:45 UTC; windows",
+        "Archs": "x64"
       }
     },
     "config": {
@@ -875,7 +863,14 @@
         "Maintainer": "Andrie de Vries <apdevries@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2023-08-30 16:50:36 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 19:03:42 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-08 03:30:15 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "config",
+        "RemoteRef": "config",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.3.2"
       }
     },
     "cpp11": {
@@ -902,13 +897,13 @@
         "Packaged": "2025-03-03 22:24:28 UTC; davis",
         "Author": "Davis Vaughan [aut, cre] (<https://orcid.org/0000-0003-4777-038X>),\n  Jim Hester [aut] (<https://orcid.org/0000-0002-2739-7082>),\n  Romain François [aut] (<https://orcid.org/0000-0002-2444-4226>),\n  Benjamin Kietzman [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Davis Vaughan <davis@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-03-03 23:20:02 UTC",
-        "Built": "R 4.4.3; ; 2025-03-04 00:50:40 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-04-06 06:12:05 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "cpp11",
         "RemoteRef": "cpp11",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.5.2"
@@ -938,7 +933,14 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-06-20 13:00:02 UTC",
-        "Built": "R 4.4.0; ; 2024-06-21 04:46:07 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:09:02 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "crayon",
+        "RemoteRef": "crayon",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.5.3"
       }
     },
     "credentials": {
@@ -967,7 +969,14 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-09-12 09:30:08 UTC",
-        "Built": "R 4.4.0; ; 2025-09-13 04:48:42 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-09-13 04:48:40 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "credentials",
+        "RemoteRef": "credentials",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "2.0.3"
       }
     },
     "crosstalk": {
@@ -992,9 +1001,9 @@
         "Packaged": "2025-08-26 22:06:47 UTC; cpsievert",
         "Author": "Joe Cheng [aut],\n  Carson Sievert [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-4958-2844>),\n  Posit Software, PBC [cph, fnd],\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/www/shared/jquery-AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Brian Reavis [ctb, cph] (selectize.js library),\n  Kristopher Michael Kowal [ctb, cph] (es5-shim library),\n  es5-shim contributors [ctb, cph] (es5-shim library),\n  Denis Ineshin [ctb, cph] (ion.rangeSlider library),\n  Sami Samhuri [ctb, cph] (Javascript strftime library)",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-08-26 23:50:02 UTC",
-        "Built": "R 4.4.3; ; 2025-10-13 10:01:26 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-08-27 04:30:44 UTC; windows"
       }
     },
     "curl": {
@@ -1021,17 +1030,10 @@
         "Packaged": "2024-09-19 15:43:51 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Hadley Wickham [ctb],\n  RStudio [cph]",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-09-20 11:50:24 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-10-05 00:28:46 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemotePkgRef": "curl",
-        "RemoteRef": "curl",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "5.2.3"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-16 12:08:23 UTC; windows",
+        "Archs": "x64"
       }
     },
     "data.table": {
@@ -1058,11 +1060,11 @@
         "Maintainer": "Tyson Barrett <t.barrett88@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-07-10 10:30:05 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-07-11 04:34:25 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-07-11 04:26:25 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "data.table",
         "RemotePkgRef": "data.table",
+        "RemoteRef": "data.table",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
@@ -1096,7 +1098,14 @@
         "Author": "Gábor Csárdi [aut, cre],\n  Kirill Müller [aut],\n  Jim Hester [aut],\n  Maëlle Salmon [ctb] (<https://orcid.org/0000-0002-2815-0399>),\n  Posit Software, PBC [cph, fnd]",
         "Repository": "RSPM",
         "Date/Publication": "2023-12-10 11:40:08 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 20:05:06 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:10:27 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "desc",
+        "RemoteRef": "desc",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.4.3"
       }
     },
     "dfeR": {
@@ -1127,7 +1136,7 @@
         "Maintainer": "Cam Race <cameron.race@education.gov.uk>",
         "Repository": "RSPM",
         "Date/Publication": "2025-01-15 21:50:07 UTC",
-        "Built": "R 4.4.0; ; 2025-01-16 04:45:31 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-04-09 23:23:45 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "dfeR",
         "RemoteRef": "dfeR",
@@ -1163,11 +1172,11 @@
         "Maintainer": "Brodie Gaslam <brodie.gaslam@yahoo.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-21 08:30:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-04-22 04:49:11 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:32:11 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "diffobj",
         "RemotePkgRef": "diffobj",
+        "RemoteRef": "diffobj",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
@@ -1196,9 +1205,9 @@
         "Packaged": "2024-06-12 16:12:51 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Joshua Kunst [aut],\n  Winston Chang [aut],\n  Posit Software, PBC [cph, fnd],\n  Paul Fitzpatrick [cph] (Author of included daff.js library),\n  Rodrigo Fernandes [cph] (Author of included diff2html library),\n  JQuery Foundation [cph] (Author of included jquery library),\n  Kevin Decker [cph] (Author of included jsdiff library),\n  Matthew Holt [cph] (Author of incldued PapaParse library),\n  Huddle [cph] (Author of included resemble library)",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-06-12 21:00:14 UTC",
-        "Built": "R 4.4.1; ; 2024-09-07 02:22:21 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-09 20:55:51 UTC; windows"
       }
     },
     "digest": {
@@ -1225,7 +1234,7 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "RSPM",
         "Date/Publication": "2024-08-19 14:10:07 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-08-20 04:36:33 UTC; windows",
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-16 12:06:20 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1255,14 +1264,14 @@
         "Packaged": "2023-11-16 21:48:56 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre] (<https://orcid.org/0000-0003-4757-117X>),\n  Romain François [aut] (<https://orcid.org/0000-0002-2444-4226>),\n  Lionel Henry [aut],\n  Kirill Müller [aut] (<https://orcid.org/0000-0002-1416-3412>),\n  Davis Vaughan [aut] (<https://orcid.org/0000-0003-4777-038X>),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-11-17 16:50:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-07-17 02:17:41 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:13:34 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemotePkgRef": "dplyr",
         "RemoteRef": "dplyr",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.1.4"
@@ -1293,7 +1302,7 @@
         "Maintainer": "Emil Hvitfeldt <emilhhvitfeldt@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-10-28 16:50:11 UTC",
-        "Built": "R 4.4.0; ; 2024-10-29 04:43:32 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-04-09 20:18:37 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "emoji",
         "RemoteRef": "emoji",
@@ -1326,9 +1335,16 @@
         "Packaged": "2025-08-27 16:20:56 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Yihui Xie [aut] (ORCID: <https://orcid.org/0000-0003-0645-5666>),\n  Michael Lawrence [ctb],\n  Thomas Kluyver [ctb],\n  Jeroen Ooms [ctb],\n  Barret Schloerke [ctb],\n  Adam Ryczkowski [ctb],\n  Hiroaki Yutani [ctb],\n  Michel Lang [ctb],\n  Karolis Koncevičius [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-08-27 16:40:02 UTC",
-        "Built": "R 4.4.3; ; 2025-10-13 08:57:16 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-08-28 04:33:35 UTC; windows",
+        "RemoteType": "standard",
+        "RemoteRef": "evaluate",
+        "RemotePkgRef": "evaluate",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.0.5"
       }
     },
     "farver": {
@@ -1354,7 +1370,7 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2024-05-13 09:33:09 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-05-14 05:09:19 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:37:13 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1379,8 +1395,15 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2024-05-15 09:00:07 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-05-16 04:50:06 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:11:00 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "fastmap",
+        "RemotePkgRef": "fastmap",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.2.0"
       }
     },
     "fontawesome": {
@@ -1409,7 +1432,14 @@
         "Maintainer": "Richard Iannone <rich@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2024-11-16 17:30:02 UTC",
-        "Built": "R 4.4.0; ; 2024-11-17 04:34:02 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:12:21 UTC; windows",
+        "RemoteType": "standard",
+        "RemoteRef": "fontawesome",
+        "RemotePkgRef": "fontawesome",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.5.3"
       }
     },
     "fs": {
@@ -1442,11 +1472,11 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-12 10:40:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-04-14 17:38:21 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-14 16:36:37 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "fs",
         "RemotePkgRef": "fs",
+        "RemoteRef": "fs",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
@@ -1476,15 +1506,15 @@
         "Packaged": "2025-05-09 18:17:41 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre] (ORCID:\n    <https://orcid.org/0000-0003-4757-117X>),\n  Max Kuhn [aut],\n  Davis Vaughan [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-05-09 23:50:06 UTC",
-        "Built": "R 4.4.2; ; 2025-05-15 09:44:28 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-05-10 04:47:12 UTC; windows",
         "RemoteType": "standard",
-        "RemoteRef": "generics",
         "RemotePkgRef": "generics",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRef": "generics",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "source",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.1.4"
       }
     },
@@ -1514,11 +1544,11 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-03-25 00:40:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-03-25 05:13:14 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-09 22:09:32 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "gert",
         "RemotePkgRef": "gert",
+        "RemoteRef": "gert",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
@@ -1553,9 +1583,9 @@
         "Packaged": "2025-08-19 08:21:45 UTC; thomas",
         "Author": "Hadley Wickham [aut] (ORCID: <https://orcid.org/0000-0003-4757-117X>),\n  Winston Chang [aut] (ORCID: <https://orcid.org/0000-0002-1576-2126>),\n  Lionel Henry [aut],\n  Thomas Lin Pedersen [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-5147-4711>),\n  Kohske Takahashi [aut],\n  Claus Wilke [aut] (ORCID: <https://orcid.org/0000-0002-7470-9261>),\n  Kara Woo [aut] (ORCID: <https://orcid.org/0000-0002-5125-4188>),\n  Hiroaki Yutani [aut] (ORCID: <https://orcid.org/0000-0002-3385-7233>),\n  Dewey Dunnington [aut] (ORCID: <https://orcid.org/0000-0002-9415-4582>),\n  Teun van den Brand [aut] (ORCID:\n    <https://orcid.org/0000-0002-9335-7468>),\n  Posit, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-09-11 07:10:02 UTC",
-        "Built": "R 4.4.3; ; 2025-10-13 10:26:21 UTC; windows"
+        "Built": "R 4.5.2; ; 2026-01-16 12:23:59 UTC; windows"
       }
     },
     "gh": {
@@ -1584,13 +1614,13 @@
         "Packaged": "2025-05-26 09:32:03 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [cre, ctb],\n  Jennifer Bryan [aut],\n  Hadley Wickham [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-05-26 13:10:02 UTC",
-        "Built": "R 4.4.3; ; 2025-05-27 23:52:29 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-05-27 04:55:30 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "gh",
         "RemoteRef": "gh",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.5.0"
@@ -1620,13 +1650,13 @@
         "Packaged": "2022-09-08 10:28:07 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre],\n  RStudio [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2022-09-08 10:42:55 UTC",
-        "Built": "R 4.4.1; ; 2024-07-17 00:52:47 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-04-09 18:33:41 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "gitcreds",
         "RemoteRef": "gitcreds",
-        "RemoteRepos": "https://cloud.r-project.org",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.1.2"
@@ -1655,16 +1685,9 @@
         "Packaged": "2025-05-08 08:30:29 UTC; henrik",
         "Author": "Henrik Bengtsson [aut, cre, cph],\n  Davis Vaughan [ctb]",
         "Maintainer": "Henrik Bengtsson <henrikb@braju.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-05-08 09:00:03 UTC",
-        "Built": "R 4.4.2; ; 2025-05-15 09:44:49 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "globals",
-        "RemotePkgRef": "globals",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "source",
-        "RemoteSha": "0.18.0"
+        "Built": "R 4.5.0; ; 2025-12-02 12:40:39 UTC; windows"
       }
     },
     "glue": {
@@ -1694,8 +1717,15 @@
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2024-09-30 22:30:01 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-10-01 04:41:41 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:07:46 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "glue",
+        "RemoteRef": "glue",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.8.0"
       }
     },
     "gtable": {
@@ -1723,16 +1753,9 @@
         "Packaged": "2024-10-25 12:42:05 UTC; thomas",
         "Author": "Hadley Wickham [aut],\n  Thomas Lin Pedersen [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-10-25 13:20:02 UTC",
-        "Built": "R 4.4.1; ; 2024-10-25 15:12:05 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "gtable",
-        "RemoteRef": "gtable",
-        "RemoteRepos": "http://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "source",
-        "RemoteSha": "0.3.6"
+        "Built": "R 4.5.0; ; 2025-12-02 12:38:19 UTC; windows"
       }
     },
     "highr": {
@@ -1758,9 +1781,16 @@
         "Packaged": "2024-05-26 19:27:21 UTC; yihui",
         "Author": "Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>),\n  Yixuan Qiu [aut],\n  Christopher Gandrud [ctb],\n  Qiang Li [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-05-26 20:00:03 UTC",
-        "Built": "R 4.4.1; ; 2024-07-17 01:25:34 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:10:05 UTC; windows",
+        "RemoteType": "standard",
+        "RemoteRef": "highr",
+        "RemotePkgRef": "highr",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.11"
       }
     },
     "hms": {
@@ -1788,16 +1818,9 @@
         "Packaged": "2023-03-21 16:52:11 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (<https://orcid.org/0000-0002-1416-3412>),\n  R Consortium [fnd],\n  RStudio [fnd]",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-03-21 18:10:02 UTC",
-        "Built": "R 4.4.1; ; 2024-07-17 01:59:52 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "hms",
-        "RemoteRef": "hms",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.1.3"
+        "Built": "R 4.5.2; ; 2026-01-16 12:24:51 UTC; windows"
       }
     },
     "htmltools": {
@@ -1828,8 +1851,15 @@
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2024-04-04 05:03:00 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 20:21:37 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:11:38 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "htmltools",
+        "RemotePkgRef": "htmltools",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.5.8.1"
       }
     },
     "htmlwidgets": {
@@ -1857,7 +1887,7 @@
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2023-12-06 06:00:06 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 23:02:02 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:21:45 UTC; windows"
       }
     },
     "httpuv": {
@@ -1887,15 +1917,8 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-16 08:00:06 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-04-17 04:58:36 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "httpuv",
-        "RemotePkgRef": "httpuv",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.6.16"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2026-01-11 05:57:33 UTC; windows",
+        "Archs": "x64"
       }
     },
     "httr": {
@@ -1923,7 +1946,14 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2023-08-15 09:00:02 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 20:15:29 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:11:28 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "httr",
+        "RemoteRef": "httr",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.4.7"
       }
     },
     "httr2": {
@@ -1954,14 +1984,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2024-11-04 16:30:02 UTC",
-        "Built": "R 4.4.0; ; 2024-11-05 04:50:58 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "httr2",
-        "RemoteRef": "httr2",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.0.6"
+        "Built": "R 4.5.2; ; 2026-01-16 12:09:54 UTC; windows"
       }
     },
     "ini": {
@@ -1984,13 +2007,14 @@
         "Suggests": "testthat",
         "NeedsCompilation": "no",
         "Packaged": "2018-05-19 23:19:45 UTC; CLIENTE",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2018-05-20 03:26:39 UTC",
-        "Built": "R 4.4.1; ; 2024-07-17 00:52:47 UTC; windows",
+        "Encoding": "UTF-8",
+        "Built": "R 4.5.0; ; 2025-04-09 18:36:39 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "ini",
         "RemoteRef": "ini",
-        "RemoteRepos": "https://cloud.r-project.org",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.3.1"
@@ -2022,7 +2046,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2022-12-20 10:00:13 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:44:55 UTC; windows",
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-16 12:10:12 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2051,7 +2075,7 @@
         "Maintainer": "Sam Firke <samuel.firke@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-12-22 16:30:01 UTC",
-        "Built": "R 4.4.0; ; 2024-12-23 04:31:34 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-08 03:49:08 UTC; windows"
       }
     },
     "jose": {
@@ -2078,16 +2102,9 @@
         "Packaged": "2024-10-03 14:12:53 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>)",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-10-04 12:20:01 UTC",
-        "Built": "R 4.4.2; ; 2025-02-06 02:28:09 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "jose",
-        "RemoteRef": "jose",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.2.1"
+        "Built": "R 4.5.0; ; 2025-04-09 19:45:05 UTC; windows"
       }
     },
     "jquerylib": {
@@ -2111,7 +2128,14 @@
         "Maintainer": "Carson Sievert <carson@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2021-04-26 17:10:02 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 20:49:43 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:12:19 UTC; windows",
+        "RemoteType": "standard",
+        "RemoteRef": "jquerylib",
+        "RemotePkgRef": "jquerylib",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.1.4"
       }
     },
     "jsonlite": {
@@ -2135,16 +2159,16 @@
         "NeedsCompilation": "yes",
         "Packaged": "2025-03-26 11:36:10 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Duncan Temple Lang [ctb],\n  Lloyd Hilaiel [cph] (author of bundled libyajl)",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-03-27 06:40:02 UTC",
-        "Built": "R 4.4.2; x86_64-w64-mingw32; 2025-03-27 13:26:52 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:09:27 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "jsonlite",
         "RemotePkgRef": "jsonlite",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRef": "jsonlite",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "source",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "2.0.0"
       }
     },
@@ -2173,13 +2197,13 @@
         "Packaged": "2025-03-15 00:17:19 UTC; runner",
         "Author": "Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>,\n    https://yihui.org),\n  Abhraneel Sarma [ctb],\n  Adam Vogt [ctb],\n  Alastair Andrew [ctb],\n  Alex Zvoleff [ctb],\n  Amar Al-Zubaidi [ctb],\n  Andre Simon [ctb] (the CSS files under inst/themes/ were derived from\n    the Highlight package http://www.andre-simon.de),\n  Aron Atkins [ctb],\n  Aaron Wolen [ctb],\n  Ashley Manton [ctb],\n  Atsushi Yasumoto [ctb] (<https://orcid.org/0000-0002-8335-495X>),\n  Ben Baumer [ctb],\n  Brian Diggs [ctb],\n  Brian Zhang [ctb],\n  Bulat Yapparov [ctb],\n  Cassio Pereira [ctb],\n  Christophe Dervieux [ctb],\n  David Hall [ctb],\n  David Hugh-Jones [ctb],\n  David Robinson [ctb],\n  Doug Hemken [ctb],\n  Duncan Murdoch [ctb],\n  Elio Campitelli [ctb],\n  Ellis Hughes [ctb],\n  Emily Riederer [ctb],\n  Fabian Hirschmann [ctb],\n  Fitch Simeon [ctb],\n  Forest Fang [ctb],\n  Frank E Harrell Jr [ctb] (the Sweavel package at inst/misc/Sweavel.sty),\n  Garrick Aden-Buie [ctb],\n  Gregoire Detrez [ctb],\n  Hadley Wickham [ctb],\n  Hao Zhu [ctb],\n  Heewon Jeon [ctb],\n  Henrik Bengtsson [ctb],\n  Hiroaki Yutani [ctb],\n  Ian Lyttle [ctb],\n  Hodges Daniel [ctb],\n  Jacob Bien [ctb],\n  Jake Burkhead [ctb],\n  James Manton [ctb],\n  Jared Lander [ctb],\n  Jason Punyon [ctb],\n  Javier Luraschi [ctb],\n  Jeff Arnold [ctb],\n  Jenny Bryan [ctb],\n  Jeremy Ashkenas [ctb, cph] (the CSS file at\n    inst/misc/docco-classic.css),\n  Jeremy Stephens [ctb],\n  Jim Hester [ctb],\n  Joe Cheng [ctb],\n  Johannes Ranke [ctb],\n  John Honaker [ctb],\n  John Muschelli [ctb],\n  Jonathan Keane [ctb],\n  JJ Allaire [ctb],\n  Johan Toloe [ctb],\n  Jonathan Sidi [ctb],\n  Joseph Larmarange [ctb],\n  Julien Barnier [ctb],\n  Kaiyin Zhong [ctb],\n  Kamil Slowikowski [ctb],\n  Karl Forner [ctb],\n  Kevin K. Smith [ctb],\n  Kirill Mueller [ctb],\n  Kohske Takahashi [ctb],\n  Lorenz Walthert [ctb],\n  Lucas Gallindo [ctb],\n  Marius Hofert [ctb],\n  Martin Modrák [ctb],\n  Michael Chirico [ctb],\n  Michael Friendly [ctb],\n  Michal Bojanowski [ctb],\n  Michel Kuhlmann [ctb],\n  Miller Patrick [ctb],\n  Nacho Caballero [ctb],\n  Nick Salkowski [ctb],\n  Niels Richard Hansen [ctb],\n  Noam Ross [ctb],\n  Obada Mahdi [ctb],\n  Pavel N. Krivitsky [ctb] (<https://orcid.org/0000-0002-9101-3362>),\n  Pedro Faria [ctb],\n  Qiang Li [ctb],\n  Ramnath Vaidyanathan [ctb],\n  Richard Cotton [ctb],\n  Robert Krzyzanowski [ctb],\n  Rodrigo Copetti [ctb],\n  Romain Francois [ctb],\n  Ruaridh Williamson [ctb],\n  Sagiru Mati [ctb] (<https://orcid.org/0000-0003-1413-3974>),\n  Scott Kostyshak [ctb],\n  Sebastian Meyer [ctb],\n  Sietse Brouwer [ctb],\n  Simon de Bernard [ctb],\n  Sylvain Rousseau [ctb],\n  Taiyun Wei [ctb],\n  Thibaut Assus [ctb],\n  Thibaut Lamadon [ctb],\n  Thomas Leeper [ctb],\n  Tim Mastny [ctb],\n  Tom Torsney-Weir [ctb],\n  Trevor Davis [ctb],\n  Viktoras Veitas [ctb],\n  Weicheng Zhu [ctb],\n  Wush Wu [ctb],\n  Zachary Foster [ctb],\n  Zhian N. Kamvar [ctb] (<https://orcid.org/0000-0003-1458-7108>),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-03-16 09:20:02 UTC",
-        "Built": "R 4.4.3; ; 2025-03-26 02:45:59 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-04-06 06:10:43 UTC; windows",
         "RemoteType": "standard",
         "RemoteRef": "knitr",
         "RemotePkgRef": "knitr",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.50"
@@ -2205,7 +2229,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2023-08-29 22:20:02 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; ; 2024-04-25 19:45:42 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-12-02 12:40:08 UTC; windows"
       }
     },
     "later": {
@@ -2234,9 +2258,9 @@
         "Packaged": "2025-08-27 07:27:24 UTC; cg334",
         "Author": "Winston Chang [aut],\n  Joe Cheng [aut],\n  Charlie Gao [aut, cre] (ORCID: <https://orcid.org/0000-0002-0750-061X>),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  Marcus Geelnard [ctb, cph] (TinyCThread library,\n    https://tinycthread.github.io/),\n  Evan Nemerson [ctb, cph] (TinyCThread library,\n    https://tinycthread.github.io/)",
         "Maintainer": "Charlie Gao <charlie.gao@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-08-27 08:40:03 UTC",
-        "Built": "R 4.4.3; x86_64-w64-mingw32; 2025-10-13 09:40:39 UTC; windows",
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-16 12:07:00 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2262,7 +2286,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2019-03-15 17:50:07 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:45:08 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:31:45 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2292,7 +2316,14 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2023-11-07 10:10:10 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 20:06:30 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:09:17 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "lifecycle",
+        "RemoteRef": "lifecycle",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.0.4"
       }
     },
     "lubridate": {
@@ -2324,17 +2355,10 @@
         "NeedsCompilation": "yes",
         "Packaged": "2024-12-07 23:41:45 UTC; vitalie",
         "Author": "Vitalie Spinu [aut, cre],\n  Garrett Grolemund [aut],\n  Hadley Wickham [aut],\n  Davis Vaughan [ctb],\n  Ian Lyttle [ctb],\n  Imanuel Costigan [ctb],\n  Jason Law [ctb],\n  Doug Mitarotonda [ctb],\n  Joseph Larmarange [ctb],\n  Jonathan Boiser [ctb],\n  Chel Hee Lee [ctb]",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-12-08 12:10:02 UTC",
-        "Built": "R 4.4.2; x86_64-w64-mingw32; 2024-12-09 13:53:12 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemotePkgRef": "lubridate",
-        "RemoteRef": "lubridate",
-        "RemoteRepos": "https://cloud.r-project.org",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "source",
-        "RemoteSha": "1.9.4"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:32:52 UTC; windows",
+        "Archs": "x64"
       }
     },
     "magrittr": {
@@ -2361,10 +2385,17 @@
         "Packaged": "2025-09-11 16:45:15 UTC; lionel",
         "Author": "Stefan Milton Bache [aut, cph] (Original author and creator of\n    magrittr),\n  Hadley Wickham [aut],\n  Lionel Henry [cre],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-09-12 07:20:14 UTC",
-        "Built": "R 4.4.3; x86_64-w64-mingw32; 2025-10-13 08:57:15 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-09-13 04:48:36 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "magrittr",
+        "RemoteRef": "magrittr",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "2.0.4"
       }
     },
     "memoise": {
@@ -2389,7 +2420,14 @@
         "Maintainer": "Winston Chang <winston@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2021-11-26 16:11:10 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 20:09:40 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:12:12 UTC; windows",
+        "RemoteType": "standard",
+        "RemoteRef": "memoise",
+        "RemotePkgRef": "memoise",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "2.0.1"
       }
     },
     "mime": {
@@ -2412,14 +2450,14 @@
         "Packaged": "2025-03-17 19:54:24 UTC; runner",
         "Author": "Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>,\n    https://yihui.org),\n  Jeffrey Horner [ctb],\n  Beilei Bian [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-03-17 20:20:02 UTC",
-        "Built": "R 4.4.3; x86_64-w64-mingw32; 2025-03-19 00:50:52 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:08:14 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "mime",
         "RemotePkgRef": "mime",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRef": "mime",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.13"
@@ -2448,17 +2486,10 @@
         "Packaged": "2024-09-19 16:09:16 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Oliver Keyes [ctb]",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-09-20 08:40:05 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-10-05 00:28:46 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemotePkgRef": "openssl",
-        "RemoteRef": "openssl",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "2.2.2"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-16 12:09:12 UTC; windows",
+        "Archs": "x64"
       }
     },
     "packrat": {
@@ -2484,16 +2515,9 @@
         "Packaged": "2025-06-16 19:37:19 UTC; aron",
         "Author": "Aron Atkins [aut, cre],\n  Toph Allen [aut],\n  Kevin Ushey [aut],\n  Jonathan McPherson [aut],\n  Joe Cheng [aut],\n  JJ Allaire [aut],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Aron Atkins <aron@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-06-16 20:00:02 UTC",
-        "Built": "R 4.4.3; ; 2025-06-17 23:50:58 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "packrat",
-        "RemotePkgRef": "packrat",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.9.3"
+        "Built": "R 4.5.0; ; 2025-06-17 04:37:40 UTC; windows"
       }
     },
     "pillar": {
@@ -2526,10 +2550,10 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-09-17 11:20:02 UTC",
-        "Built": "R 4.4.0; ; 2025-09-18 04:32:49 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-09-18 04:29:07 UTC; windows",
         "RemoteType": "standard",
-        "RemoteRef": "pillar",
         "RemotePkgRef": "pillar",
+        "RemoteRef": "pillar",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
@@ -2562,15 +2586,8 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-12-12 10:10:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-12-13 04:26:13 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemotePkgRef": "pingr",
-        "RemoteRef": "pingr",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "2.0.5"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-09 19:13:33 UTC; windows",
+        "Archs": "x64"
       }
     },
     "pkgbuild": {
@@ -2599,7 +2616,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-05-26 14:10:06 UTC",
-        "Built": "R 4.4.0; ; 2025-05-27 04:37:33 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-05-27 04:56:10 UTC; windows"
       }
     },
     "pkgconfig": {
@@ -2621,13 +2638,13 @@
         "Encoding": "UTF-8",
         "NeedsCompilation": "no",
         "Packaged": "2019-09-22 08:42:40 UTC; gaborcsardi",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2019-09-22 09:20:02 UTC",
-        "Built": "R 4.4.1; ; 2024-07-17 00:52:17 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-04-06 06:05:36 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "pkgconfig",
         "RemoteRef": "pkgconfig",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "2.0.3"
@@ -2658,9 +2675,9 @@
         "Packaged": "2025-09-23 09:15:44 UTC; lionel",
         "Author": "Hadley Wickham [aut],\n  Winston Chang [aut],\n  Jim Hester [aut],\n  Lionel Henry [aut, cre],\n  Posit Software, PBC [cph, fnd],\n  R Core team [ctb] (Some namespace and vignette code extracted from base\n    R)",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-09-23 10:20:02 UTC",
-        "Built": "R 4.4.3; ; 2025-10-13 10:26:51 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-09-24 04:27:32 UTC; windows"
       }
     },
     "praise": {
@@ -2684,7 +2701,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2015-08-11 08:22:28",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; ; 2024-04-25 19:45:23 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-12-02 12:32:09 UTC; windows"
       }
     },
     "prettyunits": {
@@ -2707,16 +2724,9 @@
         "Packaged": "2023-09-24 10:53:19 UTC; gaborcsardi",
         "Author": "Gabor Csardi [aut, cre],\n  Bill Denney [ctb] (<https://orcid.org/0000-0002-5759-428X>),\n  Christophe Regouby [ctb]",
         "Maintainer": "Gabor Csardi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-09-24 21:10:02 UTC",
-        "Built": "R 4.4.1; ; 2024-07-17 00:52:30 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "prettyunits",
-        "RemoteRef": "prettyunits",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.2.0"
+        "Built": "R 4.5.0; ; 2025-12-02 12:39:01 UTC; windows"
       }
     },
     "processx": {
@@ -2742,17 +2752,10 @@
         "Packaged": "2025-02-19 21:20:47 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre, cph] (<https://orcid.org/0000-0001-7098-9676>),\n  Winston Chang [aut],\n  Posit Software, PBC [cph, fnd],\n  Ascent Digital Services [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-02-21 17:00:01 UTC",
-        "Built": "R 4.4.2; x86_64-w64-mingw32; 2025-02-26 14:10:02 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemotePkgRef": "processx",
-        "RemoteRef": "processx",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "source",
-        "RemoteSha": "3.8.6"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:10:25 UTC; windows",
+        "Archs": "x64"
       }
     },
     "progress": {
@@ -2778,16 +2781,9 @@
         "Packaged": "2023-12-05 09:33:10 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre],\n  Rich FitzJohn [aut],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-12-06 10:30:02 UTC",
-        "Built": "R 4.4.1; ; 2024-07-17 02:09:21 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "progress",
-        "RemoteRef": "progress",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.2.3"
+        "Built": "R 4.5.0; ; 2025-04-06 06:12:20 UTC; windows"
       }
     },
     "promises": {
@@ -2817,17 +2813,10 @@
         "Packaged": "2025-05-29 15:29:40 UTC; barret",
         "Author": "Joe Cheng [aut, cre],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Joe Cheng <joe@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-05-29 16:30:02 UTC",
-        "Built": "R 4.4.3; x86_64-w64-mingw32; 2025-06-16 01:42:03 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "promises",
-        "RemotePkgRef": "promises",
-        "RemoteRepos": "https://cloud.r-project.org",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.3.3"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-16 12:07:32 UTC; windows",
+        "Archs": "x64"
       }
     },
     "ps": {
@@ -2856,15 +2845,8 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-12 09:50:01 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-04-14 17:08:08 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "ps",
-        "RemotePkgRef": "ps",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.9.1"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:32:20 UTC; windows",
+        "Archs": "x64"
       }
     },
     "purrr": {
@@ -2897,11 +2879,11 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-07-10 17:50:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-07-11 04:25:09 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-07-11 04:27:19 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "purrr",
         "RemotePkgRef": "purrr",
+        "RemoteRef": "purrr",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
@@ -2933,8 +2915,15 @@
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2021-01-31 05:40:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:39:40 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:09:19 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "rappdirs",
+        "RemoteRef": "rappdirs",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.3.3"
       }
     },
     "readr": {
@@ -2964,17 +2953,10 @@
         "Packaged": "2024-01-10 21:03:49 UTC; jenny",
         "Author": "Hadley Wickham [aut],\n  Jim Hester [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [aut, cre] (<https://orcid.org/0000-0002-6983-2759>),\n  Shelby Bearrows [ctb],\n  Posit Software, PBC [cph, fnd],\n  https://github.com/mandreyel/ [cph] (mio library),\n  Jukka Jylänki [ctb, cph] (grisu3 implementation),\n  Mikkel Jørgensen [ctb, cph] (grisu3 implementation)",
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-01-10 23:20:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-07-17 02:38:34 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemotePkgRef": "readr",
-        "RemoteRef": "readr",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "2.1.5"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-16 12:26:13 UTC; windows",
+        "Archs": "x64"
       }
     },
     "renv": {
@@ -3003,16 +2985,9 @@
         "Packaged": "2024-10-11 18:36:11 UTC; kevin",
         "Author": "Kevin Ushey [aut, cre] (<https://orcid.org/0000-0003-2880-7407>),\n  Hadley Wickham [aut] (<https://orcid.org/0000-0003-4757-117X>),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Kevin Ushey <kevin@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-10-12 07:30:02 UTC",
-        "Built": "R 4.4.1; ; 2024-10-13 23:50:34 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "renv",
-        "RemoteRef": "renv",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.0.11"
+        "Built": "R 4.5.2; ; 2026-01-14 11:01:26 UTC; windows"
       }
     },
     "rlang": {
@@ -3044,11 +3019,11 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-11 08:40:10 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-04-14 17:02:04 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-14 17:10:39 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "rlang",
         "RemotePkgRef": "rlang",
+        "RemoteRef": "rlang",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
@@ -3081,9 +3056,16 @@
         "Packaged": "2025-09-25 03:25:30 UTC; yihui",
         "Author": "JJ Allaire [aut],\n  Yihui Xie [aut, cre] (ORCID: <https://orcid.org/0000-0003-0645-5666>),\n  Christophe Dervieux [aut] (ORCID:\n    <https://orcid.org/0000-0003-4474-2498>),\n  Jonathan McPherson [aut],\n  Javier Luraschi [aut],\n  Kevin Ushey [aut],\n  Aron Atkins [aut],\n  Hadley Wickham [aut],\n  Joe Cheng [aut],\n  Winston Chang [aut],\n  Richard Iannone [aut] (ORCID: <https://orcid.org/0000-0003-3925-190X>),\n  Andrew Dunning [ctb] (ORCID: <https://orcid.org/0000-0003-0464-5036>),\n  Atsushi Yasumoto [ctb, cph] (ORCID:\n    <https://orcid.org/0000-0002-8335-495X>, cph: Number sections Lua\n    filter),\n  Barret Schloerke [ctb],\n  Carson Sievert [ctb] (ORCID: <https://orcid.org/0000-0002-4958-2844>),\n  Devon Ryan [ctb] (ORCID: <https://orcid.org/0000-0002-8549-0971>),\n  Frederik Aust [ctb] (ORCID: <https://orcid.org/0000-0003-4900-788X>),\n  Jeff Allen [ctb],\n  JooYoung Seo [ctb] (ORCID: <https://orcid.org/0000-0002-4064-6012>),\n  Malcolm Barrett [ctb],\n  Rob Hyndman [ctb],\n  Romain Lesur [ctb],\n  Roy Storey [ctb],\n  Ruben Arslan [ctb],\n  Sergio Oller [ctb],\n  Posit Software, PBC [cph, fnd],\n  jQuery UI contributors [ctb, cph] (jQuery UI library; authors listed in\n    inst/rmd/h/jqueryui/AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Alexander Farkas [ctb, cph] (html5shiv library),\n  Scott Jehl [ctb, cph] (Respond.js library),\n  Ivan Sagalaev [ctb, cph] (highlight.js library),\n  Greg Franko [ctb, cph] (tocify library),\n  John MacFarlane [ctb, cph] (Pandoc templates),\n  Google, Inc. [ctb, cph] (ioslides library),\n  Dave Raggett [ctb] (slidy library),\n  W3C [cph] (slidy library),\n  Dave Gandy [ctb, cph] (Font-Awesome),\n  Ben Sperry [ctb] (Ionicons),\n  Drifty [cph] (Ionicons),\n  Aidan Lister [ctb, cph] (jQuery StickyTabs),\n  Benct Philip Jonsson [ctb, cph] (pagebreak Lua filter),\n  Albert Krewinkel [ctb, cph] (pagebreak Lua filter)",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-09-28 11:30:02 UTC",
-        "Built": "R 4.4.3; ; 2025-10-13 10:51:10 UTC; windows"
+        "Built": "R 4.5.2; ; 2025-11-18 15:12:59 UTC; windows",
+        "RemoteType": "standard",
+        "RemoteRef": "rmarkdown",
+        "RemotePkgRef": "rmarkdown",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "source",
+        "RemoteSha": "2.30"
       }
     },
     "rprojroot": {
@@ -3111,9 +3093,16 @@
         "Packaged": "2025-08-26 15:22:42 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1416-3412>)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-08-26 16:20:02 UTC",
-        "Built": "R 4.4.3; ; 2025-10-13 08:57:41 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-08-27 04:33:41 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "rprojroot",
+        "RemoteRef": "rprojroot",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "2.1.1"
       }
     },
     "rsconnect": {
@@ -3144,7 +3133,7 @@
         "Maintainer": "Aron Atkins <aron@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-08-28 13:50:02 UTC",
-        "Built": "R 4.4.0; ; 2025-08-29 04:28:41 UTC; windows"
+        "Built": "R 4.5.2; ; 2026-01-16 12:26:55 UTC; windows"
       }
     },
     "rstudioapi": {
@@ -3169,7 +3158,7 @@
         "Author": "Kevin Ushey [aut, cre],\n  JJ Allaire [aut],\n  Hadley Wickham [aut],\n  Gary Ritchie [aut],\n  RStudio [cph]",
         "Repository": "RSPM",
         "Date/Publication": "2024-10-22 22:40:02 UTC",
-        "Built": "R 4.4.0; ; 2024-10-23 04:59:53 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-04-06 06:09:20 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "rstudioapi",
         "RemoteRef": "rstudioapi",
@@ -3205,7 +3194,7 @@
         "Maintainer": "Carson Sievert <carson@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-11 19:50:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-04-14 17:40:42 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-14 17:13:04 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemoteRef": "sass",
@@ -3243,14 +3232,7 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-24 11:00:02 UTC",
-        "Built": "R 4.4.0; ; 2025-04-25 04:37:57 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "scales",
-        "RemotePkgRef": "scales",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.4.0"
+        "Built": "R 4.5.0; ; 2025-04-25 04:55:10 UTC; windows"
       }
     },
     "shiny": {
@@ -3280,7 +3262,7 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-07-03 06:20:02 UTC",
-        "Built": "R 4.4.0; ; 2025-07-04 04:34:15 UTC; windows"
+        "Built": "R 4.5.2; ; 2026-01-16 12:27:25 UTC; windows"
       }
     },
     "shinyFeedback": {
@@ -3309,7 +3291,7 @@
         "Maintainer": "Andy Merlino <andy.merlino@tychobra.com>",
         "Repository": "RSPM",
         "Date/Publication": "2021-09-23 18:30:08 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 21:18:24 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-09 21:07:53 UTC; windows"
       }
     },
     "shinyWidgets": {
@@ -3334,16 +3316,9 @@
         "Packaged": "2025-02-21 09:09:48 UTC; perri",
         "Author": "Victor Perrier [aut, cre, cph],\n  Fanny Meyer [aut],\n  David Granjon [aut],\n  Ian Fellows [ctb] (Methods for mutating vertical tabs &\n    updateMultiInput),\n  Wil Davis [ctb] (numericRangeInput function),\n  Spencer Matthews [ctb] (autoNumeric methods),\n  JavaScript and CSS libraries authors [ctb, cph] (All authors are listed\n    in LICENSE.md)",
         "Maintainer": "Victor Perrier <victor.perrier@dreamrs.fr>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-02-21 12:30:02 UTC",
-        "Built": "R 4.4.2; ; 2025-02-26 14:24:07 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "shinyWidgets",
-        "RemoteRef": "shinyWidgets",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "source",
-        "RemoteSha": "0.9.0"
+        "Built": "R 4.5.0; ; 2025-04-09 20:37:47 UTC; windows"
       }
     },
     "shinyalert": {
@@ -3369,7 +3344,7 @@
         "Maintainer": "Dean Attali <daattali@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-04-27 23:10:02 UTC",
-        "Built": "R 4.4.0; ; 2024-04-29 23:40:17 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-09 20:45:41 UTC; windows"
       }
     },
     "shinycssloaders": {
@@ -3393,16 +3368,9 @@
         "Packaged": "2024-07-30 18:52:48 UTC; Dean",
         "Author": "Dean Attali [aut, cre] (Maintainer/developer of shinycssloaders since\n    2019, <https://orcid.org/0000-0002-5645-3493>),\n  Andras Sali [aut] (Original creator of shinycssloaders package),\n  Luke Hass [ctb, cph] (Author of included CSS loader code)",
         "Maintainer": "Dean Attali <daattali@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-07-30 22:30:02 UTC",
-        "Built": "R 4.4.1; ; 2024-08-26 01:59:08 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "shinycssloaders",
-        "RemoteRef": "shinycssloaders",
-        "RemoteRepos": "http://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.1.0"
+        "Built": "R 4.5.0; ; 2025-04-08 03:32:06 UTC; windows"
       }
     },
     "shinydisconnect": {
@@ -3428,7 +3396,7 @@
         "Maintainer": "Dean Attali <daattali@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2023-08-21 08:30:07 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 21:43:35 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-09 20:39:01 UTC; windows"
       }
     },
     "shinyjs": {
@@ -3455,7 +3423,7 @@
         "Maintainer": "Dean Attali <daattali@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2021-12-23 10:10:02 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 21:01:34 UTC; windows"
+        "Built": "R 4.5.2; ; 2026-01-16 12:28:08 UTC; windows"
       }
     },
     "shinytest2": {
@@ -3488,15 +3456,8 @@
         "Maintainer": "Barret Schloerke <barret@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-11 22:20:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-04-14 17:47:25 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "shinytest2",
-        "RemotePkgRef": "shinytest2",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.4.1"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-16 12:29:02 UTC; windows",
+        "Archs": "x64"
       }
     },
     "snakecase": {
@@ -3524,7 +3485,7 @@
         "Author": "Malte Grosser [aut, cre]",
         "Repository": "RSPM",
         "Date/Publication": "2023-08-27 22:50:09 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 20:19:58 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-12-02 12:40:54 UTC; windows"
       }
     },
     "snowflakeauth": {
@@ -3550,7 +3511,7 @@
         "Maintainer": "E. David Aja <david@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-09-02 12:00:02 UTC",
-        "Built": "R 4.4.0; ; 2025-09-03 16:30:46 UTC; windows"
+        "Built": "R 4.5.2; ; 2026-01-16 12:26:48 UTC; windows"
       }
     },
     "sourcetools": {
@@ -3574,7 +3535,7 @@
         "Packaged": "2023-01-31 18:03:04 UTC; kevin",
         "Repository": "RSPM",
         "Date/Publication": "2023-02-01 10:10:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 19:48:01 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:32:43 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -3601,7 +3562,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2016-11-12 01:06:40",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; ; 2024-04-25 20:59:35 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-09 20:40:06 UTC; windows"
       }
     },
     "stringi": {
@@ -3631,11 +3592,11 @@
         "License_is_FOSS": "yes",
         "Repository": "RSPM",
         "Date/Publication": "2025-03-27 13:10:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-03-28 04:41:51 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:07:59 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "stringi",
         "RemotePkgRef": "stringi",
+        "RemoteRef": "stringi",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
@@ -3667,9 +3628,16 @@
         "Packaged": "2025-09-03 22:57:02 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre, cph],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-09-08 12:00:02 UTC",
-        "Built": "R 4.4.3; ; 2025-10-13 10:26:25 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-09-09 04:41:02 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "stringr",
+        "RemoteRef": "stringr",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.5.2"
       }
     },
     "styler": {
@@ -3700,14 +3668,7 @@
         "Maintainer": "Lorenz Walthert <lorenz.walthert@icloud.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-04-07 23:00:02 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 20:32:42 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "styler",
-        "RemoteRef": "styler",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.10.3"
+        "Built": "R 4.5.2; ; 2026-01-16 12:34:09 UTC; windows"
       }
     },
     "sys": {
@@ -3731,14 +3692,14 @@
         "Packaged": "2024-10-03 14:13:17 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Gábor Csárdi [ctb]",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-10-04 09:40:02 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-10-04 23:51:00 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:08:07 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemotePkgRef": "sys",
         "RemoteRef": "sys",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "3.4.3"
@@ -3770,17 +3731,10 @@
         "Packaged": "2025-01-11 00:11:30 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Posit Software, PBC [cph, fnd],\n  R Core team [ctb] (Implementation of utils::recover())",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-01-13 11:20:03 UTC",
-        "Built": "R 4.4.2; x86_64-w64-mingw32; 2025-01-16 00:51:32 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemotePkgRef": "testthat",
-        "RemoteRef": "testthat",
-        "RemoteRepos": "http://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "3.2.3"
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-16 12:28:22 UTC; windows",
+        "Archs": "x64"
       }
     },
     "tibble": {
@@ -3812,14 +3766,14 @@
         "Packaged": "2025-06-07 08:54:33 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1416-3412>),\n  Hadley Wickham [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [ctb],\n  RStudio [cph, fnd]",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-06-08 12:10:02 UTC",
-        "Built": "R 4.4.3; x86_64-w64-mingw32; 2025-06-16 02:16:06 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-06-09 04:29:20 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "tibble",
         "RemotePkgRef": "tibble",
-        "RemoteRepos": "https://cloud.r-project.org",
+        "RemoteRef": "tibble",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "3.3.0"
@@ -3851,14 +3805,14 @@
         "Packaged": "2024-01-23 14:27:23 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Davis Vaughan [aut],\n  Maximilian Girlich [aut],\n  Kevin Ushey [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-01-24 14:50:09 UTC",
-        "Built": "R 4.4.1; x86_64-w64-mingw32; 2024-07-17 02:38:32 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:22:20 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemotePkgRef": "tidyr",
         "RemoteRef": "tidyr",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.3.1"
@@ -3889,13 +3843,13 @@
         "Packaged": "2024-03-11 11:46:04 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-03-11 14:10:02 UTC",
-        "Built": "R 4.4.1; ; 2024-07-17 01:59:50 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-04-06 06:11:39 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "tidyselect",
         "RemoteRef": "tidyselect",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.2.1"
@@ -3925,7 +3879,7 @@
         "Maintainer": "Vitalie Spinu <spinuvit@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-01-18 09:20:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 20:04:34 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:32:06 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -3952,7 +3906,7 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-15 15:50:03 UTC",
-        "Built": "R 4.4.0; ; 2025-04-16 04:53:23 UTC; windows",
+        "Built": "R 4.5.0; ; 2025-04-16 04:45:04 UTC; windows",
         "RemoteType": "standard",
         "RemoteRef": "tinytex",
         "RemotePkgRef": "tinytex",
@@ -3986,17 +3940,10 @@
         "Packaged": "2025-03-14 18:41:13 UTC; davis",
         "Author": "Davis Vaughan [aut, cre],\n  Howard Hinnant [cph] (Author of the included date library),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Davis Vaughan <davis@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-03-15 22:50:02 UTC",
-        "Built": "R 4.4.3; x86_64-w64-mingw32; 2025-03-26 02:31:01 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "tzdb",
-        "RemotePkgRef": "tzdb",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.5.0"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:32:07 UTC; windows",
+        "Archs": "x64"
       }
     },
     "usethis": {
@@ -4028,7 +3975,14 @@
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-09-06 05:10:02 UTC",
-        "Built": "R 4.4.0; ; 2025-09-07 04:26:09 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-09-07 04:23:26 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "usethis",
+        "RemoteRef": "usethis",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "3.2.1"
       }
     },
     "utf8": {
@@ -4053,14 +4007,14 @@
         "Packaged": "2025-06-08 18:28:11 UTC; kirill",
         "Author": "Patrick O. Perry [aut, cph],\n  Kirill Müller [cre] (ORCID: <https://orcid.org/0000-0002-1416-3412>),\n  Unicode, Inc. [cph, dtc] (Unicode Character Database)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-06-08 19:00:02 UTC",
-        "Built": "R 4.4.3; x86_64-w64-mingw32; 2025-06-16 00:35:40 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-06-09 04:28:43 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "utf8",
         "RemotePkgRef": "utf8",
-        "RemoteRepos": "https://cloud.r-project.org",
+        "RemoteRef": "utf8",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.2.6"
@@ -4086,15 +4040,8 @@
         "Repository": "RSPM",
         "Date/Publication": "2024-07-29 07:09:22 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-07-30 04:52:28 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemotePkgRef": "uuid",
-        "RemoteRef": "uuid",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.2-1"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-12-02 12:33:29 UTC; windows",
+        "Archs": "x64"
       }
     },
     "vctrs": {
@@ -4124,8 +4071,15 @@
         "Maintainer": "Davis Vaughan <davis@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2023-12-01 23:50:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-04-25 20:13:49 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:09:58 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "vctrs",
+        "RemoteRef": "vctrs",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.6.5"
       }
     },
     "viridisLite": {
@@ -4152,7 +4106,7 @@
         "Author": "Simon Garnier [aut, cre],\n  Noam Ross [ctb, cph],\n  Bob Rudis [ctb, cph],\n  Marco Sciaini [ctb, cph],\n  Antônio Pedro Camargo [ctb, cph],\n  Cédric Scherer [ctb, cph]",
         "Repository": "RSPM",
         "Date/Publication": "2023-05-02 23:50:02 UTC",
-        "Built": "R 4.4.0; ; 2024-04-25 19:47:00 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-12-02 12:32:51 UTC; windows"
       }
     },
     "vroom": {
@@ -4185,7 +4139,7 @@
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-09-19 07:30:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-09-20 04:33:25 UTC; windows",
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-16 12:25:03 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -4212,9 +4166,9 @@
         "Packaged": "2025-07-11 13:27:03 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-07-11 15:20:02 UTC",
-        "Built": "R 4.4.3; ; 2025-10-13 09:41:10 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-12-02 12:37:57 UTC; windows"
       }
     },
     "websocket": {
@@ -4242,15 +4196,8 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-10 09:00:02 UTC",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2025-04-16 05:04:10 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "websocket",
-        "RemotePkgRef": "websocket",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.4.4"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2026-01-11 05:57:34 UTC; windows",
+        "Archs": "x64"
       }
     },
     "whisker": {
@@ -4271,13 +4218,14 @@
         "RoxygenNote": "6.1.1",
         "NeedsCompilation": "no",
         "Packaged": "2022-12-05 15:15:55 UTC; hornik",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2022-12-05 15:33:50 UTC",
-        "Built": "R 4.4.1; ; 2024-07-17 00:53:04 UTC; windows",
+        "Encoding": "UTF-8",
+        "Built": "R 4.5.0; ; 2025-04-09 21:36:11 UTC; windows",
         "RemoteType": "standard",
         "RemotePkgRef": "whisker",
         "RemoteRef": "whisker",
-        "RemoteRepos": "https://cloud.r-project.org",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.4.1"
@@ -4310,7 +4258,14 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2024-10-28 13:30:02 UTC",
-        "Built": "R 4.4.0; ; 2024-10-29 04:34:54 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:08:49 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "withr",
+        "RemoteRef": "withr",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "3.0.2"
       }
     },
     "xfun": {
@@ -4336,9 +4291,9 @@
         "Packaged": "2025-08-18 23:51:54 UTC; yihui",
         "Author": "Yihui Xie [aut, cre, cph] (ORCID:\n    <https://orcid.org/0000-0003-0645-5666>, URL: https://yihui.org),\n  Wush Wu [ctb],\n  Daijiang Li [ctb],\n  Xianying Tan [ctb],\n  Salim Brüggemann [ctb] (ORCID: <https://orcid.org/0000-0002-5329-5987>),\n  Christophe Dervieux [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-08-19 02:50:02 UTC",
-        "Built": "R 4.4.3; x86_64-w64-mingw32; 2025-10-13 08:57:16 UTC; windows",
+        "Built": "R 4.5.2; x86_64-w64-mingw32; 2026-01-16 12:06:38 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -4365,7 +4320,7 @@
         "Author": "David B. Dahl [aut],\n  David Scott [aut, cre],\n  Charles Roosen [aut],\n  Arni Magnusson [aut],\n  Jonathan Swinton [aut],\n  Ajay Shah [ctb],\n  Arne Henningsen [ctb],\n  Benno Puetz [ctb],\n  Bernhard Pfaff [ctb],\n  Claudio Agostinelli [ctb],\n  Claudius Loehnert [ctb],\n  David Mitchell [ctb],\n  David Whiting [ctb],\n  Fernando da Rosa [ctb],\n  Guido Gay [ctb],\n  Guido Schulz [ctb],\n  Ian Fellows [ctb],\n  Jeff Laake [ctb],\n  John Walker [ctb],\n  Jun Yan [ctb],\n  Liviu Andronic [ctb],\n  Markus Loecher [ctb],\n  Martin Gubri [ctb],\n  Matthieu Stigler [ctb],\n  Robert Castelo [ctb],\n  Seth Falcon [ctb],\n  Stefan Edwards [ctb],\n  Sven Garbade [ctb],\n  Uwe Ligges [ctb]",
         "Date/Publication": "2019-04-21 12:20:03 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; ; 2024-04-25 19:46:08 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-12-02 12:33:40 UTC; windows"
       }
     },
     "yaml": {
@@ -4389,7 +4344,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2024-07-26 15:10:02 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.4.0; x86_64-w64-mingw32; 2024-07-27 04:42:17 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:08:12 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemotePkgRef": "yaml",
@@ -4422,16 +4377,16 @@
         "Packaged": "2025-05-13 13:31:44 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre],\n  Kuba Podgórski [ctb],\n  Rich Geldreich [ctb],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-05-13 14:10:02 UTC",
-        "Built": "R 4.4.2; x86_64-w64-mingw32; 2025-05-15 10:06:03 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-05-14 04:45:37 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "zip",
         "RemotePkgRef": "zip",
-        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteRef": "zip",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "source",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "2.3.3"
       }
     }
@@ -4456,7 +4411,7 @@
       "checksum": "c1d6b214017ea01fb7141a0b0e228e02"
     },
     ".Rprofile": {
-      "checksum": "68aa44314b3719feb807f4b7f19d47a7"
+      "checksum": "fb1c8b656ea6958dfd827f2b64096d81"
     },
     "azure-pipelines-dev.yml": {
       "checksum": "fc2ef843ff5024bcba25ff84eec05f4c"
@@ -4474,7 +4429,7 @@
       "checksum": "31d565a819730736cbcf5a38959d3398"
     },
     "data/data-dictionary.csv": {
-      "checksum": "c3a66562bd0a9825ab6aec37af01d574"
+      "checksum": "ecd69d14f695d0c39fdc4854375346af"
     },
     "data/english_devolved_areas.csv": {
       "checksum": "391e91c38d772d55f98e54fbacfc3b9f"
@@ -4693,7 +4648,7 @@
       "checksum": "d9b48105db5a9f000b202b0d2e0fe79e"
     },
     "tests/testthat/fileValidation/naming_convention-metaFail.meta.xlsx": {
-      "checksum": "50a9f1e312f3b39feacb8855c7750ab2"
+      "checksum": "db7be3fa9be710443cd81ff6d8391f33"
     },
     "tests/testthat/fileValidation/naming_convention.csv": {
       "checksum": "d9b48105db5a9f000b202b0d2e0fe79e"
@@ -5368,7 +5323,7 @@
       "checksum": "ce45333664f1579f8e6a57e82c96efe2"
     },
     "tests/testthat/sch_prov/sch_filter_group.meta.csv": {
-      "checksum": "77b48323b84cdfeacc593980593bdccc"
+      "checksum": "bd329f63f62d2d86df02b31153d62d5d"
     },
     "tests/testthat/sch_prov/sch_filter_grouped.csv": {
       "checksum": "1c38848940693acfe3cc5d68dbce4b97"
@@ -5497,7 +5452,7 @@
       "checksum": "1e405d074b26bb6cf0502238fd72c5df"
     },
     "tests/testthat/test-data/invalid_type3.meta.xlsx": {
-      "checksum": "50a9f1e312f3b39feacb8855c7750ab2"
+      "checksum": "db7be3fa9be710443cd81ff6d8391f33"
     },
     "tests/testthat/test-data/label_blank_notNA.csv": {
       "checksum": "efc245c3f96a78564f6c3498d057ef36"
@@ -5566,7 +5521,7 @@
       "checksum": "b52ab48ee255cc88624a034db31296c6"
     },
     "www/acalat_theme.css": {
-      "checksum": "e926d2ff3a5799c06d16a5e3c70b47aa"
+      "checksum": "8e7009445352b2fd4b44667eac6c48a3"
     },
     "www/builder-duck.PNG": {
       "checksum": "7574642f76936b645e9ce137ec6a99e9"

--- a/manifest.json
+++ b/manifest.json
@@ -4411,7 +4411,7 @@
       "checksum": "c1d6b214017ea01fb7141a0b0e228e02"
     },
     ".Rprofile": {
-      "checksum": "fb1c8b656ea6958dfd827f2b64096d81"
+      "checksum": "87625d5c0e2a419252ebb92891c81b12"
     },
     "azure-pipelines-dev.yml": {
       "checksum": "fc2ef843ff5024bcba25ff84eec05f4c"
@@ -4429,7 +4429,7 @@
       "checksum": "31d565a819730736cbcf5a38959d3398"
     },
     "data/data-dictionary.csv": {
-      "checksum": "ecd69d14f695d0c39fdc4854375346af"
+      "checksum": "72ef0ad55de59557f0d7268ab122d900"
     },
     "data/english_devolved_areas.csv": {
       "checksum": "391e91c38d772d55f98e54fbacfc3b9f"

--- a/manifest.json
+++ b/manifest.json
@@ -4411,7 +4411,7 @@
       "checksum": "c1d6b214017ea01fb7141a0b0e228e02"
     },
     ".Rprofile": {
-      "checksum": "1b9c1c63d896c4bb67c54964efb634cc"
+      "checksum": "4cb12acba83e9c2b5019fc66254fdebb"
     },
     "azure-pipelines-dev.yml": {
       "checksum": "fc2ef843ff5024bcba25ff84eec05f4c"
@@ -4429,7 +4429,7 @@
       "checksum": "31d565a819730736cbcf5a38959d3398"
     },
     "data/data-dictionary.csv": {
-      "checksum": "31982b769b15a03900d364d8b5ee7872"
+      "checksum": "9784adf3c2fb5ef4c2c5c7c6c72c4547"
     },
     "data/english_devolved_areas.csv": {
       "checksum": "391e91c38d772d55f98e54fbacfc3b9f"

--- a/manifest.json
+++ b/manifest.json
@@ -4411,8 +4411,7 @@
       "checksum": "c1d6b214017ea01fb7141a0b0e228e02"
     },
     ".Rprofile": {
-      "checksum": "87625d5c0e2a419252ebb92891c81b12"
-      "checksum": "d4acba8d6cb3762899bec03ca2e054aa"
+      "checksum": "90163300bedadcf4b4cb320e5357e3c9"
     },
     "azure-pipelines-dev.yml": {
       "checksum": "fc2ef843ff5024bcba25ff84eec05f4c"
@@ -4430,8 +4429,7 @@
       "checksum": "31d565a819730736cbcf5a38959d3398"
     },
     "data/data-dictionary.csv": {
-      "checksum": "72ef0ad55de59557f0d7268ab122d900"
-      "checksum": "d9ea5613f35fc968c6dc72cb9e552d49"
+      "checksum": "f4c87ba23fbbc2d7e48b5395a90e8bec"
     },
     "data/english_devolved_areas.csv": {
       "checksum": "391e91c38d772d55f98e54fbacfc3b9f"

--- a/manifest.json
+++ b/manifest.json
@@ -4411,7 +4411,7 @@
       "checksum": "c1d6b214017ea01fb7141a0b0e228e02"
     },
     ".Rprofile": {
-      "checksum": "90163300bedadcf4b4cb320e5357e3c9"
+      "checksum": "1b9c1c63d896c4bb67c54964efb634cc"
     },
     "azure-pipelines-dev.yml": {
       "checksum": "fc2ef843ff5024bcba25ff84eec05f4c"
@@ -4429,7 +4429,7 @@
       "checksum": "31d565a819730736cbcf5a38959d3398"
     },
     "data/data-dictionary.csv": {
-      "checksum": "f4c87ba23fbbc2d7e48b5395a90e8bec"
+      "checksum": "31982b769b15a03900d364d8b5ee7872"
     },
     "data/english_devolved_areas.csv": {
       "checksum": "391e91c38d772d55f98e54fbacfc3b9f"


### PR DESCRIPTION
<!-- 
Hey, thanks for raising a PR! We're excited to see what you've done!
To help us review the changes, please complete each section in this template by replacing '...' with details to help the reviewers of this pull request. 
-->

# Brief overview of changes

Added filters and indicators relevant to the CME and EHE data.

## Why are these changes being made?

So that CME and EHE data can be brought into the API.

## Detailed description of changes

For CME: I've added different labels for the Sex breakdown_topic, the Year Group, Duration and Reason filters as breakdowns and the three indicator columns used in the CME data (child_count, child_percent, rate_per_100) to data_dictionary.csv.

For EHE: I've added the ehe_status groupings for prior_settings, as well as three indicators related to notices/orders being issued or revoked.

## Additional information for reviewers

## Issue ticket number/s and link