### PR TITLE
Adding new filters and indicators  from file 2

### DIFF
--- a/data/data-dictionary.csv
+++ b/data/data-dictionary.csv
@@ -18,6 +18,12 @@ age,Filter,16 to 24,,,,api-only,Personal characteristics
 age,Filter,18 to 21,,,,api-only,Personal characteristics
 age,Filter,18 to 24,,,,api-only,Personal characteristics
 age,Filter,19 to 24,,,,api-only,Personal characteristics
+age,Filter,1 year,,,,api-only,Funded early education and childcare
+age,Filter,2 years,,,,api-only,Funded early education and childcare
+age,Filter,3 years,,,,api-only,Funded early education and childcare
+age,Filter,4 years,,,,api-only,Funded early education and childcare
+age,Filter,9 to 11 months,,,,api-only,Funded early education and childcare
+age,Filter,Total,,,,api-only,Funded early education and childcare
 age_group,Filter,19 to 24,age_youth_adult,19 plus,,api-only,Personal characteristics
 age_group,Filter,25 plus,age_youth_adult,19 plus,,api-only,Personal characteristics
 age_group,Filter,Total,age_youth_adult,19 plus,,api-only,Personal characteristics
@@ -339,6 +345,9 @@ elgs_expected_number,Filter,15,,,,api-only,Early years foundation stage profile 
 elgs_expected_number,Filter,16,,,,api-only,Early years foundation stage profile results
 elgs_expected_number,Filter,17,,,,api-only,Early years foundation stage profile results
 elgs_expected_number,Filter,Total,,,,api-only,Early years foundation stage profile results
+entitlement_type,Filter,Working parents,,,,api-only,Funded early education and childcare
+entitlement_type,Filter,Early learning for 2-year-olds,,,,api-only,Funded early education and childcare
+entitlement_type,Filter,Universal,,,,api-only,Funded early education and childcare
 establishment_governance,Filter,Academy,,,CA,api-only,Establishment characteristics
 establishment_governance,Filter,City technology college,,,CT,api-only,Establishment characteristics
 establishment_governance,Filter,Community,,,CO,api-only,Establishment characteristics
@@ -778,14 +787,19 @@ prior_attainment,Filter,Total,,,,api-only,Attainment
 provider_type,Filter,All group-based providers,,,,api-only,Establishment characteristics
 provider_type,Filter,All school-based providers,,,,api-only,Establishment characteristics
 provider_type,Filter,Childminders,,,,api-only,Establishment characteristics
+provider_type,Filter,Childminders,provider_type_group,"Private, voluntary and independent providers",,api-only,Funded early education and childcare
 provider_type,Filter,Further education colleges,,,,api-only,Establishment characteristics
 provider_type,Filter,General FE college including tertiary,,,,api-only,Establishment characteristics
 provider_type,Filter,Higher education providers,,,,api-only,Establishment characteristics
+provider_type,Filter,Independent schools,provider_type_group,"Private, voluntary and independent providers",,api-only,Funded early education and childcare
 provider_type,Filter,Local authority,,,,api-only,Establishment characteristics
+provider_type,Filter,Local authority day nurseries,provider_type_group,"Private, voluntary and independent providers",,api-only,Funded early education and childcare
 provider_type,Filter,Maintained nursery schools,,,,api-only,Establishment characteristics
 provider_type,Filter,Nursery class childcare settings,,,,api-only,Establishment characteristics
 provider_type,Filter,Other,,,,api-only,Establishment characteristics
+provider_type,Filter,Other,provider_type_group,"Private, voluntary and independent providers",,api-only,Establishment characteristics
 provider_type,Filter,Other public funded (LAs and HE),,,,api-only,Establishment characteristics
+provider_type,Filter,Private and voluntary providers,provider_type_group,"Private, voluntary and independent providers",,api-only,Funded early education and childcare
 provider_type,Filter,Private group-based providers,,,,api-only,Establishment characteristics
 provider_type,Filter,Private sector public funded,,,,api-only,Establishment characteristics
 provider_type,Filter,Private training providers in the FE sector,,,,api-only,Establishment characteristics
@@ -793,7 +807,15 @@ provider_type,Filter,"School, college, LA and other unclassified group-based pro
 provider_type,Filter,Schools,,,,api-only,Establishment characteristics
 provider_type,Filter,Sixth form college,,,,api-only,Establishment characteristics
 provider_type,Filter,Special college,,,,api-only,Establishment characteristics
-provider_type,Filter,Total,,,,api-only,Establishment characteristics
+provider_type,Filter,Special schools,provider_type_group,State-funded schools,,api-only,Funded early education and childcare
+provider_type,Filter,State-funded governor-run,provider_type_group,"Private, voluntary and independent providers",,api-only,Funded early education and childcare
+provider_type,Filter,State-funded nursery schools,provider_type_group,State-funded schools,,api-only,Funded early education and childcare
+provider_type,Filter,State-funded primary schools,provider_type_group,State-funded schools,,api-only,Funded early education and childcare
+provider_type,Filter,State-funded secondary schools,provider_type_group,State-funded schools,,api-only,Funded early education and childcare
+provider_type,Filter,Total,,,,api-only,Funded early education and childcare
+provider_type,Filter,Total,provider_type_group,"Private, voluntary and independent providers",,api-only,Funded early education and childcare
+provider_type,Filter,Total,provider_type_group,State-funded schools,,api-only,Funded early education and childcare
+provider_type,Filter,Total,provider_type_group,Total,,api-only,Funded early education and childcare
 provider_type,Filter,Unknown,,,,api-only,Establishment characteristics
 provider_type,Filter,Voluntary group-based providers,,,,api-only,Establishment characteristics
 qualification_type,Filter,AS level,,,,api-only,Attainment
@@ -1107,6 +1129,9 @@ time_frame,Filter,Year to date,,,,api-only,Pupil attendance
 total_neet_net,Filter,NEET,,,,api-only,NEET
 total_neet_net,Filter,NET,,,,api-only,NEET
 total_neet_net,Filter,Total,,,,api-only,NEET
+year_group,Filter,Nursery,,,,api-only,Funded early education and childcare
+year_group,Filter,Reception,,,,api-only,Funded early education and childcare
+year_group,Filter,Total,,,,api-only,Funded early education and childcare
 years_open,Filter,1 year,,,,api-only,Establishment characteristics
 years_open,Filter,10 years,,,,api-only,Establishment characteristics
 years_open,Filter,11 years,,,,api-only,Establishment characteristics
@@ -1522,6 +1547,7 @@ progress8original_average,Indicator,,,,,api-only,Attainment - Key stage 4
 progress8original_lower_95_ci,Indicator,,,,,api-only,Attainment - Key stage 4
 progress8original_sum,Indicator,,,,,api-only,Attainment - Key stage 4
 progress8original_upper_95_ci,Indicator,,,,,api-only,Attainment - Key stage 4
+providers_count,Indicator,,,,,api-only,Funded early education and childcare
 pupil_count,Indicator,,,,,api-only,General
 pupil_percent,Indicator,,,,,api-only,General
 qual_covid_impacted_percent,Indicator,,,,,api-only,Attainment - Key stage 4
@@ -1533,6 +1559,7 @@ qual_entries_without_discounting_sum,Indicator,,,,,api-only,Attainment - Key sta
 reference_date,Indicator,,,,,api-only,Pupil attendance
 referral_child_count,Indicator,,,,,api-only,Children in Need
 referral_count,Indicator,,,,,api-only,Children in Need
+registered_children_count,Indicator,,,,,api-only,Funded early education and childcare
 rereferral_child_count,Indicator,,,,,api-only,Children in Need
 rereferral_child_percent,Indicator,,,,,api-only,Children in Need
 rereferral_count,Indicator,,,,,api-only,Children in Need

--- a/data/data-dictionary.csv
+++ b/data/data-dictionary.csv
@@ -1,4 +1,4 @@
-﻿col_name,col_type,filter_item,col_name_parent,filter_item_parent,cbds_code,item_error_flag,contexts
+col_name,col_type,filter_item,col_name_parent,filter_item_parent,cbds_code,item_error_flag,contexts
 absence_type,Filter,Persistent absence,,,,api-only,Pupil attendance
 absence_type,Filter,Severe absence,,,,api-only,Pupil attendance
 absence_type,Filter,Total pupils,,,,api-only,Pupil attendance
@@ -346,7 +346,7 @@ elgs_expected_number,Filter,16,,,,api-only,Early years foundation stage profile 
 elgs_expected_number,Filter,17,,,,api-only,Early years foundation stage profile results
 elgs_expected_number,Filter,Total,,,,api-only,Early years foundation stage profile results
 entitlement_type,Filter,Working parents,,,,api-only,Funded early education and childcare
-entitlement_type,Filter,Early learning for 2-year-olds,,,,api-only,Funded early education and childcare
+entitlement_type,Filter,Early learning for 2 year olds,,,,api-only,Funded early education and childcare
 entitlement_type,Filter,Universal,,,,api-only,Funded early education and childcare
 establishment_governance,Filter,Academy,,,CA,api-only,Establishment characteristics
 establishment_governance,Filter,City technology college,,,CT,api-only,Establishment characteristics

--- a/manifest.json
+++ b/manifest.json
@@ -4359,7 +4359,7 @@
       "checksum": "c1d6b214017ea01fb7141a0b0e228e02"
     },
     ".Rprofile": {
-      "checksum": "b580e2b9cecb8cca7bdfc43deeba1148"
+      "checksum": "c825fe39fe5bbaea5a64d13bb0d046d2"
     },
     "azure-pipelines-dev.yml": {
       "checksum": "fc2ef843ff5024bcba25ff84eec05f4c"
@@ -4377,7 +4377,7 @@
       "checksum": "31d565a819730736cbcf5a38959d3398"
     },
     "data/data-dictionary.csv": {
-      "checksum": "6cfae3f02a31eb130673ce61fbb87b54"
+      "checksum": "f22f75809a3331f74314fb322a444414"
     },
     "data/english_devolved_areas.csv": {
       "checksum": "391e91c38d772d55f98e54fbacfc3b9f"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "en_GB",
-  "platform": "4.5.3",
+  "platform": "4.5.1",
   "metadata": {
     "appmode": "shiny",
     "primary_rmd": null,
@@ -37,14 +37,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2025-04-15 10:50:01 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.5.0; ; 2025-04-16 04:55:11 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "AsioHeaders",
-        "RemotePkgRef": "AsioHeaders",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.30.2-1"
+        "Built": "R 4.5.0; ; 2025-04-16 04:55:11 UTC; windows"
       }
     },
     "DT": {
@@ -69,15 +62,9 @@
         "Packaged": "2025-09-02 13:12:27 UTC; garrick",
         "Author": "Yihui Xie [aut],\n  Joe Cheng [aut],\n  Xianying Tan [aut],\n  Garrick Aden-Buie [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-7111-0077>),\n  JJ Allaire [ctb],\n  Maximilian Girlich [ctb],\n  Greg Freedman Ellis [ctb],\n  Johannes Rauh [ctb],\n  SpryMedia Limited [ctb, cph] (DataTables in htmlwidgets/lib),\n  Brian Reavis [ctb, cph] (selectize.js in htmlwidgets/lib),\n  Leon Gersen [ctb, cph] (noUiSlider in htmlwidgets/lib),\n  Bartek Szopka [ctb, cph] (jquery.highlight.js in htmlwidgets/lib),\n  Alex Pickering [ctb],\n  William Holmes [ctb],\n  Mikko Marttila [ctb],\n  Andres Quintero [ctb],\n  Stéphane Laurent [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Garrick Aden-Buie <garrick@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-09-02 22:00:06 UTC",
-        "Built": "R 4.5.1; ; 2025-09-05 23:51:57 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "DT",
-        "RemoteRef": "DT",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "i386+x86_64-w64-mingw32",
-        "RemoteSha": "0.34.0"
+        "Built": "R 4.5.0; ; 2025-09-03 04:28:11 UTC; windows"
       }
     },
     "PKI": {
@@ -127,14 +114,7 @@
         "Packaged": "2025-05-02 21:22:23 UTC; henrik",
         "Repository": "RSPM",
         "Date/Publication": "2025-05-02 22:20:02 UTC",
-        "Built": "R 4.5.0; ; 2025-05-03 05:14:51 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "R.cache",
-        "RemotePkgRef": "R.cache",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.17.0"
+        "Built": "R 4.5.0; ; 2025-05-03 05:14:51 UTC; windows"
       }
     },
     "R.methodsS3": {
@@ -160,14 +140,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2022-06-13 22:00:14 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.5.0; ; 2025-04-06 06:07:39 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "R.methodsS3",
-        "RemotePkgRef": "R.methodsS3",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.8.2"
+        "Built": "R 4.5.0; ; 2025-04-06 06:07:39 UTC; windows"
       }
     },
     "R.oo": {
@@ -193,14 +166,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2025-05-02 21:00:05 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.5.0; ; 2025-05-03 05:13:53 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "R.oo",
-        "RemotePkgRef": "R.oo",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.27.1"
+        "Built": "R 4.5.0; ; 2025-05-03 05:13:53 UTC; windows"
       }
     },
     "R.utils": {
@@ -226,14 +192,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2025-02-24 21:20:02 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.5.0; ; 2025-04-06 06:10:08 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "R.utils",
-        "RemotePkgRef": "R.utils",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "2.13.0"
+        "Built": "R 4.5.0; ; 2025-04-06 06:10:08 UTC; windows"
       }
     },
     "R6": {
@@ -260,7 +219,14 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-02-15 00:50:02 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 00:51:09 UTC; windows"
+        "Built": "R 4.5.1; ; 2025-09-29 00:31:01 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "R6",
+        "RemoteRef": "R6",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "2.6.1"
       }
     },
     "RColorBrewer": {
@@ -284,11 +250,9 @@
         "Encoding": "UTF-8",
         "Built": "R 4.5.0; ; 2025-04-06 06:08:42 UTC; windows",
         "RemoteType": "standard",
-        "RemoteRef": "RColorBrewer",
         "RemotePkgRef": "RColorBrewer",
+        "RemoteRef": "RColorBrewer",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.1-3"
       }
     },
@@ -314,10 +278,15 @@
         "Packaged": "2025-07-01 12:58:41 UTC; edd",
         "Author": "Dirk Eddelbuettel [aut, cre] (ORCID:\n    <https://orcid.org/0000-0001-6419-907X>),\n  Romain Francois [aut] (ORCID: <https://orcid.org/0000-0002-2444-4226>),\n  JJ Allaire [aut] (ORCID: <https://orcid.org/0000-0003-0174-9868>),\n  Kevin Ushey [aut] (ORCID: <https://orcid.org/0000-0003-2880-7407>),\n  Qiang Kou [aut] (ORCID: <https://orcid.org/0000-0001-6786-5453>),\n  Nathan Russell [aut],\n  Iñaki Ucar [aut] (ORCID: <https://orcid.org/0000-0001-6403-5550>),\n  Doug Bates [aut] (ORCID: <https://orcid.org/0000-0001-8316-9503>),\n  John Chambers [aut]",
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-07-02 16:40:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-03 23:51:36 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-07-03 05:02:22 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "Rcpp",
+        "RemoteRef": "Rcpp",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.1.0"
       }
     },
     "RcppTOML": {
@@ -405,14 +374,14 @@
         "Packaged": "2024-10-03 14:12:09 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>)",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-10-04 07:20:03 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:08:49 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 01:15:52 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemoteRef": "askpass",
         "RemotePkgRef": "askpass",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.2.1"
@@ -444,11 +413,9 @@
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:07:41 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "backports",
         "RemotePkgRef": "backports",
+        "RemoteRef": "backports",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.5.0"
       }
     },
@@ -472,7 +439,12 @@
         "Date/Publication": "2015-07-28 08:03:37",
         "Encoding": "UTF-8",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:08:45 UTC; windows",
-        "Archs": "x64"
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "base64enc",
+        "RemoteRef": "base64enc",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.1-3"
       }
     },
     "bit": {
@@ -498,14 +470,14 @@
         "Packaged": "2025-03-05 07:18:45 UTC; michael",
         "Author": "Michael Chirico [aut, cre],\n  Jens Oehlschlägel [aut],\n  Brian Ripley [ctb]",
         "Maintainer": "Michael Chirico <MichaelChirico4@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-03-06 10:50:01 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:11:04 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 00:31:31 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemoteRef": "bit",
         "RemotePkgRef": "bit",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "4.6.0"
@@ -535,14 +507,14 @@
         "Packaged": "2025-01-16 14:04:20 UTC; michael",
         "Author": "Michael Chirico [aut, cre],\n  Jens Oehlschlägel [aut],\n  Leonardo Silvestri [ctb],\n  Ofek Shilon [ctb]",
         "Maintainer": "Michael Chirico <michaelchirico4@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-01-16 16:00:07 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:11:53 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 01:15:54 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemoteRef": "bit64",
         "RemotePkgRef": "bit64",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "4.6.0-1"
@@ -570,9 +542,9 @@
         "Packaged": "2024-04-24 18:51:29 UTC; gaborcsardi",
         "Author": "Jim Hester [aut] (<https://orcid.org/0000-0002-2739-7082>),\n  Gábor Csárdi [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-04-24 19:20:07 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 00:51:31 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:07:46 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -604,9 +576,14 @@
         "Packaged": "2025-01-30 22:04:52 UTC; garrick",
         "Author": "Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Joe Cheng [aut],\n  Garrick Aden-Buie [aut] (<https://orcid.org/0000-0002-7111-0077>),\n  Posit Software, PBC [cph, fnd],\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Javi Aguilar [ctb, cph] (Bootstrap colorpicker library),\n  Thomas Park [ctb, cph] (Bootswatch library),\n  PayPal [ctb, cph] (Bootstrap accessibility plugin)",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-01-30 23:20:02 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 02:06:55 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:18:52 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "bslib",
+        "RemoteRef": "bslib",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.9.0"
       }
     },
     "cachem": {
@@ -631,10 +608,15 @@
         "Packaged": "2024-05-15 15:54:22 UTC; winston",
         "Author": "Winston Chang [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Winston Chang <winston@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-05-16 09:50:11 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 01:50:06 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:11:37 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "cachem",
+        "RemoteRef": "cachem",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.1.0"
       }
     },
     "callr": {
@@ -661,9 +643,9 @@
         "Packaged": "2024-03-25 12:10:25 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre, cph] (<https://orcid.org/0000-0001-7098-9676>),\n  Winston Chang [aut],\n  Posit Software, PBC [cph, fnd],\n  Ascent Digital Services [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-03-25 13:30:06 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 01:56:50 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:11:37 UTC; windows"
       }
     },
     "checkmate": {
@@ -692,16 +674,14 @@
         "Packaged": "2025-08-18 13:58:18 UTC; michel",
         "Author": "Michel Lang [cre, aut] (ORCID: <https://orcid.org/0000-0001-9754-0393>),\n  Bernd Bischl [ctb],\n  Dénes Tóth [ctb] (ORCID: <https://orcid.org/0000-0003-4262-3217>)",
         "Maintainer": "Michel Lang <michellang@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-08-18 16:30:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-02 08:18:02 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-08-19 04:41:01 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "checkmate",
         "RemotePkgRef": "checkmate",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteRef": "checkmate",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
         "RemoteSha": "2.3.3"
       }
     },
@@ -734,14 +714,7 @@
         "Maintainer": "Garrick Aden-Buie <garrick@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-24 03:40:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-25 04:59:20 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "chromote",
-        "RemotePkgRef": "chromote",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.5.1"
+        "Built": "R 4.5.0; ; 2025-04-25 04:59:20 UTC; windows"
       }
     },
     "cli": {
@@ -769,8 +742,15 @@
         "Maintainer": "Gábor Csárdi <gabor@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-04-23 13:50:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 00:51:12 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 00:31:01 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "cli",
+        "RemoteRef": "cli",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "3.6.5"
       }
     },
     "clipr": {
@@ -797,13 +777,13 @@
         "Packaged": "2022-02-19 02:20:21 UTC; mlincoln",
         "Author": "Matthew Lincoln [aut, cre] (<https://orcid.org/0000-0002-4387-3384>),\n  Louis Maddox [ctb],\n  Steve Simpson [ctb],\n  Jennifer Bryan [ctb]",
         "Maintainer": "Matthew Lincoln <matthew.d.lincoln@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2022-02-22 00:58:45 UTC",
-        "Built": "R 4.5.0; ; 2025-04-06 06:07:19 UTC; windows",
+        "Built": "R 4.5.1; ; 2025-09-29 00:31:09 UTC; windows",
         "RemoteType": "standard",
         "RemoteRef": "clipr",
         "RemotePkgRef": "clipr",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.8.0"
@@ -827,7 +807,7 @@
         "Packaged": "2024-03-31 18:18:09 UTC; luke",
         "Repository": "CRAN",
         "Date/Publication": "2024-03-31 20:10:06 UTC",
-        "Built": "R 4.5.3; ; 2026-03-11 08:55:50 UTC; windows"
+        "Built": "R 4.5.1; ; 2025-06-13 07:58:11 UTC; windows"
       }
     },
     "commonmark": {
@@ -851,10 +831,15 @@
         "Packaged": "2025-07-07 13:20:39 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (ORCID: <https://orcid.org/0000-0002-4035-0289>),\n  John MacFarlane [cph] (Author of cmark)",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-07-07 13:40:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-08-04 00:19:45 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-07-08 04:25:38 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "commonmark",
+        "RemoteRef": "commonmark",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.0.0"
       }
     },
     "config": {
@@ -910,13 +895,13 @@
         "Packaged": "2025-03-03 22:24:28 UTC; davis",
         "Author": "Davis Vaughan [aut, cre] (<https://orcid.org/0000-0003-4777-038X>),\n  Jim Hester [aut] (<https://orcid.org/0000-0002-2739-7082>),\n  Romain François [aut] (<https://orcid.org/0000-0002-2444-4226>),\n  Benjamin Kietzman [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Davis Vaughan <davis@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-03-03 23:20:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-06 06:12:05 UTC; windows",
+        "Built": "R 4.5.1; ; 2025-09-29 00:31:02 UTC; windows",
         "RemoteType": "standard",
-        "RemoteRef": "cpp11",
         "RemotePkgRef": "cpp11",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRef": "cpp11",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.5.2"
@@ -946,7 +931,14 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2024-06-20 13:00:02 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 00:51:23 UTC; windows"
+        "Built": "R 4.5.1; ; 2025-09-29 00:31:10 UTC; windows",
+        "RemoteType": "standard",
+        "RemoteRef": "crayon",
+        "RemotePkgRef": "crayon",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.5.3"
       }
     },
     "credentials": {
@@ -973,16 +965,9 @@
         "Packaged": "2025-09-12 08:56:54 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (ORCID: <https://orcid.org/0000-0002-4035-0289>)",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-09-12 09:30:08 UTC",
-        "Built": "R 4.5.2; ; 2025-12-30 02:47:11 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "credentials",
-        "RemotePkgRef": "credentials",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "2.0.3"
+        "Built": "R 4.5.0; ; 2025-09-13 04:48:40 UTC; windows"
       }
     },
     "crosstalk": {
@@ -1007,15 +992,9 @@
         "Packaged": "2025-08-26 22:06:47 UTC; cpsievert",
         "Author": "Joe Cheng [aut],\n  Carson Sievert [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-4958-2844>),\n  Posit Software, PBC [cph, fnd],\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/www/shared/jquery-AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Brian Reavis [ctb, cph] (selectize.js library),\n  Kristopher Michael Kowal [ctb, cph] (es5-shim library),\n  es5-shim contributors [ctb, cph] (es5-shim library),\n  Denis Ineshin [ctb, cph] (ion.rangeSlider library),\n  Sami Samhuri [ctb, cph] (Javascript strftime library)",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-08-26 23:50:02 UTC",
-        "Built": "R 4.5.1; ; 2025-09-02 09:27:58 UTC; windows",
-        "RemoteType": "standard",
-        "RemotePkgRef": "crosstalk",
-        "RemoteRef": "crosstalk",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "i386+x86_64-w64-mingw32",
-        "RemoteSha": "1.2.2"
+        "Built": "R 4.5.0; ; 2025-08-27 04:30:44 UTC; windows"
       }
     },
     "curl": {
@@ -1044,7 +1023,7 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-09-20 11:50:24 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-10-07 19:15:25 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-10-20 07:23:47 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1070,10 +1049,17 @@
         "Packaged": "2025-07-07 16:02:15 UTC; root",
         "Author": "Tyson Barrett [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-2137-1391>),\n  Matt Dowle [aut],\n  Arun Srinivasan [aut],\n  Jan Gorecki [aut],\n  Michael Chirico [aut] (ORCID: <https://orcid.org/0000-0003-0787-087X>),\n  Toby Hocking [aut] (ORCID: <https://orcid.org/0000-0002-3146-0865>),\n  Benjamin Schwendinger [aut] (ORCID:\n    <https://orcid.org/0000-0003-3315-8114>),\n  Ivan Krylov [aut] (ORCID: <https://orcid.org/0000-0002-0172-3812>),\n  Pasha Stetsenko [ctb],\n  Tom Short [ctb],\n  Steve Lianoglou [ctb],\n  Eduard Antonyan [ctb],\n  Markus Bonsch [ctb],\n  Hugh Parsonage [ctb],\n  Scott Ritchie [ctb],\n  Kun Ren [ctb],\n  Xianying Tan [ctb],\n  Rick Saporta [ctb],\n  Otto Seiskari [ctb],\n  Xianghui Dong [ctb],\n  Michel Lang [ctb],\n  Watal Iwasaki [ctb],\n  Seth Wenchel [ctb],\n  Karl Broman [ctb],\n  Tobias Schmidt [ctb],\n  David Arenburg [ctb],\n  Ethan Smith [ctb],\n  Francois Cocquemas [ctb],\n  Matthieu Gomez [ctb],\n  Philippe Chataignon [ctb],\n  Nello Blaser [ctb],\n  Dmitry Selivanov [ctb],\n  Andrey Riabushenko [ctb],\n  Cheng Lee [ctb],\n  Declan Groves [ctb],\n  Daniel Possenriede [ctb],\n  Felipe Parages [ctb],\n  Denes Toth [ctb],\n  Mus Yaramaz-David [ctb],\n  Ayappan Perumal [ctb],\n  James Sams [ctb],\n  Martin Morgan [ctb],\n  Michael Quinn [ctb],\n  @javrucebo [ctb],\n  @marc-outins [ctb],\n  Roy Storey [ctb],\n  Manish Saraswat [ctb],\n  Morgan Jacob [ctb],\n  Michael Schubmehl [ctb],\n  Davis Vaughan [ctb],\n  Leonardo Silvestri [ctb],\n  Jim Hester [ctb],\n  Anthony Damico [ctb],\n  Sebastian Freundt [ctb],\n  David Simons [ctb],\n  Elliott Sales de Andrade [ctb],\n  Cole Miller [ctb],\n  Jens Peder Meldgaard [ctb],\n  Vaclav Tlapak [ctb],\n  Kevin Ushey [ctb],\n  Dirk Eddelbuettel [ctb],\n  Tony Fischetti [ctb],\n  Ofek Shilon [ctb],\n  Vadim Khotilovich [ctb],\n  Hadley Wickham [ctb],\n  Bennet Becker [ctb],\n  Kyle Haynes [ctb],\n  Boniface Christian Kamgang [ctb],\n  Olivier Delmarcell [ctb],\n  Josh O'Brien [ctb],\n  Dereck de Mezquita [ctb],\n  Michael Czekanski [ctb],\n  Dmitry Shemetov [ctb],\n  Nitish Jha [ctb],\n  Joshua Wu [ctb],\n  Iago Giné-Vázquez [ctb],\n  Anirban Chetia [ctb],\n  Doris Amoakohene [ctb],\n  Angel Feliz [ctb],\n  Michael Young [ctb],\n  Mark Seeto [ctb],\n  Philippe Grosjean [ctb],\n  Vincent Runge [ctb],\n  Christian Wia [ctb],\n  Elise Maigné [ctb],\n  Vincent Rocher [ctb],\n  Vijay Lulla [ctb],\n  Aljaž Sluga [ctb],\n  Bill Evans [ctb]",
         "Maintainer": "Tyson Barrett <t.barrett88@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-07-10 10:30:05 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-07-11 04:26:25 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 00:31:30 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "data.table",
+        "RemotePkgRef": "data.table",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.17.8"
       }
     },
     "desc": {
@@ -1101,9 +1087,9 @@
         "NeedsCompilation": "no",
         "Packaged": "2023-12-10 11:07:50 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre],\n  Kirill Müller [aut],\n  Jim Hester [aut],\n  Maëlle Salmon [ctb] (<https://orcid.org/0000-0002-2815-0399>),\n  Posit Software, PBC [cph, fnd]",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-12-10 11:40:08 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 01:50:09 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:10:27 UTC; windows"
       }
     },
     "dfeR": {
@@ -1134,14 +1120,7 @@
         "Maintainer": "Cam Race <cameron.race@education.gov.uk>",
         "Repository": "RSPM",
         "Date/Publication": "2025-01-15 21:50:07 UTC",
-        "Built": "R 4.5.0; ; 2025-04-09 23:23:45 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "dfeR",
-        "RemotePkgRef": "dfeR",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.0.1"
+        "Built": "R 4.5.0; ; 2025-04-09 23:23:45 UTC; windows"
       }
     },
     "diffobj": {
@@ -1168,9 +1147,9 @@
         "Packaged": "2025-04-21 00:11:01 UTC; brodie",
         "Author": "Brodie Gaslam [aut, cre],\n  Michael B. Allen [ctb, cph] (Original C implementation of Myers Diff\n    Algorithm)",
         "Maintainer": "Brodie Gaslam <brodie.gaslam@yahoo.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-04-21 08:30:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 00:51:37 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-22 04:55:09 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -1226,7 +1205,12 @@
         "Repository": "RSPM",
         "Date/Publication": "2024-08-19 14:10:07 UTC",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:08:21 UTC; windows",
-        "Archs": "x64"
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "digest",
+        "RemoteRef": "digest",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.6.37"
       }
     },
     "dplyr": {
@@ -1255,14 +1239,14 @@
         "Packaged": "2023-11-16 21:48:56 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre] (<https://orcid.org/0000-0003-4757-117X>),\n  Romain François [aut] (<https://orcid.org/0000-0002-2444-4226>),\n  Lionel Henry [aut],\n  Kirill Müller [aut] (<https://orcid.org/0000-0002-1416-3412>),\n  Davis Vaughan [aut] (<https://orcid.org/0000-0003-4777-038X>),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2023-11-17 16:50:02 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:13:34 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 02:25:14 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "dplyr",
         "RemotePkgRef": "dplyr",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRef": "dplyr",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.1.4"
@@ -1293,14 +1277,7 @@
         "Maintainer": "Emil Hvitfeldt <emilhhvitfeldt@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-10-28 16:50:11 UTC",
-        "Built": "R 4.5.0; ; 2025-04-09 20:18:37 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "emoji",
-        "RemotePkgRef": "emoji",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "16.0.0"
+        "Built": "R 4.5.0; ; 2025-04-09 20:18:37 UTC; windows"
       }
     },
     "evaluate": {
@@ -1326,9 +1303,9 @@
         "Packaged": "2025-08-27 16:20:56 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Yihui Xie [aut] (ORCID: <https://orcid.org/0000-0003-0645-5666>),\n  Michael Lawrence [ctb],\n  Thomas Kluyver [ctb],\n  Jeroen Ooms [ctb],\n  Barret Schloerke [ctb],\n  Adam Ryczkowski [ctb],\n  Hiroaki Yutani [ctb],\n  Michel Lang [ctb],\n  Karolis Koncevičius [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-08-27 16:40:02 UTC",
-        "Built": "R 4.5.1; ; 2025-09-02 08:17:24 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-08-28 04:33:35 UTC; windows"
       }
     },
     "farver": {
@@ -1357,11 +1334,9 @@
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:09:15 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "farver",
         "RemotePkgRef": "farver",
+        "RemoteRef": "farver",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "2.1.2"
       }
     },
@@ -1387,7 +1362,12 @@
         "Repository": "RSPM",
         "Date/Publication": "2024-05-15 09:00:07 UTC",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:11:00 UTC; windows",
-        "Archs": "x64"
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "fastmap",
+        "RemoteRef": "fastmap",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.2.0"
       }
     },
     "fontawesome": {
@@ -1414,9 +1394,14 @@
         "Packaged": "2024-11-16 17:06:16 UTC; riannone",
         "Author": "Richard Iannone [aut, cre] (<https://orcid.org/0000-0003-3925-190X>),\n  Christophe Dervieux [ctb] (<https://orcid.org/0000-0003-4474-2498>),\n  Winston Chang [ctb],\n  Dave Gandy [ctb, cph] (Font-Awesome font),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Richard Iannone <rich@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-11-16 17:30:02 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 01:56:48 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:12:21 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "fontawesome",
+        "RemoteRef": "fontawesome",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.5.3"
       }
     },
     "fs": {
@@ -1447,10 +1432,15 @@
         "Packaged": "2025-04-12 09:39:13 UTC; gaborcsardi",
         "Author": "Jim Hester [aut],\n  Hadley Wickham [aut],\n  Gábor Csárdi [aut, cre],\n  libuv project contributors [cph] (libuv library),\n  Joyent, Inc. and other Node contributors [cph] (libuv library),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-04-12 10:40:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 00:51:12 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-14 16:36:37 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "fs",
+        "RemoteRef": "fs",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.6.6"
       }
     },
     "generics": {
@@ -1476,13 +1466,13 @@
         "Packaged": "2025-05-09 18:17:41 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre] (ORCID:\n    <https://orcid.org/0000-0003-4757-117X>),\n  Max Kuhn [aut],\n  Davis Vaughan [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-05-09 23:50:06 UTC",
-        "Built": "R 4.5.0; ; 2025-05-10 04:47:12 UTC; windows",
+        "Built": "R 4.5.1; ; 2025-09-29 00:31:03 UTC; windows",
         "RemoteType": "standard",
-        "RemoteRef": "generics",
         "RemotePkgRef": "generics",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRef": "generics",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.1.4"
@@ -1515,14 +1505,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2025-03-25 00:40:02 UTC",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-09 22:09:32 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "gert",
-        "RemotePkgRef": "gert",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "2.1.5"
+        "Archs": "x64"
       }
     },
     "ggplot2": {
@@ -1586,14 +1569,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-05-26 13:10:02 UTC",
-        "Built": "R 4.5.0; ; 2025-05-27 04:55:30 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "gh",
-        "RemotePkgRef": "gh",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.5.0"
+        "Built": "R 4.5.0; ; 2025-05-27 04:55:30 UTC; windows"
       }
     },
     "gitcreds": {
@@ -1622,14 +1598,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2022-09-08 10:42:55 UTC",
-        "Built": "R 4.5.0; ; 2025-04-09 18:33:41 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "gitcreds",
-        "RemotePkgRef": "gitcreds",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.1.2"
+        "Built": "R 4.5.0; ; 2025-04-09 18:33:41 UTC; windows"
       }
     },
     "globals": {
@@ -1657,14 +1626,7 @@
         "Maintainer": "Henrik Bengtsson <henrikb@braju.com>",
         "Repository": "RSPM",
         "Date/Publication": "2025-05-08 09:00:03 UTC",
-        "Built": "R 4.5.0; ; 2025-05-09 04:55:18 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "globals",
-        "RemotePkgRef": "globals",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.18.0"
+        "Built": "R 4.5.0; ; 2025-05-09 04:55:18 UTC; windows"
       }
     },
     "glue": {
@@ -1694,8 +1656,15 @@
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-09-30 22:30:01 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 00:51:10 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 00:31:01 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "glue",
+        "RemoteRef": "glue",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.8.0"
       }
     },
     "gtable": {
@@ -1727,11 +1696,9 @@
         "Date/Publication": "2024-10-25 13:20:02 UTC",
         "Built": "R 4.5.0; ; 2025-04-06 06:09:54 UTC; windows",
         "RemoteType": "standard",
-        "RemoteRef": "gtable",
         "RemotePkgRef": "gtable",
+        "RemoteRef": "gtable",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.3.6"
       }
     },
@@ -1758,9 +1725,9 @@
         "Packaged": "2024-05-26 19:27:21 UTC; yihui",
         "Author": "Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>),\n  Yixuan Qiu [aut],\n  Christopher Gandrud [ctb],\n  Qiang Li [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-05-26 20:00:03 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 01:50:05 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:10:05 UTC; windows"
       }
     },
     "hms": {
@@ -1788,13 +1755,13 @@
         "Packaged": "2023-03-21 16:52:11 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (<https://orcid.org/0000-0002-1416-3412>),\n  R Consortium [fnd],\n  RStudio [fnd]",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2023-03-21 18:10:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-06 06:11:40 UTC; windows",
+        "Built": "R 4.5.1; ; 2025-09-29 01:49:28 UTC; windows",
         "RemoteType": "standard",
-        "RemoteRef": "hms",
         "RemotePkgRef": "hms",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRef": "hms",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.1.3"
@@ -1829,7 +1796,12 @@
         "Repository": "RSPM",
         "Date/Publication": "2024-04-04 05:03:00 UTC",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:11:38 UTC; windows",
-        "Archs": "x64"
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "htmltools",
+        "RemoteRef": "htmltools",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.5.8.1"
       }
     },
     "htmlwidgets": {
@@ -1855,9 +1827,9 @@
         "Packaged": "2023-12-06 00:11:16 UTC; cpsievert",
         "Author": "Ramnath Vaidyanathan [aut, cph],\n  Yihui Xie [aut],\n  JJ Allaire [aut],\n  Joe Cheng [aut],\n  Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Kenton Russell [aut, cph],\n  Ellis Hughes [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Carson Sievert <carson@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-12-06 06:00:06 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 02:32:09 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:21:45 UTC; windows"
       }
     },
     "httpuv": {
@@ -1885,10 +1857,15 @@
         "Packaged": "2025-04-15 17:47:41 UTC; cg334",
         "Author": "Joe Cheng [aut],\n  Winston Chang [aut, cre],\n  Posit, PBC fnd [cph],\n  Hector Corrada Bravo [ctb],\n  Jeroen Ooms [ctb],\n  Andrzej Krzemienski [cph] (optional.hpp),\n  libuv project contributors [cph] (libuv library, see src/libuv/AUTHORS\n    file),\n  Joyent, Inc. and other Node contributors [cph] (libuv library, see\n    src/libuv/AUTHORS file; and http-parser library, see\n    src/http-parser/AUTHORS file),\n  Niels Provos [cph] (libuv subcomponent: tree.h),\n  Internet Systems Consortium, Inc. [cph] (libuv subcomponent: inet_pton\n    and inet_ntop, contained in src/libuv/src/inet.c),\n  Alexander Chemeris [cph] (libuv subcomponent: stdint-msvc2008.h (from\n    msinttypes)),\n  Google, Inc. [cph] (libuv subcomponent: pthread-fixes.c),\n  Sony Mobile Communcations AB [cph] (libuv subcomponent:\n    pthread-fixes.c),\n  Berkeley Software Design Inc. [cph] (libuv subcomponent:\n    android-ifaddrs.h, android-ifaddrs.c),\n  Kenneth MacKay [cph] (libuv subcomponent: android-ifaddrs.h,\n    android-ifaddrs.c),\n  Emergya (Cloud4all, FP7/2007-2013, grant agreement no 289016) [cph]\n    (libuv subcomponent: android-ifaddrs.h, android-ifaddrs.c),\n  Steve Reid [aut] (SHA-1 implementation),\n  James Brown [aut] (SHA-1 implementation),\n  Bob Trower [aut] (base64 implementation),\n  Alexander Peslyak [aut] (MD5 implementation),\n  Trantor Standard Systems [cph] (base64 implementation),\n  Igor Sysoev [cph] (http-parser)",
         "Maintainer": "Winston Chang <winston@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-04-16 08:00:06 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 02:06:53 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-08-28 04:46:07 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "httpuv",
+        "RemoteRef": "httpuv",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.6.16"
       }
     },
     "httr": {
@@ -1914,13 +1891,13 @@
         "Packaged": "2023-08-15 02:56:56 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Posit, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2023-08-15 09:00:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-06 06:11:28 UTC; windows",
+        "Built": "R 4.5.1; ; 2025-09-29 01:49:28 UTC; windows",
         "RemoteType": "standard",
         "RemoteRef": "httr",
         "RemotePkgRef": "httr",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.4.7"
@@ -1954,7 +1931,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2024-11-04 16:30:02 UTC",
-        "Built": "R 4.5.1; ; 2025-10-07 19:18:18 UTC; windows"
+        "Built": "R 4.5.1; ; 2025-10-20 07:25:36 UTC; windows"
       }
     },
     "ini": {
@@ -1980,14 +1957,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2018-05-20 03:26:39 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.5.0; ; 2025-04-09 18:36:39 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "ini",
-        "RemotePkgRef": "ini",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.3.1"
+        "Built": "R 4.5.0; ; 2025-04-09 18:36:39 UTC; windows"
       }
     },
     "isoband": {
@@ -2019,11 +1989,9 @@
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:08:50 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "isoband",
         "RemotePkgRef": "isoband",
+        "RemoteRef": "isoband",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.2.7"
       }
     },
@@ -2103,9 +2071,14 @@
         "Packaged": "2021-04-26 16:40:21 UTC; cpsievert",
         "Author": "Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Joe Cheng [aut],\n  RStudio [cph],\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/lib/jquery-AUTHORS.txt)",
         "Maintainer": "Carson Sievert <carson@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2021-04-26 17:10:02 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 01:56:48 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:12:19 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "jquerylib",
+        "RemoteRef": "jquerylib",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.1.4"
       }
     },
     "jsonlite": {
@@ -2131,8 +2104,15 @@
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Duncan Temple Lang [ctb],\n  Lloyd Hilaiel [cph] (author of bundled libyajl)",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-27 06:40:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 00:51:10 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 00:31:02 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "jsonlite",
+        "RemotePkgRef": "jsonlite",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "2.0.0"
       }
     },
     "knitr": {
@@ -2160,9 +2140,9 @@
         "Packaged": "2025-03-15 00:17:19 UTC; runner",
         "Author": "Yihui Xie [aut, cre] (<https://orcid.org/0000-0003-0645-5666>,\n    https://yihui.org),\n  Abhraneel Sarma [ctb],\n  Adam Vogt [ctb],\n  Alastair Andrew [ctb],\n  Alex Zvoleff [ctb],\n  Amar Al-Zubaidi [ctb],\n  Andre Simon [ctb] (the CSS files under inst/themes/ were derived from\n    the Highlight package http://www.andre-simon.de),\n  Aron Atkins [ctb],\n  Aaron Wolen [ctb],\n  Ashley Manton [ctb],\n  Atsushi Yasumoto [ctb] (<https://orcid.org/0000-0002-8335-495X>),\n  Ben Baumer [ctb],\n  Brian Diggs [ctb],\n  Brian Zhang [ctb],\n  Bulat Yapparov [ctb],\n  Cassio Pereira [ctb],\n  Christophe Dervieux [ctb],\n  David Hall [ctb],\n  David Hugh-Jones [ctb],\n  David Robinson [ctb],\n  Doug Hemken [ctb],\n  Duncan Murdoch [ctb],\n  Elio Campitelli [ctb],\n  Ellis Hughes [ctb],\n  Emily Riederer [ctb],\n  Fabian Hirschmann [ctb],\n  Fitch Simeon [ctb],\n  Forest Fang [ctb],\n  Frank E Harrell Jr [ctb] (the Sweavel package at inst/misc/Sweavel.sty),\n  Garrick Aden-Buie [ctb],\n  Gregoire Detrez [ctb],\n  Hadley Wickham [ctb],\n  Hao Zhu [ctb],\n  Heewon Jeon [ctb],\n  Henrik Bengtsson [ctb],\n  Hiroaki Yutani [ctb],\n  Ian Lyttle [ctb],\n  Hodges Daniel [ctb],\n  Jacob Bien [ctb],\n  Jake Burkhead [ctb],\n  James Manton [ctb],\n  Jared Lander [ctb],\n  Jason Punyon [ctb],\n  Javier Luraschi [ctb],\n  Jeff Arnold [ctb],\n  Jenny Bryan [ctb],\n  Jeremy Ashkenas [ctb, cph] (the CSS file at\n    inst/misc/docco-classic.css),\n  Jeremy Stephens [ctb],\n  Jim Hester [ctb],\n  Joe Cheng [ctb],\n  Johannes Ranke [ctb],\n  John Honaker [ctb],\n  John Muschelli [ctb],\n  Jonathan Keane [ctb],\n  JJ Allaire [ctb],\n  Johan Toloe [ctb],\n  Jonathan Sidi [ctb],\n  Joseph Larmarange [ctb],\n  Julien Barnier [ctb],\n  Kaiyin Zhong [ctb],\n  Kamil Slowikowski [ctb],\n  Karl Forner [ctb],\n  Kevin K. Smith [ctb],\n  Kirill Mueller [ctb],\n  Kohske Takahashi [ctb],\n  Lorenz Walthert [ctb],\n  Lucas Gallindo [ctb],\n  Marius Hofert [ctb],\n  Martin Modrák [ctb],\n  Michael Chirico [ctb],\n  Michael Friendly [ctb],\n  Michal Bojanowski [ctb],\n  Michel Kuhlmann [ctb],\n  Miller Patrick [ctb],\n  Nacho Caballero [ctb],\n  Nick Salkowski [ctb],\n  Niels Richard Hansen [ctb],\n  Noam Ross [ctb],\n  Obada Mahdi [ctb],\n  Pavel N. Krivitsky [ctb] (<https://orcid.org/0000-0002-9101-3362>),\n  Pedro Faria [ctb],\n  Qiang Li [ctb],\n  Ramnath Vaidyanathan [ctb],\n  Richard Cotton [ctb],\n  Robert Krzyzanowski [ctb],\n  Rodrigo Copetti [ctb],\n  Romain Francois [ctb],\n  Ruaridh Williamson [ctb],\n  Sagiru Mati [ctb] (<https://orcid.org/0000-0003-1413-3974>),\n  Scott Kostyshak [ctb],\n  Sebastian Meyer [ctb],\n  Sietse Brouwer [ctb],\n  Simon de Bernard [ctb],\n  Sylvain Rousseau [ctb],\n  Taiyun Wei [ctb],\n  Thibaut Assus [ctb],\n  Thibaut Lamadon [ctb],\n  Thomas Leeper [ctb],\n  Tim Mastny [ctb],\n  Tom Torsney-Weir [ctb],\n  Trevor Davis [ctb],\n  Viktoras Veitas [ctb],\n  Weicheng Zhu [ctb],\n  Wush Wu [ctb],\n  Zachary Foster [ctb],\n  Zhian N. Kamvar [ctb] (<https://orcid.org/0000-0003-1458-7108>),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-03-16 09:20:02 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 01:56:49 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:10:43 UTC; windows"
       }
     },
     "labeling": {
@@ -2187,11 +2167,9 @@
         "Encoding": "UTF-8",
         "Built": "R 4.5.0; ; 2025-04-06 06:08:56 UTC; windows",
         "RemoteType": "standard",
-        "RemoteRef": "labeling",
         "RemotePkgRef": "labeling",
+        "RemoteRef": "labeling",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.4.3"
       }
     },
@@ -2221,10 +2199,15 @@
         "Packaged": "2025-08-27 07:27:24 UTC; cg334",
         "Author": "Winston Chang [aut],\n  Joe Cheng [aut],\n  Charlie Gao [aut, cre] (ORCID: <https://orcid.org/0000-0002-0750-061X>),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  Marcus Geelnard [ctb, cph] (TinyCThread library,\n    https://tinycthread.github.io/),\n  Evan Nemerson [ctb, cph] (TinyCThread library,\n    https://tinycthread.github.io/)",
         "Maintainer": "Charlie Gao <charlie.gao@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-08-27 08:40:03 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-02 09:14:01 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-08-28 04:44:23 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "later",
+        "RemoteRef": "later",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.4.4"
       }
     },
     "lazyeval": {
@@ -2250,14 +2233,7 @@
         "Date/Publication": "2019-03-15 17:50:07 UTC",
         "Encoding": "UTF-8",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:06:22 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "lazyeval",
-        "RemotePkgRef": "lazyeval",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.2.2"
+        "Archs": "x64"
       }
     },
     "lifecycle": {
@@ -2286,7 +2262,14 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2023-11-07 10:10:10 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 01:50:06 UTC; windows"
+        "Built": "R 4.5.1; ; 2025-09-29 01:15:49 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "lifecycle",
+        "RemoteRef": "lifecycle",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.0.4"
       }
     },
     "lubridate": {
@@ -2321,14 +2304,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2024-12-08 12:10:02 UTC",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:13:43 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "lubridate",
-        "RemotePkgRef": "lubridate",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.9.4"
+        "Archs": "x64"
       }
     },
     "magrittr": {
@@ -2362,7 +2338,8 @@
         "RemoteType": "standard",
         "RemotePkgRef": "magrittr",
         "RemoteRef": "magrittr",
-        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "2.0.4"
       }
@@ -2387,9 +2364,14 @@
         "Packaged": "2021-11-24 21:24:50 UTC; jhester",
         "Author": "Hadley Wickham [aut],\n  Jim Hester [aut],\n  Winston Chang [aut, cre],\n  Kirill Müller [aut],\n  Daniel Cook [aut],\n  Mark Edmondson [ctb]",
         "Maintainer": "Winston Chang <winston@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2021-11-26 16:11:10 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 01:56:48 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:12:12 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "memoise",
+        "RemoteRef": "memoise",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.0.1"
       }
     },
     "mime": {
@@ -2415,7 +2397,14 @@
         "Repository": "CRAN",
         "Date/Publication": "2025-03-17 20:20:02 UTC",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-08 00:42:20 UTC; windows",
-        "Archs": "x64"
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "mime",
+        "RemotePkgRef": "mime",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.13"
       }
     },
     "openssl": {
@@ -2443,7 +2432,7 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-09-20 08:40:05 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-10-07 19:17:07 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-10-20 07:24:49 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2509,8 +2498,9 @@
         "RemoteType": "standard",
         "RemotePkgRef": "pillar",
         "RemoteRef": "pillar",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "i386+x86_64-w64-mingw32",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.11.1"
       }
     },
@@ -2541,14 +2531,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2024-12-12 10:10:02 UTC",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-09 19:13:33 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "pingr",
-        "RemotePkgRef": "pingr",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "2.0.5"
+        "Archs": "x64"
       }
     },
     "pkgbuild": {
@@ -2575,9 +2558,9 @@
         "Packaged": "2025-05-26 10:36:48 UTC; gaborcsardi",
         "Author": "Hadley Wickham [aut],\n  Jim Hester [aut],\n  Gábor Csárdi [aut, cre],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-05-26 14:10:06 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 02:06:56 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-05-27 04:56:10 UTC; windows"
       }
     },
     "pkgconfig": {
@@ -2599,13 +2582,13 @@
         "Encoding": "UTF-8",
         "NeedsCompilation": "no",
         "Packaged": "2019-09-22 08:42:40 UTC; gaborcsardi",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2019-09-22 09:20:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-06 06:05:36 UTC; windows",
+        "Built": "R 4.5.1; ; 2025-09-29 00:31:02 UTC; windows",
         "RemoteType": "standard",
-        "RemoteRef": "pkgconfig",
         "RemotePkgRef": "pkgconfig",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRef": "pkgconfig",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "2.0.3"
@@ -2636,9 +2619,9 @@
         "Packaged": "2025-09-23 09:15:44 UTC; lionel",
         "Author": "Hadley Wickham [aut],\n  Winston Chang [aut],\n  Jim Hester [aut],\n  Lionel Henry [aut, cre],\n  Posit Software, PBC [cph, fnd],\n  R Core team [ctb] (Some namespace and vignette code extracted from base\n    R)",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-09-23 10:20:02 UTC",
-        "Built": "R 4.5.2; ; 2026-01-23 03:26:41 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-09-24 04:27:32 UTC; windows"
       }
     },
     "praise": {
@@ -2659,9 +2642,10 @@
         "Collate": "'adjective.R' 'adverb.R' 'exclamation.R' 'verb.R' 'rpackage.R'\n'package.R'",
         "NeedsCompilation": "no",
         "Packaged": "2015-08-11 02:01:43 UTC; gaborcsardi",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2015-08-11 08:22:28",
-        "Built": "R 4.5.1; ; 2025-07-04 00:51:35 UTC; windows"
+        "Encoding": "UTF-8",
+        "Built": "R 4.5.0; ; 2025-04-06 06:06:18 UTC; windows"
       }
     },
     "prettyunits": {
@@ -2684,13 +2668,13 @@
         "Packaged": "2023-09-24 10:53:19 UTC; gaborcsardi",
         "Author": "Gabor Csardi [aut, cre],\n  Bill Denney [ctb] (<https://orcid.org/0000-0002-5759-428X>),\n  Christophe Regouby [ctb]",
         "Maintainer": "Gabor Csardi <csardi.gabor@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2023-09-24 21:10:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-06 06:08:16 UTC; windows",
+        "Built": "R 4.5.1; ; 2025-09-29 00:31:28 UTC; windows",
         "RemoteType": "standard",
         "RemoteRef": "prettyunits",
         "RemotePkgRef": "prettyunits",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.2.0"
@@ -2719,9 +2703,9 @@
         "Packaged": "2025-02-19 21:20:47 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre, cph] (<https://orcid.org/0000-0001-7098-9676>),\n  Winston Chang [aut],\n  Posit Software, PBC [cph, fnd],\n  Ascent Digital Services [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-02-21 17:00:01 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 01:50:09 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:10:25 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2748,13 +2732,13 @@
         "Packaged": "2023-12-05 09:33:10 UTC; gaborcsardi",
         "Author": "Gábor Csárdi [aut, cre],\n  Rich FitzJohn [aut],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2023-12-06 10:30:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-06 06:12:20 UTC; windows",
+        "Built": "R 4.5.1; ; 2025-09-29 02:08:58 UTC; windows",
         "RemoteType": "standard",
         "RemoteRef": "progress",
         "RemotePkgRef": "progress",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.2.3"
@@ -2787,10 +2771,15 @@
         "Packaged": "2025-05-29 15:29:40 UTC; barret",
         "Author": "Joe Cheng [aut, cre],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Joe Cheng <joe@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-05-29 16:30:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 01:56:48 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-08-28 04:45:29 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "promises",
+        "RemoteRef": "promises",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.3.3"
       }
     },
     "ps": {
@@ -2817,9 +2806,9 @@
         "Packaged": "2025-04-12 09:23:06 UTC; gaborcsardi",
         "Author": "Jay Loden [aut],\n  Dave Daeschler [aut],\n  Giampaolo Rodola' [aut],\n  Gábor Csárdi [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-04-12 09:50:01 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 00:51:41 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-14 17:09:13 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -2853,8 +2842,15 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-07-10 17:50:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-14 01:49:28 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 01:49:23 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "purrr",
+        "RemoteRef": "purrr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.1.0"
       }
     },
     "rappdirs": {
@@ -2882,8 +2878,15 @@
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
         "Repository": "CRAN",
         "Date/Publication": "2021-01-31 05:40:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 00:51:09 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 00:31:02 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "rappdirs",
+        "RemotePkgRef": "rappdirs",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.3.3"
       }
     },
     "readr": {
@@ -2913,14 +2916,14 @@
         "Packaged": "2024-01-10 21:03:49 UTC; jenny",
         "Author": "Hadley Wickham [aut],\n  Jim Hester [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [aut, cre] (<https://orcid.org/0000-0002-6983-2759>),\n  Shelby Bearrows [ctb],\n  Posit Software, PBC [cph, fnd],\n  https://github.com/mandreyel/ [cph] (mio library),\n  Jukka Jylänki [ctb, cph] (grisu3 implementation),\n  Mikkel Jørgensen [ctb, cph] (grisu3 implementation)",
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-01-10 23:20:02 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:16:59 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 02:40:03 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemoteRef": "readr",
         "RemotePkgRef": "readr",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "2.1.5"
@@ -2954,7 +2957,7 @@
         "Maintainer": "Kevin Ushey <kevin@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-10-12 07:30:02 UTC",
-        "Built": "R 4.5.1; ; 2025-08-22 16:56:37 UTC; windows"
+        "Built": "R 4.5.2; ; 2026-02-23 11:33:42 UTC; windows"
       }
     },
     "rlang": {
@@ -2984,14 +2987,14 @@
         "Packaged": "2025-04-10 09:25:27 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut],\n  mikefc [cph] (Hash implementation based on Mike's xxhashlite),\n  Yann Collet [cph] (Author of the embedded xxHash library),\n  Posit, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-04-11 08:40:10 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-14 17:10:39 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 00:31:01 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "rlang",
         "RemotePkgRef": "rlang",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRef": "rlang",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.1.6"
@@ -3053,16 +3056,9 @@
         "Packaged": "2025-08-26 15:22:42 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1416-3412>)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-08-26 16:20:02 UTC",
-        "Built": "R 4.5.1; ; 2025-09-02 08:17:24 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "rprojroot",
-        "RemotePkgRef": "rprojroot",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "2.1.1"
+        "Built": "R 4.5.0; ; 2025-08-27 04:33:41 UTC; windows"
       }
     },
     "rsconnect": {
@@ -3116,9 +3112,9 @@
         "NeedsCompilation": "no",
         "Packaged": "2024-10-22 20:55:52 UTC; kevin",
         "Author": "Kevin Ushey [aut, cre],\n  JJ Allaire [aut],\n  Hadley Wickham [aut],\n  Gary Ritchie [aut],\n  RStudio [cph]",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-10-22 22:40:02 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 00:51:10 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:09:20 UTC; windows"
       }
     },
     "sass": {
@@ -3145,10 +3141,15 @@
         "Packaged": "2025-04-11 18:34:19 UTC; cpsievert",
         "Author": "Joe Cheng [aut],\n  Timothy Mastny [aut],\n  Richard Iannone [aut] (<https://orcid.org/0000-0003-3925-190X>),\n  Barret Schloerke [aut] (<https://orcid.org/0000-0001-9986-114X>),\n  Carson Sievert [aut, cre] (<https://orcid.org/0000-0002-4958-2844>),\n  Christophe Dervieux [ctb] (<https://orcid.org/0000-0003-4474-2498>),\n  RStudio [cph, fnd],\n  Sass Open Source Foundation [ctb, cph] (LibSass library),\n  Greter Marcel [ctb, cph] (LibSass library),\n  Mifsud Michael [ctb, cph] (LibSass library),\n  Hampton Catlin [ctb, cph] (LibSass library),\n  Natalie Weizenbaum [ctb, cph] (LibSass library),\n  Chris Eppstein [ctb, cph] (LibSass library),\n  Adams Joseph [ctb, cph] (json.cpp),\n  Trifunovic Nemanja [ctb, cph] (utf8.h)",
         "Maintainer": "Carson Sievert <carson@rstudio.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-04-11 19:50:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 01:56:48 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-14 17:13:04 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "sass",
+        "RemoteRef": "sass",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.4.10"
       }
     },
     "scales": {
@@ -3180,11 +3181,9 @@
         "Date/Publication": "2025-04-24 11:00:02 UTC",
         "Built": "R 4.5.0; ; 2025-04-25 04:55:10 UTC; windows",
         "RemoteType": "standard",
-        "RemoteRef": "scales",
         "RemotePkgRef": "scales",
+        "RemoteRef": "scales",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.4.0"
       }
     },
@@ -3213,9 +3212,14 @@
         "Packaged": "2025-07-03 01:15:18 UTC; cpsievert",
         "Author": "Winston Chang [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1576-2126>),\n  Joe Cheng [aut],\n  JJ Allaire [aut],\n  Carson Sievert [aut] (ORCID: <https://orcid.org/0000-0002-4958-2844>),\n  Barret Schloerke [aut] (ORCID: <https://orcid.org/0000-0001-9986-114X>),\n  Yihui Xie [aut],\n  Jeff Allen [aut],\n  Jonathan McPherson [aut],\n  Alan Dipert [aut],\n  Barbara Borges [aut],\n  Posit Software, PBC [cph, fnd],\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/www/shared/jquery-AUTHORS.txt),\n  jQuery UI contributors [ctb, cph] (jQuery UI library; authors listed in\n    inst/www/shared/jqueryui/AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Prem Nawaz Khan [ctb] (Bootstrap accessibility plugin),\n  Victor Tsaran [ctb] (Bootstrap accessibility plugin),\n  Dennis Lembree [ctb] (Bootstrap accessibility plugin),\n  Srinivasu Chakravarthula [ctb] (Bootstrap accessibility plugin),\n  Cathy O'Connor [ctb] (Bootstrap accessibility plugin),\n  PayPal, Inc [cph] (Bootstrap accessibility plugin),\n  Stefan Petre [ctb, cph] (Bootstrap-datepicker library),\n  Andrew Rowls [ctb, cph] (Bootstrap-datepicker library),\n  Brian Reavis [ctb, cph] (selectize.js library),\n  Salmen Bejaoui [ctb, cph] (selectize-plugin-a11y library),\n  Denis Ineshin [ctb, cph] (ion.rangeSlider library),\n  Sami Samhuri [ctb, cph] (Javascript strftime library),\n  SpryMedia Limited [ctb, cph] (DataTables library),\n  John Fraser [ctb, cph] (showdown.js library),\n  John Gruber [ctb, cph] (showdown.js library),\n  Ivan Sagalaev [ctb, cph] (highlight.js library),\n  R Core Team [ctb, cph] (tar implementation from R)",
         "Maintainer": "Winston Chang <winston@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-07-03 06:20:02 UTC",
-        "Built": "R 4.5.1; ; 2025-07-03 23:52:24 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-07-04 04:30:30 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "shiny",
+        "RemoteRef": "shiny",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.11.1"
       }
     },
     "shinyFeedback": {
@@ -3297,14 +3301,7 @@
         "Maintainer": "Dean Attali <daattali@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-04-27 23:10:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-09 20:45:41 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "shinyalert",
-        "RemotePkgRef": "shinyalert",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "3.1.0"
+        "Built": "R 4.5.0; ; 2025-04-09 20:45:41 UTC; windows"
       }
     },
     "shinycssloaders": {
@@ -3330,14 +3327,7 @@
         "Maintainer": "Dean Attali <daattali@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-07-30 22:30:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-08 03:32:06 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "shinycssloaders",
-        "RemotePkgRef": "shinycssloaders",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.1.0"
+        "Built": "R 4.5.0; ; 2025-04-08 03:32:06 UTC; windows"
       }
     },
     "shinydisconnect": {
@@ -3388,9 +3378,9 @@
         "Packaged": "2021-12-21 11:32:22 UTC; Dean-X1C",
         "Author": "Dean Attali [aut, cre] (<https://orcid.org/0000-0002-5645-3493>)",
         "Maintainer": "Dean Attali <daattali@gmail.com>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2021-12-23 10:10:02 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 02:17:29 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-06 06:22:54 UTC; windows"
       }
     },
     "shinytest2": {
@@ -3424,14 +3414,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2025-04-11 22:20:02 UTC",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-14 17:46:02 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "shinytest2",
-        "RemotePkgRef": "shinytest2",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.4.1"
+        "Archs": "x64"
       }
     },
     "snakecase": {
@@ -3507,10 +3490,15 @@
         "Encoding": "UTF-8",
         "NeedsCompilation": "yes",
         "Packaged": "2023-01-31 18:03:04 UTC; kevin",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2023-02-01 10:10:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 00:51:10 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:07:36 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "sourcetools",
+        "RemoteRef": "sourcetools",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.1.7-1"
       }
     },
     "sparkline": {
@@ -3567,7 +3555,14 @@
         "Repository": "CRAN",
         "Date/Publication": "2025-03-27 13:10:02 UTC",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-08 00:42:32 UTC; windows",
-        "Archs": "x64"
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "stringi",
+        "RemoteRef": "stringi",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.8.7"
       }
     },
     "stringr": {
@@ -3597,7 +3592,14 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-09-08 12:00:02 UTC",
-        "Built": "R 4.5.1; ; 2025-09-08 22:26:12 UTC; windows"
+        "Built": "R 4.5.1; ; 2025-09-29 01:49:22 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "stringr",
+        "RemoteRef": "stringr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.5.2"
       }
     },
     "styler": {
@@ -3628,14 +3630,7 @@
         "Maintainer": "Lorenz Walthert <lorenz.walthert@icloud.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-04-07 23:00:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-09 20:06:27 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "styler",
-        "RemotePkgRef": "styler",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.10.3"
+        "Built": "R 4.5.1; ; 2025-10-20 07:26:41 UTC; windows"
       }
     },
     "sys": {
@@ -3659,14 +3654,14 @@
         "Packaged": "2024-10-03 14:13:17 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Gábor Csárdi [ctb]",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-10-04 09:40:02 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:08:07 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 00:31:12 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemoteRef": "sys",
         "RemotePkgRef": "sys",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "3.4.3"
@@ -3698,9 +3693,9 @@
         "Packaged": "2025-01-11 00:11:30 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Posit Software, PBC [cph, fnd],\n  R Core team [ctb] (Implementation of utils::recover())",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-01-13 11:20:03 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 02:32:10 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:14:31 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -3733,14 +3728,14 @@
         "Packaged": "2025-06-07 08:54:33 UTC; kirill",
         "Author": "Kirill Müller [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-1416-3412>),\n  Hadley Wickham [aut],\n  Romain Francois [ctb],\n  Jennifer Bryan [ctb],\n  RStudio [cph, fnd]",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-06-08 12:10:02 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-06-09 04:29:20 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 02:08:53 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "tibble",
         "RemotePkgRef": "tibble",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRef": "tibble",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "3.3.0"
@@ -3774,12 +3769,13 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-01-24 14:50:09 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-16 02:35:20 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 02:40:01 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemotePkgRef": "tidyr",
         "RemoteRef": "tidyr",
-        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.3.1"
       }
@@ -3809,13 +3805,13 @@
         "Packaged": "2024-03-11 11:46:04 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2024-03-11 14:10:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-06 06:11:39 UTC; windows",
+        "Built": "R 4.5.1; ; 2025-09-29 01:49:21 UTC; windows",
         "RemoteType": "standard",
-        "RemoteRef": "tidyselect",
         "RemotePkgRef": "tidyselect",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRef": "tidyselect",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.2.1"
@@ -3846,14 +3842,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2024-01-18 09:20:02 UTC",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:12:39 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "timechange",
-        "RemotePkgRef": "timechange",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.3.0"
+        "Archs": "x64"
       }
     },
     "tinytex": {
@@ -3877,9 +3866,9 @@
         "Packaged": "2025-04-15 14:48:13 UTC; yihui",
         "Author": "Yihui Xie [aut, cre, cph] (<https://orcid.org/0000-0003-0645-5666>),\n  Posit Software, PBC [cph, fnd],\n  Christophe Dervieux [ctb] (<https://orcid.org/0000-0003-4474-2498>),\n  Devon Ryan [ctb] (<https://orcid.org/0000-0002-8549-0971>),\n  Ethan Heinzen [ctb],\n  Fernando Cagua [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-04-15 15:50:03 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 01:50:08 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-04-16 04:45:04 UTC; windows"
       }
     },
     "tzdb": {
@@ -3906,14 +3895,14 @@
         "Packaged": "2025-03-14 18:41:13 UTC; davis",
         "Author": "Davis Vaughan [aut, cre],\n  Howard Hinnant [cph] (Author of the included date library),\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Davis Vaughan <davis@posit.co>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-03-15 22:50:02 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:12:38 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 00:31:30 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
         "RemoteRef": "tzdb",
         "RemotePkgRef": "tzdb",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.5.0"
@@ -3946,16 +3935,9 @@
         "Packaged": "2025-09-05 20:27:33 UTC; jenny",
         "Author": "Hadley Wickham [aut] (ORCID: <https://orcid.org/0000-0003-4757-117X>),\n  Jennifer Bryan [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-6983-2759>),\n  Malcolm Barrett [aut] (ORCID: <https://orcid.org/0000-0003-0299-5825>),\n  Andy Teucher [aut] (ORCID: <https://orcid.org/0000-0002-7840-692X>),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-09-06 05:10:02 UTC",
-        "Built": "R 4.5.2; ; 2025-12-30 03:20:11 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "usethis",
-        "RemotePkgRef": "usethis",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "3.2.1"
+        "Built": "R 4.5.0; ; 2025-09-07 04:23:26 UTC; windows"
       }
     },
     "utf8": {
@@ -3980,14 +3962,14 @@
         "Packaged": "2025-06-08 18:28:11 UTC; kirill",
         "Author": "Patrick O. Perry [aut, cph],\n  Kirill Müller [cre] (ORCID: <https://orcid.org/0000-0002-1416-3412>),\n  Unicode, Inc. [cph, dtc] (Unicode Character Database)",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
-        "Repository": "RSPM",
+        "Repository": "CRAN",
         "Date/Publication": "2025-06-08 19:00:02 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-06-09 04:28:43 UTC; windows",
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 00:31:02 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemoteRef": "utf8",
         "RemotePkgRef": "utf8",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
+        "RemoteRef": "utf8",
+        "RemoteRepos": "https://cran.rstudio.com",
         "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.2.6"
@@ -4014,14 +3996,7 @@
         "Date/Publication": "2024-07-29 07:09:22 UTC",
         "Encoding": "UTF-8",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:08:06 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "uuid",
-        "RemotePkgRef": "uuid",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.2-1"
+        "Archs": "x64"
       }
     },
     "vctrs": {
@@ -4051,8 +4026,15 @@
         "Maintainer": "Davis Vaughan <davis@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2023-12-01 23:50:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-07-04 01:56:47 UTC; windows",
-        "Archs": "x64"
+        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 01:30:57 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "vctrs",
+        "RemoteRef": "vctrs",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "0.6.5"
       }
     },
     "viridisLite": {
@@ -4081,11 +4063,9 @@
         "Date/Publication": "2023-05-02 23:50:02 UTC",
         "Built": "R 4.5.0; ; 2025-04-06 06:09:19 UTC; windows",
         "RemoteType": "standard",
-        "RemoteRef": "viridisLite",
         "RemotePkgRef": "viridisLite",
+        "RemoteRef": "viridisLite",
         "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "0.4.2"
       }
     },
@@ -4122,9 +4102,10 @@
         "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-29 02:25:23 UTC; windows",
         "Archs": "x64",
         "RemoteType": "standard",
-        "RemotePkgRef": "vroom",
         "RemoteRef": "vroom",
-        "RemoteRepos": "https://cran.rstudio.com/",
+        "RemotePkgRef": "vroom",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
         "RemotePkgPlatform": "x86_64-w64-mingw32",
         "RemoteSha": "1.6.6"
       }
@@ -4152,9 +4133,9 @@
         "Packaged": "2025-07-11 13:27:03 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-07-11 15:20:02 UTC",
-        "Built": "R 4.5.2; ; 2026-01-23 02:47:45 UTC; windows"
+        "Built": "R 4.5.0; ; 2025-07-12 04:29:16 UTC; windows"
       }
     },
     "websocket": {
@@ -4182,15 +4163,8 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2025-04-10 09:00:02 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-07-03 06:11:07 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "websocket",
-        "RemotePkgRef": "websocket",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "1.4.4"
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-08-28 04:45:29 UTC; windows",
+        "Archs": "x64"
       }
     },
     "whisker": {
@@ -4214,14 +4188,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2022-12-05 15:33:50 UTC",
         "Encoding": "UTF-8",
-        "Built": "R 4.5.0; ; 2025-04-09 21:36:11 UTC; windows",
-        "RemoteType": "standard",
-        "RemoteRef": "whisker",
-        "RemotePkgRef": "whisker",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "0.4.1"
+        "Built": "R 4.5.0; ; 2025-04-09 21:36:11 UTC; windows"
       }
     },
     "withr": {
@@ -4251,7 +4218,14 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-10-28 13:30:02 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 00:51:10 UTC; windows"
+        "Built": "R 4.5.1; ; 2025-09-29 00:31:02 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "withr",
+        "RemoteRef": "withr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "3.0.2"
       }
     },
     "xfun": {
@@ -4277,9 +4251,9 @@
         "Packaged": "2025-08-18 23:51:54 UTC; yihui",
         "Author": "Yihui Xie [aut, cre, cph] (ORCID:\n    <https://orcid.org/0000-0003-0645-5666>, URL: https://yihui.org),\n  Wush Wu [ctb],\n  Daijiang Li [ctb],\n  Xianying Tan [ctb],\n  Salim Brüggemann [ctb] (ORCID: <https://orcid.org/0000-0002-5329-5987>),\n  Christophe Dervieux [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2025-08-19 02:50:02 UTC",
-        "Built": "R 4.5.1; x86_64-w64-mingw32; 2025-09-08 22:25:29 UTC; windows",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-08-19 04:33:56 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -4300,12 +4274,18 @@
         "URL": "http://xtable.r-forge.r-project.org/",
         "Depends": "R (>= 2.10.0)",
         "License": "GPL (>= 2)",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "NeedsCompilation": "no",
         "Packaged": "2019-04-21 10:56:51 UTC; dsco036",
         "Author": "David B. Dahl [aut],\n  David Scott [aut, cre],\n  Charles Roosen [aut],\n  Arni Magnusson [aut],\n  Jonathan Swinton [aut],\n  Ajay Shah [ctb],\n  Arne Henningsen [ctb],\n  Benno Puetz [ctb],\n  Bernhard Pfaff [ctb],\n  Claudio Agostinelli [ctb],\n  Claudius Loehnert [ctb],\n  David Mitchell [ctb],\n  David Whiting [ctb],\n  Fernando da Rosa [ctb],\n  Guido Gay [ctb],\n  Guido Schulz [ctb],\n  Ian Fellows [ctb],\n  Jeff Laake [ctb],\n  John Walker [ctb],\n  Jun Yan [ctb],\n  Liviu Andronic [ctb],\n  Markus Loecher [ctb],\n  Martin Gubri [ctb],\n  Matthieu Stigler [ctb],\n  Robert Castelo [ctb],\n  Seth Falcon [ctb],\n  Stefan Edwards [ctb],\n  Sven Garbade [ctb],\n  Uwe Ligges [ctb]",
         "Date/Publication": "2019-04-21 12:20:03 UTC",
-        "Built": "R 4.5.1; ; 2025-07-04 00:51:10 UTC; windows"
+        "Encoding": "UTF-8",
+        "Built": "R 4.5.0; ; 2025-04-06 06:08:11 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "xtable",
+        "RemoteRef": "xtable",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.8-4"
       }
     },
     "yaml": {
@@ -4326,9 +4306,10 @@
         "BugReports": "https://github.com/vubiostat/r-yaml/issues",
         "NeedsCompilation": "yes",
         "Packaged": "2024-07-22 15:44:18 UTC; garbetsp",
-        "Repository": "CRAN",
+        "Repository": "RSPM",
         "Date/Publication": "2024-07-26 15:10:02 UTC",
-        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-06-18 00:26:50 UTC; windows",
+        "Encoding": "UTF-8",
+        "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-04-06 06:08:12 UTC; windows",
         "Archs": "x64"
       }
     },
@@ -4357,14 +4338,7 @@
         "Repository": "RSPM",
         "Date/Publication": "2025-05-13 14:10:02 UTC",
         "Built": "R 4.5.0; x86_64-w64-mingw32; 2025-05-14 04:45:37 UTC; windows",
-        "Archs": "x64",
-        "RemoteType": "standard",
-        "RemoteRef": "zip",
-        "RemotePkgRef": "zip",
-        "RemoteRepos": "https://packagemanager.posit.co/cran/latest",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "x86_64-w64-mingw32",
-        "RemoteSha": "2.3.3"
+        "Archs": "x64"
       }
     }
   },
@@ -4385,7 +4359,7 @@
       "checksum": "c1d6b214017ea01fb7141a0b0e228e02"
     },
     ".Rprofile": {
-      "checksum": "509905801e4dac49784f8a970cfce770"
+      "checksum": "b580e2b9cecb8cca7bdfc43deeba1148"
     },
     "azure-pipelines-dev.yml": {
       "checksum": "fc2ef843ff5024bcba25ff84eec05f4c"
@@ -4403,7 +4377,7 @@
       "checksum": "31d565a819730736cbcf5a38959d3398"
     },
     "data/data-dictionary.csv": {
-      "checksum": "6807e28cbaa93fec371989d020265808"
+      "checksum": "6cfae3f02a31eb130673ce61fbb87b54"
     },
     "data/english_devolved_areas.csv": {
       "checksum": "391e91c38d772d55f98e54fbacfc3b9f"
@@ -4526,10 +4500,10 @@
       "checksum": "12e9b09de5275bdc13bde6ae5a82f8b1"
     },
     "tests/testthat/_snaps/UI-01_example_files/example_files-001.json": {
-      "checksum": "22ff3d638b5843f1a78622dd025b0718"
+      "checksum": "3824e397e0b583a9367e306830fccd72"
     },
     "tests/testthat/_snaps/UI-01_example_files/example_files-002.json": {
-      "checksum": "3f758be2237e6e9ef0d8b621097ab5cb"
+      "checksum": "2d7c57ccba3887c66d3b24a4a1ae570f"
     },
     "tests/testthat/_snaps/UI-02_edge_cases/edge_cases-001.json": {
       "checksum": "75228173459ba6f210f07e7ce363ab5e"
@@ -4622,7 +4596,7 @@
       "checksum": "d9b48105db5a9f000b202b0d2e0fe79e"
     },
     "tests/testthat/fileValidation/naming_convention-metaFail.meta.xlsx": {
-      "checksum": "50a9f1e312f3b39feacb8855c7750ab2"
+      "checksum": "db7be3fa9be710443cd81ff6d8391f33"
     },
     "tests/testthat/fileValidation/naming_convention.csv": {
       "checksum": "d9b48105db5a9f000b202b0d2e0fe79e"
@@ -5426,7 +5400,7 @@
       "checksum": "1e405d074b26bb6cf0502238fd72c5df"
     },
     "tests/testthat/test-data/invalid_type3.meta.xlsx": {
-      "checksum": "50a9f1e312f3b39feacb8855c7750ab2"
+      "checksum": "db7be3fa9be710443cd81ff6d8391f33"
     },
     "tests/testthat/test-data/label_blank_notNA.csv": {
       "checksum": "efc245c3f96a78564f6c3498d057ef36"


### PR DESCRIPTION
<!-- 
Hey, thanks for raising a PR! We're excited to see what you've done!
To help us review the changes, please complete each section in this template by replacing '...' with details to help the reviewers of this pull request. 
-->

# Brief overview of changes

This PR seeks to add new filter names, filter items, and indicator names from the file [2 Children registered and providers by provider type](https://explore-education-statistics.service.gov.uk/data-catalogue/data-set/5f044e8f-80bc-44df-b1c9-98ef286c1a2f) from the recent [Funded early education and childcare](https://explore-education-statistics.service.gov.uk/find-statistics/funded-early-education-and-childcare/2026) release.

## Why are these changes being made?

These changes are being made to consider the appropriateness of updating this data set to be accessible via EES API, as data in this file is used in Edustats.

## Detailed description of changes

Filters for `entitlement_type` and `year_group` have been added.

Filter items have been added to the existing `age` and `provider_type` filter (including adding a new filter parent of provider_type_group) 

Indicators of `providers_count` and `registered_children_count` have been added.

## Additional information for reviewers

Would be great to get your thoughts on these additions to the data dictionary @rmbielby, please do let me know if you have any questions!